### PR TITLE
Bring AWS Organizations enablement into Terraform management

### DIFF
--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -1,0 +1,9 @@
+resource "aws_organizations_organization" "default" {
+  aws_service_access_principals = [
+    "sso.amazonaws.com"
+  ]
+  enabled_policy_types = [
+    "SERVICE_CONTROL_POLICY"
+  ]
+  feature_set = "ALL"
+}


### PR DESCRIPTION
Brings clickops-created AWS Organizations enablement into Terraform.

Note: These have already been imported into the remote Terraform state.