### PR TITLE
Bring AWS Organizations OPG OU accounts into Terraform management

### DIFF
--- a/terraform/organizations-accounts-opg-digicop.tf
+++ b/terraform/organizations-accounts-opg-digicop.tf
@@ -1,0 +1,51 @@
+# OPG OU: DigiCop
+resource "aws_organizations_account" "moj-opg-digicop-production" {
+  name      = "MoJ OPG DigiCop Production"
+  email     = local.account_emails["MoJ OPG DigiCop Production"][0]
+  parent_id = aws_organizations_organizational_unit.opg-digicop.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-digicop-development" {
+  name      = "MoJ OPG DigiCop Development"
+  email     = local.account_emails["MoJ OPG DigiCop Development"][0]
+  parent_id = aws_organizations_organizational_unit.opg-digicop.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-digicop-preproduction" {
+  name      = "MoJ OPG DigiCop Preproduction"
+  email     = local.account_emails["MoJ OPG DigiCop Preproduction"][0]
+  parent_id = aws_organizations_organizational_unit.opg-digicop.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-opg-digideps.tf
+++ b/terraform/organizations-accounts-opg-digideps.tf
@@ -1,0 +1,51 @@
+# OPG OU: DigiDeps
+resource "aws_organizations_account" "opg-digi-deps-prod" {
+  name      = "OPG Digi Deps Prod"
+  email     = local.account_emails["OPG Digi Deps Prod"][0]
+  parent_id = aws_organizations_organizational_unit.opg-digideps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-digi-deps-dev" {
+  name      = "OPG Digi Deps Dev"
+  email     = local.account_emails["OPG Digi Deps Dev"][0]
+  parent_id = aws_organizations_organizational_unit.opg-digideps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-digi-deps-preprod" {
+  name      = "OPG Digi Deps Preprod"
+  email     = local.account_emails["OPG Digi Deps Preprod"][0]
+  parent_id = aws_organizations_organizational_unit.opg-digideps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-opg-lpa-refunds.tf
+++ b/terraform/organizations-accounts-opg-lpa-refunds.tf
@@ -1,0 +1,85 @@
+# OPG OU: LPA Refunds
+resource "aws_organizations_account" "opg-refund-develop" {
+  name      = "opg-refund-develop"
+  email     = local.account_emails["opg-refund-develop"][0]
+  parent_id = aws_organizations_organizational_unit.opg-lpa-refunds.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-refund-production" {
+  name      = "opg-refund-production"
+  email     = local.account_emails["opg-refund-production"][0]
+  parent_id = aws_organizations_organizational_unit.opg-lpa-refunds.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-lpa-refunds-development" {
+  name      = "MOJ OPG LPA Refunds Development"
+  email     = local.account_emails["MOJ OPG LPA Refunds Development"][0]
+  parent_id = aws_organizations_organizational_unit.opg-lpa-refunds.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-lpa-refunds-preproduction" {
+  name      = "MOJ OPG LPA Refunds Preproduction"
+  email     = local.account_emails["MOJ OPG LPA Refunds Preproduction"][0]
+  parent_id = aws_organizations_organizational_unit.opg-lpa-refunds.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-lpa-refunds-production" {
+  name      = "MOJ OPG LPA Refunds Production"
+  email     = local.account_emails["MOJ OPG LPA Refunds Production"][0]
+  parent_id = aws_organizations_organizational_unit.opg-lpa-refunds.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-opg-make-an-lpa.tf
+++ b/terraform/organizations-accounts-opg-make-an-lpa.tf
@@ -1,0 +1,68 @@
+# OPG OU: Make an LPA
+resource "aws_organizations_account" "moj-lpa-preproduction" {
+  name      = "MOJ LPA Preproduction"
+  email     = local.account_emails["MOJ LPA Preproduction"][0]
+  parent_id = aws_organizations_organizational_unit.opg-make-an-lpa.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-lpa-production" {
+  name      = "OPG LPA Production"
+  email     = local.account_emails["OPG LPA Production"][0]
+  parent_id = aws_organizations_organizational_unit.opg-make-an-lpa.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-lpa-production" {
+  name      = "MOJ OPG LPA Production"
+  email     = local.account_emails["MOJ OPG LPA Production"][0]
+  parent_id = aws_organizations_organizational_unit.opg-make-an-lpa.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-lpa-development" {
+  name      = "MOJ LPA Development"
+  email     = local.account_emails["MOJ LPA Development"][0]
+  parent_id = aws_organizations_organizational_unit.opg-make-an-lpa.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-opg-sirius.tf
+++ b/terraform/organizations-accounts-opg-sirius.tf
@@ -1,0 +1,102 @@
+# OPG OU: Sirius
+resource "aws_organizations_account" "moj-opg-sirius-production" {
+  name      = "MoJ OPG Sirius Production"
+  email     = local.account_emails["MoJ OPG Sirius Production"][0]
+  parent_id = aws_organizations_organizational_unit.opg-sirius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-sirius-development" {
+  name      = "MoJ OPG Sirius Development"
+  email     = local.account_emails["MoJ OPG Sirius Development"][0]
+  parent_id = aws_organizations_organizational_unit.opg-sirius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-sirius-dev" {
+  name      = "opg-sirius-dev"
+  email     = local.account_emails["opg-sirius-dev"][0]
+  parent_id = aws_organizations_organizational_unit.opg-sirius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-sirius-preproduction" {
+  name      = "MoJ OPG Sirius Preproduction"
+  email     = local.account_emails["MoJ OPG Sirius Preproduction"][0]
+  parent_id = aws_organizations_organizational_unit.opg-sirius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-sirius-backup" {
+  name      = "OPG Sirius Backup"
+  email     = local.account_emails["OPG Sirius Backup"][0]
+  parent_id = aws_organizations_organizational_unit.opg-sirius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-sirius-production" {
+  name      = "OPG Sirius Production"
+  email     = local.account_emails["OPG Sirius Production"][0]
+  parent_id = aws_organizations_organizational_unit.opg-sirius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-opg-use-my-lpa.tf
+++ b/terraform/organizations-accounts-opg-use-my-lpa.tf
@@ -1,0 +1,51 @@
+# OPG OU: Use My LPA
+resource "aws_organizations_account" "opg-use-my-lpa-production" {
+  name      = "OPG Use My LPA Production"
+  email     = local.account_emails["OPG Use My LPA Production"][0]
+  parent_id = aws_organizations_organizational_unit.opg-use-my-lpa.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-use-my-lpa-preproduction" {
+  name      = "OPG Use My LPA Preproduction"
+  email     = local.account_emails["OPG Use My LPA Preproduction"][0]
+  parent_id = aws_organizations_organizational_unit.opg-use-my-lpa.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-use-my-lpa-development" {
+  name      = "OPG Use My LPA Development"
+  email     = local.account_emails["OPG Use My LPA Development"][0]
+  parent_id = aws_organizations_organizational_unit.opg-use-my-lpa.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-opg.tf
+++ b/terraform/organizations-accounts-opg.tf
@@ -1,0 +1,119 @@
+# OPG OU
+resource "aws_organizations_account" "moj-opg-management" {
+  name      = "MoJ OPG Management"
+  email     = local.account_emails["MoJ OPG Management"][0]
+  parent_id = aws_organizations_organizational_unit.opg.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-shared" {
+  name      = "opg-shared"
+  email     = local.account_emails["opg-shared"][0]
+  parent_id = aws_organizations_organizational_unit.opg.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-shared-production" {
+  name      = "MoJ OPG Shared Production"
+  email     = local.account_emails["MoJ OPG Shared Production"][0]
+  parent_id = aws_organizations_organizational_unit.opg.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "opg-backups" {
+  name      = "OPG Backups"
+  email     = local.account_emails["OPG Backups"][0]
+  parent_id = aws_organizations_organizational_unit.opg.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-identity" {
+  name      = "MoJ OPG Identity"
+  email     = local.account_emails["MoJ OPG Identity"][0]
+  parent_id = aws_organizations_organizational_unit.opg.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-shared-development" {
+  name      = "MoJ OPG Shared Development"
+  email     = local.account_emails["MoJ OPG Shared Development"][0]
+  parent_id = aws_organizations_organizational_unit.opg.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-opg-sandbox" {
+  name      = "MoJ OPG Sandbox"
+  email     = local.account_emails["MoJ OPG Sandbox"][0]
+  parent_id = aws_organizations_organizational_unit.opg.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}


### PR DESCRIPTION
Brings clickops-created AWS Organizations OPG OU accounts into Terraform.

Note: These have already been imported into the remote Terraform state.