### PR TITLE
Allow ModernisationPlatformOrganisationManagement access to the modernisation-platform-terraform-state bucket

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -40,6 +40,19 @@ data "aws_iam_policy_document" "terraform-organisation-management" {
       "*"
     ]
   }
+
+  statement {
+    sid = "AllowAccessToModernisationPlatformS3Bucket"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = [
+      "arn:aws:s3:::modernisation-platform-terraform-state/*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "terraform-organisation-management-policy" {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "terraform-organisation-management" {
   }
 
   statement {
-    sid = "AllowAccessToModernisationPlatformS3Bucket"
+    sid    = "AllowAccessToModernisationPlatformS3Bucket"
     effect = "Allow"
     actions = [
       "s3:GetObject",


### PR DESCRIPTION
This allows the ModernisationPlatformOrganisationManagement to GetObject, PutObject, and PutObjectACL on the modernisation-platform-terraform-state s3 bucket.

This is to allow for cross-account S3 object reading and writing.