### PR TITLE
Allow ModernisationPlatformOrganisationManagementRole to access all resources

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "organisation-management" {
       "organizations:CreateOrganizationalUnit"
     ]
     resources = [
-      "arn:aws:organizations:::*"
+      "*"
     ]
   }
 }


### PR DESCRIPTION
This PR:
- Changes the `resource` value to `*`, as the `organizations*` permissions don't support resource-level granularity