### PR TITLE
Create IAM role for Organisation Management through Terraform

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,32 @@
+data "aws_iam_policy_document" "organisation-management" {
+  statement {
+    sid = "DenyAllApartFromOrganisationManagement"
+    effect = "Deny"
+    actions = ["*"]
+    not_actions = [
+      # Note that this doesn't allow the account to delete Organisational Units
+      "organizations:DescribeOrganization",
+      "organizations:DescribeOrganizationalUnit",
+      "organizations:CreateOrganizationalUnit",
+      "organizations:UpdateOrganizationalUnit",
+      "organizations:CreateAccount",
+      "organizations:MoveAccount",
+      "iam:CreateServiceLinkedRole"
+    ]
+  }
+}
+
+resource "aws_iam_user" "terraform-organisation-management" {
+  name = "TerraformOrganisationManagement"
+}
+
+resource "aws_iam_policy" "terraform-organisation-management-policy" {
+  name = "TerraformOrganisationManagementPolicy"
+  description = "A policy that allows Terraform to only manage organisations"
+  policy = data.aws_iam_policy_document.organisation-management.json
+}
+
+resource "aws_iam_user_policy_attachment" "terraform-organisation-management-policy-attachment" {
+  user = aws_iam_user.terraform-organisation-management.name
+  policy_arn = aws_iam_policy.terraform-organisation-management-policy.arn
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,8 +1,34 @@
+data "aws_organizations_organization" "org" {}
+
+locals {
+  account_ids = {
+    for account in data.aws_organizations_organization.org.accounts :
+    lower(account.email) => account.id
+  }
+}
+
+resource "aws_iam_role" "terraform-modernisation-platform-organisation-management-role" {
+  name               = "ModernisationPlatformOrganisationManagementRole"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${local.account_ids["aws+modernisation-platform@digital.justice.gov.uk"]}:root"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
 data "aws_iam_policy_document" "organisation-management" {
   statement {
-    sid     = "DenyAllApartFromOrganisationManagement"
-    effect  = "Deny"
-    actions = ["*"]
+    sid    = "DenyAllApartFromOrganisationManagement"
+    effect = "Deny"
     not_actions = [
       # Note that this doesn't allow the account to delete Organisational Units
       "organizations:DescribeOrganization",
@@ -13,20 +39,19 @@ data "aws_iam_policy_document" "organisation-management" {
       "organizations:MoveAccount",
       "iam:CreateServiceLinkedRole"
     ]
+    resources = [
+      "arn:aws:organizations:::*"
+    ]
   }
-}
-
-resource "aws_iam_user" "terraform-organisation-management" {
-  name = "TerraformOrganisationManagement"
 }
 
 resource "aws_iam_policy" "terraform-organisation-management-policy" {
   name        = "TerraformOrganisationManagementPolicy"
-  description = "A policy that allows Terraform to only manage organisations"
+  description = "A policy that allows the Modernisation Platform to manage organisations"
   policy      = data.aws_iam_policy_document.organisation-management.json
 }
 
-resource "aws_iam_user_policy_attachment" "terraform-organisation-management-policy-attachment" {
-  user       = aws_iam_user.terraform-organisation-management.name
+resource "aws_iam_role_policy_attachment" "terraform-organisation-management-attachment" {
+  role       = aws_iam_role.terraform-modernisation-platform-organisation-management-role.name
   policy_arn = aws_iam_policy.terraform-organisation-management-policy.arn
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,7 +1,7 @@
 data "aws_iam_policy_document" "organisation-management" {
   statement {
-    sid = "DenyAllApartFromOrganisationManagement"
-    effect = "Deny"
+    sid     = "DenyAllApartFromOrganisationManagement"
+    effect  = "Deny"
     actions = ["*"]
     not_actions = [
       # Note that this doesn't allow the account to delete Organisational Units
@@ -21,12 +21,12 @@ resource "aws_iam_user" "terraform-organisation-management" {
 }
 
 resource "aws_iam_policy" "terraform-organisation-management-policy" {
-  name = "TerraformOrganisationManagementPolicy"
+  name        = "TerraformOrganisationManagementPolicy"
   description = "A policy that allows Terraform to only manage organisations"
-  policy = data.aws_iam_policy_document.organisation-management.json
+  policy      = data.aws_iam_policy_document.organisation-management.json
 }
 
 resource "aws_iam_user_policy_attachment" "terraform-organisation-management-policy-attachment" {
-  user = aws_iam_user.terraform-organisation-management.name
+  user       = aws_iam_user.terraform-organisation-management.name
   policy_arn = aws_iam_policy.terraform-organisation-management-policy.arn
 }


### PR DESCRIPTION
This PR:
- Creates an assumable IAM role in the root account, specifically for the Modernisation Platform account, that can only perform actions to create and update Organisational Units, and to create and move subsidiary accounts within Organisational Units.

This user will allow the Modernisation Platform Environments to be automatically created, and attached to OUs within the Ministry of Justice root AWS account, through a CI/CD pipeline.

It does not allow destructive permissions.