### PR TITLE
Bring AWS Organizations Platforms and Architecture OU accounts into Terraform management

### DIFF
--- a/terraform/organizations-accounts-platforms-and-architecture-cloud-platform.tf
+++ b/terraform/organizations-accounts-platforms-and-architecture-cloud-platform.tf
@@ -1,0 +1,51 @@
+# Platforms & Architecture OU: Cloud Platform
+resource "aws_organizations_account" "cloud-platform-transit-gateways" {
+  name      = "Cloud Platform Transit Gateways"
+  email     = local.account_emails["Cloud Platform Transit Gateways"][0]
+  parent_id = aws_organizations_organizational_unit.platforms-and-architecture-cloud-platform.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "cloud-platform-ephemeral-test" {
+  name      = "Cloud Platform Ephemeral Test"
+  email     = local.account_emails["Cloud Platform Ephemeral Test"][0]
+  parent_id = aws_organizations_organizational_unit.platforms-and-architecture-cloud-platform.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
+resource "aws_organizations_account" "cloud-platform" {
+  name      = "Cloud Platform"
+  email     = local.account_emails["Cloud Platform"][0]
+  parent_id = aws_organizations_organizational_unit.platforms-and-architecture-cloud-platform.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-platforms-and-architecture-modernisation-platform.tf
+++ b/terraform/organizations-accounts-platforms-and-architecture-modernisation-platform.tf
@@ -1,0 +1,2 @@
+# The Modernisation Platform manage their own OUs and accounts.
+# See: https://github.com/ministryofjustice/modernisation-platform


### PR DESCRIPTION
Brings clickops-created AWS Organizations Platforms and Architecture OU accounts into Terraform.

Note: These have already been imported into the remote Terraform state.