### PR TITLE
Configure AWS SSO

### DIFF
--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -1,0 +1,38 @@
+# SAML: Auth0 credentials
+resource "aws_secretsmanager_secret" "auth0_saml" {
+  name        = "auth0_saml"
+  description = "Auth0 Machine to Machine credentials for Terraform to setup Auth0 for AWS SSO"
+  tags        = local.root_account
+}
+
+data "aws_secretsmanager_secret_version" "auth0_saml" {
+  secret_id = aws_secretsmanager_secret.auth0_saml.id
+}
+
+# SAML: GitHub client ID and secrets
+resource "aws_secretsmanager_secret" "github_saml" {
+  name        = "github_saml"
+  description = "GitHub client ID and secret for the Ministry of Justice owned OAuth app for AWS SSO"
+  tags        = local.root_account
+}
+
+data "aws_secretsmanager_secret_version" "github_saml" {
+  secret_id = aws_secretsmanager_secret.github_saml.id
+}
+
+# SAML: AWS SSO
+resource "aws_secretsmanager_secret" "aws_saml" {
+  name        = "aws_saml"
+  description = "AWS SSO ACS and Issuer URLs"
+  tags        = local.root_account
+}
+
+data "aws_secretsmanager_secret_version" "aws_saml" {
+  secret_id = aws_secretsmanager_secret.aws_saml.id
+}
+
+locals {
+  auth0_saml  = jsondecode(data.aws_secretsmanager_secret_version.auth0_saml.secret_string)
+  github_saml = jsondecode(data.aws_secretsmanager_secret_version.github_saml.secret_string)
+  aws_saml    = jsondecode(data.aws_secretsmanager_secret_version.aws_saml.secret_string)
+}

--- a/terraform/sso.tf
+++ b/terraform/sso.tf
@@ -1,0 +1,12 @@
+module "sso" {
+  source                     = "https://github.com/ministryofjustice/moj-terraform-aws-sso"
+  auth0_tenant_domain        = "ministryofjustice.eu.auth0.com"
+  auth0_client_id            = local.auth0_saml.client_id
+  auth0_client_secret        = local.auth0_saml.client_secret
+  auth0_github_client_id     = local.github_saml.client_id
+  auth0_github_client_secret = local.github_saml.client_secret
+  auth0_aws_sso_acs_url      = local.aws_saml.acs_url
+  auth0_aws_sso_issuer_url   = local.aws_saml.issuer_url
+  auth0_github_allowed_orgs  = ["ministryofjustice"]
+  auth0_allowed_domains      = ["justice.gov.uk", "digital.justice.gov.uk"]
+}


### PR DESCRIPTION
This PR adds a couple of few secrets to configure an Auth0 application, to enable AWS SSO at the root level within MOJ. It also uses the ministryofjustice/moj-terraform-aws-sso module to provision the base configuration of Auth0 and AWS SSO.

This PR is dependent on ministryofjustice/moj-terraform-aws-sso#5, which is a repurposed Auth0 configuration from the Modernisation Platform proof of concept, which is no longer needed but already had the base module configured.