### PR TITLE
Expand ModernisationPlatform s3 bucket permissions

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -51,8 +51,8 @@ data "aws_iam_policy_document" "terraform-organisation-management" {
   }
 
   statement {
-    effect = "Allow"
-    actions = ["s3:GetObject"]
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*"]
   }
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -57,8 +57,8 @@ data "aws_iam_policy_document" "terraform-organisation-management" {
   }
 
   statement {
-    effect    = "Allow"
-    actions   = [
+    effect = "Allow"
+    actions = [
       "s3:PutObject",
       "s3:PutObjectAcl"
     ]

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -58,7 +58,10 @@ data "aws_iam_policy_document" "terraform-organisation-management" {
 
   statement {
     effect    = "Allow"
-    actions   = ["s3:PutObject"]
+    actions   = [
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
     resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*"]
 
     condition {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -41,17 +41,31 @@ data "aws_iam_policy_document" "terraform-organisation-management" {
     ]
   }
 
+  # Allow access to the bucket from the MoJ root account
+  # Policy extrapolated from:
+  # https://www.terraform.io/docs/backends/types/s3.html#s3-bucket-permissions
   statement {
-    sid    = "AllowAccessToModernisationPlatformS3Bucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state"]
+  }
+
+  statement {
     effect = "Allow"
-    actions = [
-      "s3:GetObject",
-      "s3:PutObject",
-      "s3:PutObjectAcl"
-    ]
-    resources = [
-      "arn:aws:s3:::modernisation-platform-terraform-state/*"
-    ]
+    actions = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*"]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
   }
 }
 


### PR DESCRIPTION
Fixes a bug for the Modernisation Platform where Terraform couldn't ListBucket when using `terraform workspace`.