### PR TITLE
Bring AWS Organizations CICA OU accounts into Terraform management

### DIFF
--- a/terraform/organizations-accounts-cica.tf
+++ b/terraform/organizations-accounts-cica.tf
@@ -1,0 +1,17 @@
+# CICA OU
+resource "aws_organizations_account" "cica" {
+  name      = "CICA"
+  email     = local.account_emails["CICA"][0]
+  parent_id = aws_organizations_organizational_unit.cica.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}


### PR DESCRIPTION
Brings clickops-created AWS Organizations CICA OU accounts into Terraform.

Note: These have already been imported into the remote Terraform state.