### PR TITLE
Initial role for OPG engineers in the root aws account

### DIFF
--- a/terraform/modules/opg_role/README.md
+++ b/terraform/modules/opg_role/README.md
@@ -1,0 +1,19 @@
+# OPG Role
+
+Creates an IAM role that can be assumed by AWS IAM Users
+
+## Requirements
+
+| Name      | Version   |
+|-----------|-----------|
+| terraform | >= 0.13.0 |
+| aws       | >= 2.70   |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| name | name for the IAM role | `string` | `` | yes |
+| user\_arns | List of IAM user ARNs | `list` | `[]` | yes |
+| base\_policy\_arn | Base policy to give the role | `string` | `arn:aws:iam::aws:policy/ReadOnlyAccess` | no |
+| custom\_policy\_json | Custom policy to apply to the role | `json` | `` | no |

--- a/terraform/modules/opg_role/main.tf
+++ b/terraform/modules/opg_role/main.tf
@@ -1,0 +1,28 @@
+resource "aws_iam_role" "role" {
+  name               = var.name
+  assume_role_policy = data.aws_iam_policy_document.role.json
+}
+
+data "aws_iam_policy_document" "role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = var.user_arns
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "base" {
+  role       = aws_iam_role.role.id
+  policy_arn = var.base_policy_arn
+}
+
+resource "aws_iam_role_policy" "custom" {
+  count  = var.custom_policy_json != "" ? 1 : 0
+  policy = var.custom_policy_json
+  role   = aws_iam_role.role.id
+}

--- a/terraform/modules/opg_role/variables.tf
+++ b/terraform/modules/opg_role/variables.tf
@@ -1,0 +1,14 @@
+variable "user_arns" {
+  type    = list(string)
+  default = []
+}
+
+variable "name" {}
+
+variable "base_policy_arn" {
+  default = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+variable "custom_policy_json" {
+  default = ""
+}

--- a/terraform/opg-roles.tf
+++ b/terraform/opg-roles.tf
@@ -1,0 +1,31 @@
+module "opg-sso-operator" {
+  source             = "./modules/opg_role"
+  name               = "opg-operator"
+  user_arns          = local.opg_engineers
+  custom_policy_json = data.aws_iam_policy_document.opg_operator.json
+}
+
+data "aws_iam_policy_document" "opg_operator" {
+  statement {
+    sid       = "AllowOrganizationsAccess"
+    effect    = "Allow"
+    actions   = ["organizations:*"]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "AllowSSOAccess"
+    effect    = "Allow"
+    actions   = ["sso:*"]
+    resources = ["*"]
+  }
+}
+
+
+locals {
+  # I've decided to hard code our ARNs, I don't want to make this repo depend on our accounts.
+  # Once SSO has been implemented we can get rid of these anyway
+  opg_engineers = [
+    "arn:aws:iam::631181914621:user/thomas.withers",
+    "arn:aws:iam::631181914621:user/andrew.pearce",
+  ]
+}


### PR DESCRIPTION
Adds an IAM role module which allows us to create a role that can be assumed by a set of users