### PR TITLE
Bring AWS Organizations root OU and closed OU accounts into Terraform management

### DIFF
--- a/terraform/organizations-accounts-closed-accounts.tf
+++ b/terraform/organizations-accounts-closed-accounts.tf
@@ -1,0 +1,67 @@
+resource "aws_organizations_account" "moj-opg-identity-closed-0" {
+  name = "MoJ OPG Identity"
+  email = local.account_emails["MoJ OPG Identity"][0]
+  parent_id = aws_organizations_organizational_unit.closed-accounts.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-identity-closed-2" {
+  name = "MoJ OPG Identity"
+  email = local.account_emails["MoJ OPG Identity"][1]
+  parent_id = aws_organizations_organizational_unit.closed-accounts.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "money-to-prisoners-closed" {
+  name = "Money To Prisoners"
+  email = local.account_emails["Money To Prisoners"][0]
+  parent_id = aws_organizations_organizational_unit.closed-accounts.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-security-closed" {
+  name = "MoJ-Security"
+  email = local.account_emails["MoJ-Security"][0]
+  parent_id = aws_organizations_organizational_unit.closed-accounts.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-closed-accounts.tf
+++ b/terraform/organizations-accounts-closed-accounts.tf
@@ -1,6 +1,6 @@
 resource "aws_organizations_account" "moj-opg-identity-closed-0" {
-  name = "MoJ OPG Identity"
-  email = local.account_emails["MoJ OPG Identity"][0]
+  name      = "MoJ OPG Identity"
+  email     = local.account_emails["MoJ OPG Identity"][0]
   parent_id = aws_organizations_organizational_unit.closed-accounts.id
 
   lifecycle {
@@ -16,8 +16,8 @@ resource "aws_organizations_account" "moj-opg-identity-closed-0" {
 }
 
 resource "aws_organizations_account" "moj-opg-identity-closed-2" {
-  name = "MoJ OPG Identity"
-  email = local.account_emails["MoJ OPG Identity"][1]
+  name      = "MoJ OPG Identity"
+  email     = local.account_emails["MoJ OPG Identity"][1]
   parent_id = aws_organizations_organizational_unit.closed-accounts.id
 
   lifecycle {
@@ -33,8 +33,8 @@ resource "aws_organizations_account" "moj-opg-identity-closed-2" {
 }
 
 resource "aws_organizations_account" "money-to-prisoners-closed" {
-  name = "Money To Prisoners"
-  email = local.account_emails["Money To Prisoners"][0]
+  name      = "Money To Prisoners"
+  email     = local.account_emails["Money To Prisoners"][0]
   parent_id = aws_organizations_organizational_unit.closed-accounts.id
 
   lifecycle {
@@ -50,8 +50,8 @@ resource "aws_organizations_account" "money-to-prisoners-closed" {
 }
 
 resource "aws_organizations_account" "moj-security-closed" {
-  name = "MoJ-Security"
-  email = local.account_emails["MoJ-Security"][0]
+  name      = "MoJ-Security"
+  email     = local.account_emails["MoJ-Security"][0]
   parent_id = aws_organizations_organizational_unit.closed-accounts.id
 
   lifecycle {

--- a/terraform/organizations-accounts.tf
+++ b/terraform/organizations-accounts.tf
@@ -1,0 +1,176 @@
+# This is a slightly hacky way to get email addresses for already configured accounts.
+# We should store all (including new) account email addresses in AWS Secrets Manager,
+# rather than rely on this in the future.
+data "aws_organizations_organization" "root" {}
+
+output "account_ids" {
+  value = local.account_emails
+}
+
+locals {
+  account_emails = {
+    for account in data.aws_organizations_organization.root.accounts :
+    account.name => account.email...
+  }
+}
+
+# Accounts that sit within the root OU. This doesn't include the actual root account.
+resource "aws_organizations_account" "bichard7-2020-prototype" {
+  name      = "Bichard7 2020 Prototype"
+  email     = local.account_emails["Bichard7 2020 Prototype"][0]
+  parent_id = aws_organizations_organization.default.roots[0].id
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "cica-development" {
+  name      = "CICA Development"
+  email     = local.account_emails["CICA Development"][0]
+  parent_id = aws_organizations_organization.default.roots[0].id
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "cica-test-verify" {
+  name      = "CICA Test & Verify"
+  email     = local.account_emails["CICA Test & Verify"][0]
+  parent_id = aws_organizations_organization.default.roots[0].id
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "cica-uat" {
+  name      = "CICA UAT"
+  email     = local.account_emails["CICA UAT"][0]
+  parent_id = aws_organizations_organization.default.roots[0].id
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-infrastructure-dev" {
+  name      = "Electronic Monitoring Infrastructure Dev"
+  email     = local.account_emails["Electronic Monitoring Infrastructure Dev"][0]
+  parent_id = aws_organizations_organization.default.roots[0].id
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "modernisation-platform" {
+  name      = "Modernisation Platform"
+  email     = local.account_emails["Modernisation Platform"][0]
+  parent_id = aws_organizations_organization.default.roots[0].id
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-billing-management" {
+  name      = "MoJ Billing Management"
+  email     = local.account_emails["MoJ Billing Management"][0]
+  parent_id = aws_organizations_organization.default.roots[0].id
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-official-public-key-infrastructure-dev" {
+  name      = "MOJ Official (Public Key Infrastructure Dev)"
+  email     = local.account_emails["MOJ Official (Public Key Infrastructure Dev)"][0]
+  parent_id = aws_organizations_organization.default.roots[0].id
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-official-public-key-infrastructure" {
+  name      = "MOJ Official (Public Key Infrastructure)"
+  email     = local.account_emails["MOJ Official (Public Key Infrastructure)"][0]
+  parent_id = aws_organizations_organization.default.roots[0].id
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-official-shared-services" {
+  name      = "MOJ Official (Shared Services)"
+  email     = local.account_emails["MOJ Official (Shared Services)"][0]
+  parent_id = aws_organizations_organization.default.roots[0].id
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts.tf
+++ b/terraform/organizations-accounts.tf
@@ -19,6 +19,7 @@ resource "aws_organizations_account" "bichard7-2020-prototype" {
   name      = "Bichard7 2020 Prototype"
   email     = local.account_emails["Bichard7 2020 Prototype"][0]
   parent_id = aws_organizations_organization.default.roots[0].id
+
   lifecycle {
     # If any of these attributes are changed, it attempts to destroy and recreate the account,
     # so we should ignore the changes to prevent this from happening.
@@ -35,6 +36,7 @@ resource "aws_organizations_account" "cica-development" {
   name      = "CICA Development"
   email     = local.account_emails["CICA Development"][0]
   parent_id = aws_organizations_organization.default.roots[0].id
+
   lifecycle {
     # If any of these attributes are changed, it attempts to destroy and recreate the account,
     # so we should ignore the changes to prevent this from happening.
@@ -51,6 +53,7 @@ resource "aws_organizations_account" "cica-test-verify" {
   name      = "CICA Test & Verify"
   email     = local.account_emails["CICA Test & Verify"][0]
   parent_id = aws_organizations_organization.default.roots[0].id
+
   lifecycle {
     # If any of these attributes are changed, it attempts to destroy and recreate the account,
     # so we should ignore the changes to prevent this from happening.
@@ -67,6 +70,7 @@ resource "aws_organizations_account" "cica-uat" {
   name      = "CICA UAT"
   email     = local.account_emails["CICA UAT"][0]
   parent_id = aws_organizations_organization.default.roots[0].id
+
   lifecycle {
     # If any of these attributes are changed, it attempts to destroy and recreate the account,
     # so we should ignore the changes to prevent this from happening.
@@ -83,6 +87,7 @@ resource "aws_organizations_account" "electronic-monitoring-infrastructure-dev" 
   name      = "Electronic Monitoring Infrastructure Dev"
   email     = local.account_emails["Electronic Monitoring Infrastructure Dev"][0]
   parent_id = aws_organizations_organization.default.roots[0].id
+
   lifecycle {
     # If any of these attributes are changed, it attempts to destroy and recreate the account,
     # so we should ignore the changes to prevent this from happening.
@@ -99,6 +104,7 @@ resource "aws_organizations_account" "modernisation-platform" {
   name      = "Modernisation Platform"
   email     = local.account_emails["Modernisation Platform"][0]
   parent_id = aws_organizations_organization.default.roots[0].id
+
   lifecycle {
     # If any of these attributes are changed, it attempts to destroy and recreate the account,
     # so we should ignore the changes to prevent this from happening.
@@ -115,6 +121,7 @@ resource "aws_organizations_account" "moj-billing-management" {
   name      = "MoJ Billing Management"
   email     = local.account_emails["MoJ Billing Management"][0]
   parent_id = aws_organizations_organization.default.roots[0].id
+
   lifecycle {
     # If any of these attributes are changed, it attempts to destroy and recreate the account,
     # so we should ignore the changes to prevent this from happening.
@@ -131,6 +138,7 @@ resource "aws_organizations_account" "moj-official-public-key-infrastructure-dev
   name      = "MOJ Official (Public Key Infrastructure Dev)"
   email     = local.account_emails["MOJ Official (Public Key Infrastructure Dev)"][0]
   parent_id = aws_organizations_organization.default.roots[0].id
+
   lifecycle {
     # If any of these attributes are changed, it attempts to destroy and recreate the account,
     # so we should ignore the changes to prevent this from happening.
@@ -147,6 +155,7 @@ resource "aws_organizations_account" "moj-official-public-key-infrastructure" {
   name      = "MOJ Official (Public Key Infrastructure)"
   email     = local.account_emails["MOJ Official (Public Key Infrastructure)"][0]
   parent_id = aws_organizations_organization.default.roots[0].id
+
   lifecycle {
     # If any of these attributes are changed, it attempts to destroy and recreate the account,
     # so we should ignore the changes to prevent this from happening.
@@ -163,6 +172,7 @@ resource "aws_organizations_account" "moj-official-shared-services" {
   name      = "MOJ Official (Shared Services)"
   email     = local.account_emails["MOJ Official (Shared Services)"][0]
   parent_id = aws_organizations_organization.default.roots[0].id
+
   lifecycle {
     # If any of these attributes are changed, it attempts to destroy and recreate the account,
     # so we should ignore the changes to prevent this from happening.


### PR DESCRIPTION
Brings clickops-created AWS Organizations root OU and closed OU accounts into Terraform.

Note: These have already been imported into the remote Terraform state.