### PR TITLE
Bring IAM user group memberships into Terraform management

### DIFF
--- a/terraform/iam-users.tf
+++ b/terraform/iam-users.tf
@@ -87,6 +87,6 @@ resource "aws_iam_user" "user" {
 
 resource "aws_iam_user_group_membership" "group_memberships" {
   for_each = local.all_iam_users_and_groups
-  user = aws_iam_user.user[each.key].name
-  groups = each.value
+  user     = aws_iam_user.user[each.key].name
+  groups   = each.value
 }

--- a/terraform/iam-users.tf
+++ b/terraform/iam-users.tf
@@ -1,40 +1,92 @@
 locals {
-  iam_users = [
-    "AliceCudmore",
-    "AnthonyBishop",
-    "CeriBuck",
-    "Christine.Elliott",
-    "claim-crown-court-defence",
-    "JakeMulley",
-    "JasonBirchall",
-    "LeahCios",
-    "MaxLakanu",
-    "ModernisationPlatformOrganisationManagement",
-    "PaulWyborn",
-    "Poornima.Krishnasamy",
-    "PSPI",
-    "RohanSalunkhe",
-    "SabluMiah",
-    "SarahRees",
-    "SeanBusby",
-    "SidElangovan",
-    "SteveMarshall"
-  ]
+  all_iam_users_and_groups = {
+    "AliceCudmore" = [
+      aws_iam_group.billing_full_access.name
+    ]
+    "AnthonyBishop" = [
+      aws_iam_group.aws_organisations_service_admins.name,
+      aws_iam_group.billing_full_access.name
+    ]
+    "CeriBuck" = [
+      aws_iam_group.billing_full_access.name
+    ]
+    "Christine.Elliott" = [
+      aws_iam_group.billing_full_access.name
+    ]
+    "claim-crown-court-defence" = []
+    "JakeMulley" = [
+      aws_iam_group.admins.name,
+      aws_iam_group.aws_organisations_service_admins.name,
+      aws_iam_group.billing_full_access.name
+    ]
+    "JasonBirchall" = [
+      aws_iam_group.admins.name,
+      aws_iam_group.aws_organisations_service_admins.name
+    ]
+    "LeahCios" = [
+      aws_iam_group.billing_full_access.name
+    ]
+    "MaxLakanu" = [
+      aws_iam_group.billing_full_access.name
+    ]
+    "ModernisationPlatformOrganisationManagement" = []
+    "PaulWyborn" = [
+      aws_iam_group.admins.name,
+      aws_iam_group.aws_organisations_service_admins.name,
+      aws_iam_group.billing_full_access.name
+    ]
+    "Poornima.Krishnasamy" = [
+      aws_iam_group.admins.name,
+      aws_iam_group.aws_organisations_service_admins.name
+    ]
+    "PSPI" = [
+      aws_iam_group.billing_full_access.name
+    ]
+    "RohanSalunkhe" = [
+      aws_iam_group.billing_full_access.name
+    ]
+    "SabluMiah" = [
+      aws_iam_group.admins.name,
+      aws_iam_group.aws_organisations_service_admins.name
+    ]
+    "SarahRees" = [
+      aws_iam_group.billing_full_access.name
+    ]
+    "SeanBusby" = [
+      aws_iam_group.admins.name,
+      aws_iam_group.aws_organisations_service_admins.name,
+      aws_iam_group.billing_full_access.name
+    ]
+    "SidElangovan" = [
+      aws_iam_group.admins.name
+    ]
+    "SteveMarshall" = [
+      aws_iam_group.admins.name,
+      aws_iam_group.aws_organisations_service_admins.name,
+      aws_iam_group.billing_full_access.name
+    ]
+  }
 }
 
 resource "aws_iam_user" "user" {
-  for_each = toset(local.iam_users)
-  name     = each.value
+  for_each = local.all_iam_users_and_groups
+  name     = each.key
 
   # This below is only so Terraform represents what is in the AWS account
 
   ## In the future...
   ## This should be true for all accounts so we can forcibly delete them even if the have AWS access keys set
-  force_destroy = each.value == "ModernisationPlatformOrganisationManagement" ? true : false
+  force_destroy = each.key == "ModernisationPlatformOrganisationManagement" ? true : false
 
   ## and this needs to be updated to tag all accounts with specifics
-  tags = each.value == "claim-crown-court-defence" ? {
+  tags = each.key == "claim-crown-court-defence" ? {
     Agency = "crimebillingonline"
     Owner  = "claim-crown-court-defence"
   } : {}
+}
+
+resource "aws_iam_user_group_membership" "group_memberships" {
+  for_each = local.all_iam_users_and_groups
+  user = aws_iam_user.user[each.key].name
+  groups = each.value
 }


### PR DESCRIPTION
Brings clicksops-created IAM user group memberships into Terraform management.

Note: These have already been imported into the remote Terraform state.