### PR TITLE
Bring IAM account alias into Terraform management

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,3 +1,7 @@
+resource "aws_iam_account_alias" "default" {
+  account_alias = "mojmaster"
+}
+
 data "aws_iam_policy_document" "terraform-organisation-management" {
   statement {
     sid    = "AllowOrganisationManagement"


### PR DESCRIPTION
Brings clickops-created IAM account alias into Terraform.

Note: These have already been imported into the remote Terraform state.

