### PR TITLE
Bring AWS Organizations Analytics Platform OU accounts into Terraform management

### DIFF
--- a/terraform/organizations-accounts-analytics-platform.tf
+++ b/terraform/organizations-accounts-analytics-platform.tf
@@ -1,0 +1,102 @@
+# Analytics Platform OU
+resource "aws_organizations_account" "analytical-platform-development" {
+  name      = "Analytical Platform Development"
+  email     = local.account_emails["Analytical Platform Development"][0]
+  parent_id = aws_organizations_organizational_unit.analytics-platform.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "analytics-platform-development" {
+  name      = "Analytics Platform Development"
+  email     = local.account_emails["Analytics Platform Development"][0]
+  parent_id = aws_organizations_organizational_unit.analytics-platform.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "analytical-platform-landing" {
+  name      = "Analytical Platform Landing"
+  email     = local.account_emails["Analytical Platform Landing"][0]
+  parent_id = aws_organizations_organizational_unit.analytics-platform.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "analytical-platform-production" {
+  name      = "Analytical Platform Production"
+  email     = local.account_emails["Analytical Platform Production"][0]
+  parent_id = aws_organizations_organizational_unit.analytics-platform.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "analytical-platform-data-engineering" {
+  name      = "Analytical Platform Data Engineering"
+  email     = local.account_emails["Analytical Platform Data Engineering"][0]
+  parent_id = aws_organizations_organizational_unit.analytics-platform.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "moj-analytics-platform" {
+  name      = "MoJ Analytics Platform"
+  email     = local.account_emails["MoJ Analytics Platform"][0]
+  parent_id = aws_organizations_organizational_unit.analytics-platform.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}


### PR DESCRIPTION
Brings clickops-created AWS Organizations Analytics Platform OU accounts into Terraform.

Note: These have already been imported into the remote Terraform state.