### PR TITLE
Create CI user for Terraform

### DIFF
--- a/terraform/ci.tf
+++ b/terraform/ci.tf
@@ -1,10 +1,10 @@
 resource "aws_iam_user" "ci" {
-  name     = "ci"
+  name = "ci"
 }
 
 resource "aws_iam_user_policy" "ci" {
-  policy   = data.aws_iam_policy_document.ci.json
-  user     = aws_iam_user.ci.id
+  policy = data.aws_iam_policy_document.ci.json
+  user   = aws_iam_user.ci.id
 }
 
 data "aws_iam_policy_document" "ci" {
@@ -26,13 +26,13 @@ module "ci" {
 
 data "aws_iam_policy_document" "ci" {
   statement {
-    sid       = "DenyIAMUserCreation"
-    effect    = "Deny"
-    actions   = [
+    sid    = "DenyIAMUserCreation"
+    effect = "Deny"
+    actions = [
       "iam:CreateAccessKey",
       "iam:CreateLoginProfile",
       "iam:ChangePassword"
-      ]
+    ]
     resources = ["*"]
   }
 }

--- a/terraform/ci.tf
+++ b/terraform/ci.tf
@@ -1,0 +1,39 @@
+resource "aws_iam_user" "ci" {
+  name     = "ci"
+}
+
+resource "aws_iam_user_policy" "ci" {
+  policy   = data.aws_iam_policy_document.ci.json
+  user     = aws_iam_user.ci.id
+}
+
+data "aws_iam_policy_document" "ci" {
+  statement {
+    sid       = "AllowAssumeRole"
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    resources = ["*"]
+  }
+}
+
+module "ci" {
+  source             = "./modules/opg_role"
+  name               = "ci"
+  user_arns          = aws_iam_user.ci.arn
+  base_policy_arn    = "arn:aws:iam::aws:policy/AdministratorAccess"
+  custom_policy_json = data.aws_iam_policy_document.ci.json
+}
+
+data "aws_iam_policy_document" "ci" {
+  statement {
+    sid       = "DenyIAMUserCreation"
+    effect    = "Deny"
+    actions   = [
+      "iam:CreateAccessKey",
+      "iam:CreateLoginProfile",
+      "iam:ChangePassword"
+      ]
+    resources = ["*"]
+  }
+}
+


### PR DESCRIPTION
Create a CI user for GitHub actions. 

I've put an explicit Deny rule in to ensure this CI user can't create login profiles, AWS Access Keys and change user passwords. We shouldn't be storing any other data in the account as its the root so I don't think we need any other restrictions.