### PR TITLE
Bring IAM Users into Terraform management

### DIFF
--- a/terraform/iam-users.tf
+++ b/terraform/iam-users.tf
@@ -1,0 +1,40 @@
+locals {
+  iam_users = [
+    "AliceCudmore",
+    "AnthonyBishop",
+    "CeriBuck",
+    "Christine.Elliott",
+    "claim-crown-court-defence",
+    "JakeMulley",
+    "JasonBirchall",
+    "LeahCios",
+    "MaxLakanu",
+    "ModernisationPlatformOrganisationManagement",
+    "PaulWyborn",
+    "Poornima.Krishnasamy",
+    "PSPI",
+    "RohanSalunkhe",
+    "SabluMiah",
+    "SarahRees",
+    "SeanBusby",
+    "SidElangovan",
+    "SteveMarshall"
+  ]
+}
+
+resource "aws_iam_user" "user" {
+  for_each = toset(local.iam_users)
+  name     = each.value
+
+  # This below is only so Terraform represents what is in the AWS account
+
+  ## In the future...
+  ## This should be true for all accounts so we can forcibly delete them even if the have AWS access keys set
+  force_destroy = each.value == "ModernisationPlatformOrganisationManagement" ? true : false
+
+  ## and this needs to be updated to tag all accounts with specifics
+  tags = each.value == "claim-crown-court-defence" ? {
+    Agency = "crimebillingonline"
+    Owner  = "claim-crown-court-defence"
+  } : {}
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -78,13 +78,7 @@ resource "aws_iam_policy" "terraform-organisation-management-policy" {
   policy      = data.aws_iam_policy_document.terraform-organisation-management.json
 }
 
-# Individual IAM user for the Modernisation Platform
-resource "aws_iam_user" "terraform-organisation-management-user" {
-  name          = "ModernisationPlatformOrganisationManagement"
-  force_destroy = true
-}
-
 resource "aws_iam_user_policy_attachment" "terraform-organisation-management-attachment" {
-  user       = aws_iam_user.terraform-organisation-management-user.name
+  user       = aws_iam_user.user["ModernisationPlatformOrganisationManagement"].name
   policy_arn = aws_iam_policy.terraform-organisation-management-policy.arn
 }


### PR DESCRIPTION
Brings clickops-created IAM Users into Terraform.

Note: These have already been imported into the remote Terraform state.