### PR TITLE
Bring IAM roles into Terraform management

### DIFF
--- a/terraform/iam-roles.tf
+++ b/terraform/iam-roles.tf
@@ -1,0 +1,87 @@
+# Service-linked roles
+resource "aws_iam_service_linked_role" "organizations" {
+  aws_service_name = "organizations.amazonaws.com"
+  description      = "Service-linked role used by AWS Organizations to enable integration of other AWS services with Organizations."
+}
+
+resource "aws_iam_service_linked_role" "securityhub" {
+  aws_service_name = "securityhub.amazonaws.com"
+  description      = "A service-linked role required for AWS Security Hub to access your resources."
+}
+
+resource "aws_iam_service_linked_role" "sso" {
+  aws_service_name = "sso.amazonaws.com"
+  description      = "Service-linked role used by AWS SSO to manage AWS resources, including IAM roles, policies and SAML IdP on your behalf."
+}
+
+resource "aws_iam_service_linked_role" "support" {
+  aws_service_name = "support.amazonaws.com"
+  description      = "Enables resource access for AWS to provide billing, administrative and support services"
+}
+
+resource "aws_iam_service_linked_role" "trustedadvisor" {
+  aws_service_name = "trustedadvisor.amazonaws.com"
+  description      = "Access for the AWS Trusted Advisor Service to help reduce cost, increase performance, and improve security of your AWS environment."
+}
+
+# Other roles
+## IAM ReadOnly Access Role
+resource "aws_iam_role" "iam-read-only-access-role" {
+  name = "IAMReadOnlyAccessRole"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowAssumeIAMReadOnlyAccessRole",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${local.caller_identity.account_id}:root"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+## lambda_basic_execution-test
+resource "aws_iam_role" "lambda_basic_execution-test" {
+  name = "lambda_basic_execution-test"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+## lambda-iam-generate-report-role
+resource "aws_iam_role" "lambda-iam-generate-report-role" {
+  name = "lambda-iam-generate-report-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 locals {
   root_account = {
     business-unit = "Platforms"
@@ -5,4 +7,5 @@ locals {
     is-production = true
     owner         = "Hosting Leads: hosting-leads@digital.justice.gov.uk"
   }
+  caller_identity = data.aws_caller_identity.current
 }


### PR DESCRIPTION
Brings clickops-created IAM roles into Terraform.

Note: These have already been imported into the remote Terraform state.