### PR TITLE
Bring AWS Organizations HMPPS OU accounts into Terraform management

### DIFF
--- a/terraform/organizations-accounts-hmpps-delius.tf
+++ b/terraform/organizations-accounts-hmpps-delius.tf
@@ -1,0 +1,255 @@
+# HMPPS OU: Delius
+resource "aws_organizations_account" "alfresco-non-prod" {
+  name      = "Alfresco non-prod"
+  email     = local.account_emails["Alfresco non-prod"][0] # TODO: Move this into AWS Secrets Manager
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-training" {
+  name      = "HMPPS Delius Training"
+  email     = local.account_emails["HMPPS Delius Training"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-mis-test" {
+  name      = "HMPPS Delius MIS Test"
+  email     = local.account_emails["HMPPS Delius MIS Test"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "delius-new-tech-non-prod" {
+  name      = "Delius New Tech non-prod"
+  email     = local.account_emails["Delius New Tech non-prod"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-training-test" {
+  name      = "HMPPS Delius Training Test"
+  email     = local.account_emails["HMPPS Delius Training Test"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-pre-production" {
+  name      = "HMPPS Delius Pre Production"
+  email     = local.account_emails["HMPPS Delius Pre Production"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-po-test" {
+  name      = "HMPPS Delius PO Test"
+  email     = local.account_emails["HMPPS Delius PO Test"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-mis-non-prod" {
+  name      = "HMPPS Delius MIS non prod"
+  email     = local.account_emails["HMPPS Delius MIS non prod"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-po-test-1" {
+  name      = "HMPPS Delius PO Test 1"
+  email     = local.account_emails["HMPPS Delius PO Test 1"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "delius-core-non-prod" {
+  name      = "Delius Core non-prod"
+  email     = local.account_emails["Delius Core non-prod"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "probation-management-non-prod" {
+  name      = "Probation Management non-prod"
+  email     = local.account_emails["Probation Management non-prod"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-stage" {
+  name      = "HMPPS Delius Stage"
+  email     = local.account_emails["HMPPS Delius Stage"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-test" {
+  name      = "HMPPS Delius Test"
+  email     = local.account_emails["HMPPS Delius Test"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-po-test-2" {
+  name      = "HMPPS Delius PO Test 2"
+  email     = local.account_emails["HMPPS Delius PO Test 2"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-delius-performance" {
+  name      = "HMPPS Delius Performance"
+  email     = local.account_emails["HMPPS Delius Performance"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-delius.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-hmpps-electronic-monitoring.tf
+++ b/terraform/organizations-accounts-hmpps-electronic-monitoring.tf
@@ -1,0 +1,221 @@
+# HMPPS OU: Electronic Monitoring
+resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-dev" {
+  name      = "Electronic Monitoring Monitoring&Mapping Dev"
+  email     = local.account_emails["Electronic Monitoring Monitoring&Mapping Dev"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-shared-logging" {
+  name      = "Electronic Monitoring Shared Logging"
+  email     = local.account_emails["Electronic Monitoring Shared Logging"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-tagging-hardware-pre-prod" {
+  name      = "Electronic Monitoring Tagging Hardware Pre-Prod"
+  email     = local.account_emails["Electronic Monitoring Tagging Hardware Pre-Prod"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-shared-networking-non-prod" {
+  name      = "Electronic Monitoring Shared Networking (non-prod)"
+  email     = local.account_emails["Electronic Monitoring Shared Networking (non-prod)"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-tagging-hardware-prod" {
+  name      = "Electronic Monitoring Tagging Hardware Prod"
+  email     = local.account_emails["Electronic Monitoring Tagging Hardware Prod"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-pre-prod" {
+  name      = "Electronic Monitoring Monitoring&Mapping Pre-Prod"
+  email     = local.account_emails["Electronic Monitoring Monitoring&Mapping Pre-Prod"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-identity-access-management" {
+  name      = "Electronic Monitoring Identity & Access Management"
+  email     = local.account_emails["Electronic Monitoring Identity & Access Management"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-test" {
+  name      = "Electronic Monitoring Monitoring&Mapping Test"
+  email     = local.account_emails["Electronic Monitoring Monitoring&Mapping Test"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-shared-networking" {
+  name      = "Electronic Monitoring Shared Networking"
+  email     = local.account_emails["Electronic Monitoring Shared Networking"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-tagging-hardware-test" {
+  name      = "Electronic Monitoring Tagging Hardware Test"
+  email     = local.account_emails["Electronic Monitoring Tagging Hardware Test"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-protective-monitoring" {
+  name      = "Electronic Monitoring Protective Monitoring"
+  email     = local.account_emails["Electronic Monitoring Protective Monitoring"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-archive-query-service" {
+  name      = "Electronic Monitoring Archive & Query Service"
+  email     = local.account_emails["Electronic Monitoring Archive & Query Service"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-prod" {
+  name      = "Electronic Monitoring Monitoring&Mapping Prod"
+  email     = local.account_emails["Electronic Monitoring Monitoring&Mapping Prod"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-hmpps-vcms.tf
+++ b/terraform/organizations-accounts-hmpps-vcms.tf
@@ -1,0 +1,120 @@
+# HMPPS OU: VCMS
+resource "aws_organizations_account" "hmpps-victim-case-management-system-production" {
+  name      = "HMPPS Victim Case Management System Production"
+  email     = local.account_emails["HMPPS Victim Case Management System Production"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-vcms.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-victim-case-management-system-integration" {
+  name      = "HMPPS Victim Case Management System Integration"
+  email     = local.account_emails["HMPPS Victim Case Management System Integration"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-vcms.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-victim-case-management-system-performance" {
+  name      = "HMPPS Victim Case Management System Performance"
+  email     = local.account_emails["HMPPS Victim Case Management System Performance"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-vcms.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-victim-case-management-system-test" {
+  name      = "HMPPS Victim Case Management System Test"
+  email     = local.account_emails["HMPPS Victim Case Management System Test"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-vcms.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "vcms-non-prod" {
+  name      = "VCMS non-prod"
+  email     = local.account_emails["VCMS non-prod"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-vcms.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-victim-case-management-system-pre-production" {
+  name      = "HMPPS Victim Case Management System Pre Production"
+  email     = local.account_emails["HMPPS Victim Case Management System Pre Production"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-vcms.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-victim-case-management-system-stage" {
+  name      = "HMPPS Victim Case Management System Stage"
+  email     = local.account_emails["HMPPS Victim Case Management System Stage"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps-vcms.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+

--- a/terraform/organizations-accounts-hmpps.tf
+++ b/terraform/organizations-accounts-hmpps.tf
@@ -1,0 +1,256 @@
+# HMPPS OU
+resource "aws_organizations_account" "strategic-partner-gateway-non-production" {
+  name      = "Strategic Partner Gateway Non Production"
+  email     = local.account_emails["Strategic Partner Gateway Non Production"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "probation" {
+  name      = "Probation"
+  email     = local.account_emails["Probation"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-management" {
+  name      = "HMPPS Management"
+  email     = local.account_emails["HMPPS Management"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-co-financing-organisation" {
+  name      = "HMPPS Co-Financing Organisation"
+  email     = local.account_emails["HMPPS Co-Financing Organisation"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-security-audit" {
+  name      = "HMPPS Security Audit"
+  email     = local.account_emails["HMPPS Security Audit"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-performance-hub" {
+  name      = "HMPPS Performance Hub"
+  email     = local.account_emails["HMPPS Performance Hub"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-prod" {
+  name      = "HMPPS PROD"
+  email     = local.account_emails["HMPPS PROD"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-engineering-production" {
+  name      = "HMPPS Engineering Production"
+  email     = local.account_emails["HMPPS Engineering Production"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-check-my-diary-prod" {
+  name      = "HMPPS Check My Diary Prod"
+  email     = local.account_emails["HMPPS Check My Diary Prod"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-dev" {
+  name      = "HMPPS Dev"
+  email     = local.account_emails["HMPPS Dev"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "noms-api" {
+  name      = "NOMS API"
+  email     = local.account_emails["NOMS API"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-security-poc" {
+  name      = "HMPPS Security POC"
+  email     = local.account_emails["HMPPS Security POC"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-probation-production" {
+  name      = "HMPPS Probation Production"
+  email     = local.account_emails["HMPPS Probation Production"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "public-sector-prison-industries" {
+  name      = "Public Sector Prison Industries"
+  email     = local.account_emails["Public Sector Prison Industries"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps-check-my-diary-development" {
+  name      = "HMPPS Check My Diary Development"
+  email     = local.account_emails["HMPPS Check My Diary Development"][0]
+  parent_id = aws_organizations_organizational_unit.hmpps.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+


### PR DESCRIPTION
Brings clickops-created AWS Organizations HMPPS OU accounts into Terraform.

Note: These have already been imported into the remote Terraform state.