### PR TITLE
Bring AWS Organizations policy attachment to accounts into Terraform management

### DIFF
--- a/terraform/organizations-accounts-analytics-platform.tf
+++ b/terraform/organizations-accounts-analytics-platform.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "analytical-platform-development" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "analytical-platform-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.analytical-platform-development.id
+}
+
 resource "aws_organizations_account" "analytics-platform-development" {
   name      = "Analytics Platform Development"
   email     = local.account_emails["Analytics Platform Development"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "analytics-platform-development" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "analytics-platform-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.analytics-platform-development.id
 }
 
 resource "aws_organizations_account" "analytical-platform-landing" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "analytical-platform-landing" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "analytical-platform-landing" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.analytical-platform-landing.id
+}
+
 resource "aws_organizations_account" "analytical-platform-production" {
   name      = "Analytical Platform Production"
   email     = local.account_emails["Analytical Platform Production"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "analytical-platform-production" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "analytical-platform-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.analytical-platform-production.id
 }
 
 resource "aws_organizations_account" "analytical-platform-data-engineering" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "analytical-platform-data-engineering" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "analytical-platform-data-engineering" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.analytical-platform-data-engineering.id
+}
+
 resource "aws_organizations_account" "moj-analytics-platform" {
   name      = "MoJ Analytics Platform"
   email     = local.account_emails["MoJ Analytics Platform"][0]
@@ -99,4 +124,9 @@ resource "aws_organizations_account" "moj-analytics-platform" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-analytics-platform" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-analytics-platform.id
 }

--- a/terraform/organizations-accounts-central-digital.tf
+++ b/terraform/organizations-accounts-central-digital.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "parliamentary-questions" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "parliamentary-questions" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.parliamentary-questions.id
+}
+
 resource "aws_organizations_account" "cloud-networks-psn" {
   name      = "Cloud Networks PSN"
   email     = local.account_emails["Cloud Networks PSN"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "cloud-networks-psn" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "cloud-networks-psn" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.cloud-networks-psn.id
 }
 
 resource "aws_organizations_account" "moj-digital-services" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "moj-digital-services" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-digital-services" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-digital-services.id
+}
+
 resource "aws_organizations_account" "platforms-non-production" {
   name      = "platforms-non-production"
   email     = local.account_emails["platforms-non-production"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "platforms-non-production" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "platforms-non-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.platforms-non-production.id
 }
 
 resource "aws_organizations_account" "network-architecture" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "network-architecture" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "network-architecture" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.network-architecture.id
+}
+
 resource "aws_organizations_account" "moj-peoplefinder" {
   name      = "MoJ PeopleFinder"
   email     = local.account_emails["MoJ PeopleFinder"][0]
@@ -99,6 +124,11 @@ resource "aws_organizations_account" "moj-peoplefinder" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-peoplefinder" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-peoplefinder.id
 }
 
 resource "aws_organizations_account" "moj-cla" {
@@ -118,6 +148,11 @@ resource "aws_organizations_account" "moj-cla" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-cla" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-cla.id
+}
+
 resource "aws_organizations_account" "patterns" {
   name      = "Patterns"
   email     = local.account_emails["Patterns"][0]
@@ -133,4 +168,9 @@ resource "aws_organizations_account" "patterns" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "patterns" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.patterns.id
 }

--- a/terraform/organizations-accounts-cica.tf
+++ b/terraform/organizations-accounts-cica.tf
@@ -15,3 +15,8 @@ resource "aws_organizations_account" "cica" {
     ]
   }
 }
+
+resource "aws_organizations_policy_attachment" "cica" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.cica.id
+}

--- a/terraform/organizations-accounts-closed-accounts.tf
+++ b/terraform/organizations-accounts-closed-accounts.tf
@@ -15,6 +15,11 @@ resource "aws_organizations_account" "moj-opg-identity-closed-0" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-identity-closed-0" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-identity-closed-0.id
+}
+
 resource "aws_organizations_account" "moj-opg-identity-closed-2" {
   name      = "MoJ OPG Identity"
   email     = local.account_emails["MoJ OPG Identity"][1]
@@ -30,6 +35,11 @@ resource "aws_organizations_account" "moj-opg-identity-closed-2" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-opg-identity-closed-2" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-identity-closed-2.id
 }
 
 resource "aws_organizations_account" "money-to-prisoners-closed" {
@@ -49,6 +59,11 @@ resource "aws_organizations_account" "money-to-prisoners-closed" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "money-to-prisoners-closed" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.money-to-prisoners-closed.id
+}
+
 resource "aws_organizations_account" "moj-security-closed" {
   name      = "MoJ-Security"
   email     = local.account_emails["MoJ-Security"][0]
@@ -64,4 +79,9 @@ resource "aws_organizations_account" "moj-security-closed" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-security-closed" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-security-closed.id
 }

--- a/terraform/organizations-accounts-hmcts.tf
+++ b/terraform/organizations-accounts-hmcts.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "hmcts-fee-remissions" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmcts-fee-remissions" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmcts-fee-remissions.id
+}
+
 resource "aws_organizations_account" "manchester-traffic-dev" {
   name      = "Manchester Traffic Dev"
   email     = local.account_emails["Manchester Traffic Dev"][0]
@@ -33,6 +38,11 @@ resource "aws_organizations_account" "manchester-traffic-dev" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "manchester-traffic-dev" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.manchester-traffic-dev.id
+}
+
 resource "aws_organizations_account" "get-help-with-child-arrangements" {
   name      = "Get help with child arrangements"
   email     = local.account_emails["Get help with child arrangements"][0]
@@ -48,4 +58,9 @@ resource "aws_organizations_account" "get-help-with-child-arrangements" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "get-help-with-child-arrangements" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.get-help-with-child-arrangements.id
 }

--- a/terraform/organizations-accounts-hmpps-delius.tf
+++ b/terraform/organizations-accounts-hmpps-delius.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "alfresco-non-prod" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "alfresco-non-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.alfresco-non-prod.id
+}
+
 resource "aws_organizations_account" "hmpps-delius-training" {
   name      = "HMPPS Delius Training"
   email     = local.account_emails["HMPPS Delius Training"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "hmpps-delius-training" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-delius-training" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-training.id
 }
 
 resource "aws_organizations_account" "hmpps-delius-mis-test" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "hmpps-delius-mis-test" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-delius-mis-test" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-mis-test.id
+}
+
 resource "aws_organizations_account" "delius-new-tech-non-prod" {
   name      = "Delius New Tech non-prod"
   email     = local.account_emails["Delius New Tech non-prod"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "delius-new-tech-non-prod" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "delius-new-tech-non-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.delius-new-tech-non-prod.id
 }
 
 resource "aws_organizations_account" "hmpps-delius-training-test" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "hmpps-delius-training-test" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-delius-training-test" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-training-test.id
+}
+
 resource "aws_organizations_account" "hmpps-delius-pre-production" {
   name      = "HMPPS Delius Pre Production"
   email     = local.account_emails["HMPPS Delius Pre Production"][0]
@@ -99,6 +124,11 @@ resource "aws_organizations_account" "hmpps-delius-pre-production" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-delius-pre-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-pre-production.id
 }
 
 resource "aws_organizations_account" "hmpps-delius-po-test" {
@@ -118,6 +148,11 @@ resource "aws_organizations_account" "hmpps-delius-po-test" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-delius-po-test" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-po-test.id
+}
+
 resource "aws_organizations_account" "hmpps-delius-mis-non-prod" {
   name      = "HMPPS Delius MIS non prod"
   email     = local.account_emails["HMPPS Delius MIS non prod"][0]
@@ -133,6 +168,11 @@ resource "aws_organizations_account" "hmpps-delius-mis-non-prod" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-delius-mis-non-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-mis-non-prod.id
 }
 
 resource "aws_organizations_account" "hmpps-delius-po-test-1" {
@@ -152,6 +192,11 @@ resource "aws_organizations_account" "hmpps-delius-po-test-1" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-delius-po-test-1" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-po-test-1.id
+}
+
 resource "aws_organizations_account" "delius-core-non-prod" {
   name      = "Delius Core non-prod"
   email     = local.account_emails["Delius Core non-prod"][0]
@@ -167,6 +212,11 @@ resource "aws_organizations_account" "delius-core-non-prod" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "delius-core-non-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.delius-core-non-prod.id
 }
 
 resource "aws_organizations_account" "probation-management-non-prod" {
@@ -186,6 +236,11 @@ resource "aws_organizations_account" "probation-management-non-prod" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "probation-management-non-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.probation-management-non-prod.id
+}
+
 resource "aws_organizations_account" "hmpps-delius-stage" {
   name      = "HMPPS Delius Stage"
   email     = local.account_emails["HMPPS Delius Stage"][0]
@@ -201,6 +256,11 @@ resource "aws_organizations_account" "hmpps-delius-stage" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-delius-stage" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-stage.id
 }
 
 resource "aws_organizations_account" "hmpps-delius-test" {
@@ -220,6 +280,11 @@ resource "aws_organizations_account" "hmpps-delius-test" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-delius-test" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-test.id
+}
+
 resource "aws_organizations_account" "hmpps-delius-po-test-2" {
   name      = "HMPPS Delius PO Test 2"
   email     = local.account_emails["HMPPS Delius PO Test 2"][0]
@@ -237,6 +302,11 @@ resource "aws_organizations_account" "hmpps-delius-po-test-2" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-delius-po-test-2" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-po-test-2.id
+}
+
 resource "aws_organizations_account" "hmpps-delius-performance" {
   name      = "HMPPS Delius Performance"
   email     = local.account_emails["HMPPS Delius Performance"][0]
@@ -252,4 +322,9 @@ resource "aws_organizations_account" "hmpps-delius-performance" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-delius-performance" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-delius-performance.id
 }

--- a/terraform/organizations-accounts-hmpps-electronic-monitoring.tf
+++ b/terraform/organizations-accounts-hmpps-electronic-monitoring.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-d
   }
 }
 
+resource "aws_organizations_policy_attachment" "electronic-monitoring-monitoring-mapping-dev" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-monitoring-mapping-dev.id
+}
+
 resource "aws_organizations_account" "electronic-monitoring-shared-logging" {
   name      = "Electronic Monitoring Shared Logging"
   email     = local.account_emails["Electronic Monitoring Shared Logging"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "electronic-monitoring-shared-logging" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "electronic-monitoring-shared-logging" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-shared-logging.id
 }
 
 resource "aws_organizations_account" "electronic-monitoring-tagging-hardware-pre-prod" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "electronic-monitoring-tagging-hardware-pre
   }
 }
 
+resource "aws_organizations_policy_attachment" "electronic-monitoring-tagging-hardware-pre-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-tagging-hardware-pre-prod.id
+}
+
 resource "aws_organizations_account" "electronic-monitoring-shared-networking-non-prod" {
   name      = "Electronic Monitoring Shared Networking (non-prod)"
   email     = local.account_emails["Electronic Monitoring Shared Networking (non-prod)"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "electronic-monitoring-shared-networking-no
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "electronic-monitoring-shared-networking-non-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-shared-networking-non-prod.id
 }
 
 resource "aws_organizations_account" "electronic-monitoring-tagging-hardware-prod" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "electronic-monitoring-tagging-hardware-pro
   }
 }
 
+resource "aws_organizations_policy_attachment" "electronic-monitoring-tagging-hardware-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-tagging-hardware-prod.id
+}
+
 resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-pre-prod" {
   name      = "Electronic Monitoring Monitoring&Mapping Pre-Prod"
   email     = local.account_emails["Electronic Monitoring Monitoring&Mapping Pre-Prod"][0]
@@ -99,6 +124,11 @@ resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-p
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "electronic-monitoring-monitoring-mapping-pre-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-monitoring-mapping-pre-prod.id
 }
 
 resource "aws_organizations_account" "electronic-monitoring-identity-access-management" {
@@ -118,6 +148,11 @@ resource "aws_organizations_account" "electronic-monitoring-identity-access-mana
   }
 }
 
+resource "aws_organizations_policy_attachment" "electronic-monitoring-identity-access-management" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-identity-access-management.id
+}
+
 resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-test" {
   name      = "Electronic Monitoring Monitoring&Mapping Test"
   email     = local.account_emails["Electronic Monitoring Monitoring&Mapping Test"][0]
@@ -133,6 +168,11 @@ resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-t
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "electronic-monitoring-monitoring-mapping-test" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-monitoring-mapping-test.id
 }
 
 resource "aws_organizations_account" "electronic-monitoring-shared-networking" {
@@ -152,6 +192,11 @@ resource "aws_organizations_account" "electronic-monitoring-shared-networking" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "electronic-monitoring-shared-networking" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-shared-networking.id
+}
+
 resource "aws_organizations_account" "electronic-monitoring-tagging-hardware-test" {
   name      = "Electronic Monitoring Tagging Hardware Test"
   email     = local.account_emails["Electronic Monitoring Tagging Hardware Test"][0]
@@ -167,6 +212,11 @@ resource "aws_organizations_account" "electronic-monitoring-tagging-hardware-tes
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "electronic-monitoring-tagging-hardware-test" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-tagging-hardware-test.id
 }
 
 resource "aws_organizations_account" "electronic-monitoring-protective-monitoring" {
@@ -186,6 +236,11 @@ resource "aws_organizations_account" "electronic-monitoring-protective-monitorin
   }
 }
 
+resource "aws_organizations_policy_attachment" "electronic-monitoring-protective-monitoring" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-protective-monitoring.id
+}
+
 resource "aws_organizations_account" "electronic-monitoring-archive-query-service" {
   name      = "Electronic Monitoring Archive & Query Service"
   email     = local.account_emails["Electronic Monitoring Archive & Query Service"][0]
@@ -203,6 +258,11 @@ resource "aws_organizations_account" "electronic-monitoring-archive-query-servic
   }
 }
 
+resource "aws_organizations_policy_attachment" "electronic-monitoring-archive-query-service" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-archive-query-service.id
+}
+
 resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-prod" {
   name      = "Electronic Monitoring Monitoring&Mapping Prod"
   email     = local.account_emails["Electronic Monitoring Monitoring&Mapping Prod"][0]
@@ -218,4 +278,9 @@ resource "aws_organizations_account" "electronic-monitoring-monitoring-mapping-p
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "electronic-monitoring-monitoring-mapping-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-monitoring-mapping-prod.id
 }

--- a/terraform/organizations-accounts-hmpps-vcms.tf
+++ b/terraform/organizations-accounts-hmpps-vcms.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "hmpps-victim-case-management-system-produc
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-victim-case-management-system-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-victim-case-management-system-production.id
+}
+
 resource "aws_organizations_account" "hmpps-victim-case-management-system-integration" {
   name      = "HMPPS Victim Case Management System Integration"
   email     = local.account_emails["HMPPS Victim Case Management System Integration"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "hmpps-victim-case-management-system-integr
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-victim-case-management-system-integration" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-victim-case-management-system-integration.id
 }
 
 resource "aws_organizations_account" "hmpps-victim-case-management-system-performance" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "hmpps-victim-case-management-system-perfor
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-victim-case-management-system-performance" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-victim-case-management-system-performance.id
+}
+
 resource "aws_organizations_account" "hmpps-victim-case-management-system-test" {
   name      = "HMPPS Victim Case Management System Test"
   email     = local.account_emails["HMPPS Victim Case Management System Test"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "hmpps-victim-case-management-system-test" 
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-victim-case-management-system-test" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-victim-case-management-system-test.id
 }
 
 resource "aws_organizations_account" "vcms-non-prod" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "vcms-non-prod" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "vcms-non-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.vcms-non-prod.id
+}
+
 resource "aws_organizations_account" "hmpps-victim-case-management-system-pre-production" {
   name      = "HMPPS Victim Case Management System Pre Production"
   email     = local.account_emails["HMPPS Victim Case Management System Pre Production"][0]
@@ -99,6 +124,11 @@ resource "aws_organizations_account" "hmpps-victim-case-management-system-pre-pr
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-victim-case-management-system-pre-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-victim-case-management-system-pre-production.id
 }
 
 resource "aws_organizations_account" "hmpps-victim-case-management-system-stage" {
@@ -118,3 +148,7 @@ resource "aws_organizations_account" "hmpps-victim-case-management-system-stage"
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-victim-case-management-system-stage" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-victim-case-management-system-stage.id
+}

--- a/terraform/organizations-accounts-hmpps.tf
+++ b/terraform/organizations-accounts-hmpps.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "strategic-partner-gateway-non-production" 
   }
 }
 
+resource "aws_organizations_policy_attachment" "strategic-partner-gateway-non-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.strategic-partner-gateway-non-production.id
+}
+
 resource "aws_organizations_account" "probation" {
   name      = "Probation"
   email     = local.account_emails["Probation"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "probation" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "probation" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.probation.id
 }
 
 resource "aws_organizations_account" "hmpps-management" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "hmpps-management" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-management" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-management.id
+}
+
 resource "aws_organizations_account" "hmpps-co-financing-organisation" {
   name      = "HMPPS Co-Financing Organisation"
   email     = local.account_emails["HMPPS Co-Financing Organisation"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "hmpps-co-financing-organisation" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-co-financing-organisation" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-co-financing-organisation.id
 }
 
 resource "aws_organizations_account" "hmpps-security-audit" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "hmpps-security-audit" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-security-audit" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-security-audit.id
+}
+
 resource "aws_organizations_account" "hmpps-performance-hub" {
   name      = "HMPPS Performance Hub"
   email     = local.account_emails["HMPPS Performance Hub"][0]
@@ -99,6 +124,11 @@ resource "aws_organizations_account" "hmpps-performance-hub" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-performance-hub" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-performance-hub.id
 }
 
 resource "aws_organizations_account" "hmpps-prod" {
@@ -118,6 +148,11 @@ resource "aws_organizations_account" "hmpps-prod" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-prod.id
+}
+
 resource "aws_organizations_account" "hmpps-engineering-production" {
   name      = "HMPPS Engineering Production"
   email     = local.account_emails["HMPPS Engineering Production"][0]
@@ -133,6 +168,11 @@ resource "aws_organizations_account" "hmpps-engineering-production" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-engineering-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-engineering-production.id
 }
 
 resource "aws_organizations_account" "hmpps-check-my-diary-prod" {
@@ -152,6 +192,11 @@ resource "aws_organizations_account" "hmpps-check-my-diary-prod" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-check-my-diary-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-check-my-diary-prod.id
+}
+
 resource "aws_organizations_account" "hmpps-dev" {
   name      = "HMPPS Dev"
   email     = local.account_emails["HMPPS Dev"][0]
@@ -167,6 +212,11 @@ resource "aws_organizations_account" "hmpps-dev" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-dev" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-dev.id
 }
 
 resource "aws_organizations_account" "noms-api" {
@@ -186,6 +236,11 @@ resource "aws_organizations_account" "noms-api" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "noms-api" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.noms-api.id
+}
+
 resource "aws_organizations_account" "hmpps-security-poc" {
   name      = "HMPPS Security POC"
   email     = local.account_emails["HMPPS Security POC"][0]
@@ -201,6 +256,11 @@ resource "aws_organizations_account" "hmpps-security-poc" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-security-poc" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-security-poc.id
 }
 
 resource "aws_organizations_account" "hmpps-probation-production" {
@@ -220,6 +280,11 @@ resource "aws_organizations_account" "hmpps-probation-production" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-probation-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-probation-production.id
+}
+
 resource "aws_organizations_account" "public-sector-prison-industries" {
   name      = "Public Sector Prison Industries"
   email     = local.account_emails["Public Sector Prison Industries"][0]
@@ -237,6 +302,11 @@ resource "aws_organizations_account" "public-sector-prison-industries" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "public-sector-prison-industries" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.public-sector-prison-industries.id
+}
+
 resource "aws_organizations_account" "hmpps-check-my-diary-development" {
   name      = "HMPPS Check My Diary Development"
   email     = local.account_emails["HMPPS Check My Diary Development"][0]
@@ -252,5 +322,10 @@ resource "aws_organizations_account" "hmpps-check-my-diary-development" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-check-my-diary-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.hmpps-check-my-diary-development.id
 }
 

--- a/terraform/organizations-accounts-laa.tf
+++ b/terraform/organizations-accounts-laa.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "laa-test" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "laa-test" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.laa-test.id
+}
+
 resource "aws_organizations_account" "laa-uat" {
   name      = "LAA UAT"
   email     = local.account_emails["LAA UAT"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "laa-uat" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "laa-uat" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.laa-uat.id
 }
 
 resource "aws_organizations_account" "aws-laa" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "aws-laa" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "aws-laa" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.aws-laa.id
+}
+
 resource "aws_organizations_account" "laa-staging" {
   name      = "LAA Staging"
   email     = local.account_emails["LAA Staging"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "laa-staging" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "laa-staging" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.laa-staging.id
 }
 
 resource "aws_organizations_account" "legal-aid-agency" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "legal-aid-agency" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "legal-aid-agency" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.legal-aid-agency.id
+}
+
 resource "aws_organizations_account" "laa-development" {
   name      = "LAA Development"
   email     = local.account_emails["LAA Development"][0]
@@ -99,6 +124,11 @@ resource "aws_organizations_account" "laa-development" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "laa-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.laa-development.id
 }
 
 resource "aws_organizations_account" "laa-cloudtrail" {
@@ -118,6 +148,11 @@ resource "aws_organizations_account" "laa-cloudtrail" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "laa-cloudtrail" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.laa-cloudtrail.id
+}
+
 resource "aws_organizations_account" "laa-production" {
   name      = "LAA Production"
   email     = local.account_emails["LAA Production"][0]
@@ -135,6 +170,11 @@ resource "aws_organizations_account" "laa-production" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "laa-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.laa-production.id
+}
+
 resource "aws_organizations_account" "laa-shared-services" {
   name      = "LAA Shared services"
   email     = local.account_emails["LAA Shared services"][0]
@@ -150,4 +190,9 @@ resource "aws_organizations_account" "laa-shared-services" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "laa-shared-services" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.laa-shared-services.id
 }

--- a/terraform/organizations-accounts-opg-digicop.tf
+++ b/terraform/organizations-accounts-opg-digicop.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "moj-opg-digicop-production" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-digicop-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-digicop-production.id
+}
+
 resource "aws_organizations_account" "moj-opg-digicop-development" {
   name      = "MoJ OPG DigiCop Development"
   email     = local.account_emails["MoJ OPG DigiCop Development"][0]
@@ -33,6 +38,11 @@ resource "aws_organizations_account" "moj-opg-digicop-development" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-digicop-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-digicop-development.id
+}
+
 resource "aws_organizations_account" "moj-opg-digicop-preproduction" {
   name      = "MoJ OPG DigiCop Preproduction"
   email     = local.account_emails["MoJ OPG DigiCop Preproduction"][0]
@@ -48,4 +58,9 @@ resource "aws_organizations_account" "moj-opg-digicop-preproduction" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-opg-digicop-preproduction" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-digicop-preproduction.id
 }

--- a/terraform/organizations-accounts-opg-digideps.tf
+++ b/terraform/organizations-accounts-opg-digideps.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "opg-digi-deps-prod" {
   }
 }
 
+resource "aws_organizations_account" "opg-digi-deps-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-digi-deps-prod.id
+}
+
 resource "aws_organizations_account" "opg-digi-deps-dev" {
   name      = "OPG Digi Deps Dev"
   email     = local.account_emails["OPG Digi Deps Dev"][0]
@@ -33,6 +38,11 @@ resource "aws_organizations_account" "opg-digi-deps-dev" {
   }
 }
 
+resource "aws_organizations_account" "opg-digi-deps-dev" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-digi-deps-dev.id
+}
+
 resource "aws_organizations_account" "opg-digi-deps-preprod" {
   name      = "OPG Digi Deps Preprod"
   email     = local.account_emails["OPG Digi Deps Preprod"][0]
@@ -48,4 +58,9 @@ resource "aws_organizations_account" "opg-digi-deps-preprod" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_account" "opg-digi-deps-preprod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-digi-deps-preprod.id
 }

--- a/terraform/organizations-accounts-opg-lpa-refunds.tf
+++ b/terraform/organizations-accounts-opg-lpa-refunds.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "opg-refund-develop" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "opg-refund-develop" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-refund-develop.id
+}
+
 resource "aws_organizations_account" "opg-refund-production" {
   name      = "opg-refund-production"
   email     = local.account_emails["opg-refund-production"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "opg-refund-production" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "opg-refund-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-refund-production.id
 }
 
 resource "aws_organizations_account" "moj-opg-lpa-refunds-development" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "moj-opg-lpa-refunds-development" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-lpa-refunds-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-lpa-refunds-development.id
+}
+
 resource "aws_organizations_account" "moj-opg-lpa-refunds-preproduction" {
   name      = "MOJ OPG LPA Refunds Preproduction"
   email     = local.account_emails["MOJ OPG LPA Refunds Preproduction"][0]
@@ -67,6 +82,11 @@ resource "aws_organizations_account" "moj-opg-lpa-refunds-preproduction" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-lpa-refunds-preproduction" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-lpa-refunds-preproduction.id
+}
+
 resource "aws_organizations_account" "moj-opg-lpa-refunds-production" {
   name      = "MOJ OPG LPA Refunds Production"
   email     = local.account_emails["MOJ OPG LPA Refunds Production"][0]
@@ -82,4 +102,9 @@ resource "aws_organizations_account" "moj-opg-lpa-refunds-production" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-opg-lpa-refunds-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-lpa-refunds-production.id
 }

--- a/terraform/organizations-accounts-opg-make-an-lpa.tf
+++ b/terraform/organizations-accounts-opg-make-an-lpa.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "moj-lpa-preproduction" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-lpa-preproduction" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-lpa-preproduction.id
+}
+
 resource "aws_organizations_account" "opg-lpa-production" {
   name      = "OPG LPA Production"
   email     = local.account_emails["OPG LPA Production"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "opg-lpa-production" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "opg-lpa-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-lpa-production.id
 }
 
 resource "aws_organizations_account" "moj-opg-lpa-production" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "moj-opg-lpa-production" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-lpa-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-lpa-production.id
+}
+
 resource "aws_organizations_account" "moj-lpa-development" {
   name      = "MOJ LPA Development"
   email     = local.account_emails["MOJ LPA Development"][0]
@@ -65,4 +80,9 @@ resource "aws_organizations_account" "moj-lpa-development" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-lpa-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-lpa-development.id
 }

--- a/terraform/organizations-accounts-opg-sirius.tf
+++ b/terraform/organizations-accounts-opg-sirius.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "moj-opg-sirius-production" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-sirius-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-sirius-production.id
+}
+
 resource "aws_organizations_account" "moj-opg-sirius-development" {
   name      = "MoJ OPG Sirius Development"
   email     = local.account_emails["MoJ OPG Sirius Development"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "moj-opg-sirius-development" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-opg-sirius-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-sirius-development.id
 }
 
 resource "aws_organizations_account" "opg-sirius-dev" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "opg-sirius-dev" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "opg-sirius-dev" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-sirius-dev.id
+}
+
 resource "aws_organizations_account" "moj-opg-sirius-preproduction" {
   name      = "MoJ OPG Sirius Preproduction"
   email     = local.account_emails["MoJ OPG Sirius Preproduction"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "moj-opg-sirius-preproduction" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-opg-sirius-preproduction" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-sirius-preproduction.id
 }
 
 resource "aws_organizations_account" "opg-sirius-backup" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "opg-sirius-backup" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "opg-sirius-backup" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-sirius-backup.id
+}
+
 resource "aws_organizations_account" "opg-sirius-production" {
   name      = "OPG Sirius Production"
   email     = local.account_emails["OPG Sirius Production"][0]
@@ -99,4 +124,9 @@ resource "aws_organizations_account" "opg-sirius-production" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "opg-sirius-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-sirius-production.id
 }

--- a/terraform/organizations-accounts-opg-use-my-lpa.tf
+++ b/terraform/organizations-accounts-opg-use-my-lpa.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "opg-use-my-lpa-production" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "opg-use-my-lpa-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-use-my-lpa-production.id
+}
+
 resource "aws_organizations_account" "opg-use-my-lpa-preproduction" {
   name      = "OPG Use My LPA Preproduction"
   email     = local.account_emails["OPG Use My LPA Preproduction"][0]
@@ -33,6 +38,11 @@ resource "aws_organizations_account" "opg-use-my-lpa-preproduction" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "opg-use-my-lpa-preproduction" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-use-my-lpa-preproduction.id
+}
+
 resource "aws_organizations_account" "opg-use-my-lpa-development" {
   name      = "OPG Use My LPA Development"
   email     = local.account_emails["OPG Use My LPA Development"][0]
@@ -48,4 +58,9 @@ resource "aws_organizations_account" "opg-use-my-lpa-development" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "opg-use-my-lpa-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-use-my-lpa-development.id
 }

--- a/terraform/organizations-accounts-opg.tf
+++ b/terraform/organizations-accounts-opg.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "moj-opg-management" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-management" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-management.id
+}
+
 resource "aws_organizations_account" "opg-shared" {
   name      = "opg-shared"
   email     = local.account_emails["opg-shared"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "opg-shared" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "opg-shared" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-shared.id
 }
 
 resource "aws_organizations_account" "moj-opg-shared-production" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "moj-opg-shared-production" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-shared-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-shared-production.id
+}
+
 resource "aws_organizations_account" "opg-backups" {
   name      = "OPG Backups"
   email     = local.account_emails["OPG Backups"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "opg-backups" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "opg-backups" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.opg-backups.id
 }
 
 resource "aws_organizations_account" "moj-opg-identity" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "moj-opg-identity" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-identity" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-identity.id
+}
+
 resource "aws_organizations_account" "moj-opg-shared-development" {
   name      = "MoJ OPG Shared Development"
   email     = local.account_emails["MoJ OPG Shared Development"][0]
@@ -101,6 +126,11 @@ resource "aws_organizations_account" "moj-opg-shared-development" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-opg-shared-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-shared-development.id
+}
+
 resource "aws_organizations_account" "moj-opg-sandbox" {
   name      = "MoJ OPG Sandbox"
   email     = local.account_emails["MoJ OPG Sandbox"][0]
@@ -116,4 +146,9 @@ resource "aws_organizations_account" "moj-opg-sandbox" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-opg-sandbox" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-opg-sandbox.id
 }

--- a/terraform/organizations-accounts-platforms-and-architecture-cloud-platform.tf
+++ b/terraform/organizations-accounts-platforms-and-architecture-cloud-platform.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "cloud-platform-transit-gateways" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "cloud-platform-transit-gateways" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.cloud-platform-transit-gateways.id
+}
+
 resource "aws_organizations_account" "cloud-platform-ephemeral-test" {
   name      = "Cloud Platform Ephemeral Test"
   email     = local.account_emails["Cloud Platform Ephemeral Test"][0]
@@ -33,6 +38,11 @@ resource "aws_organizations_account" "cloud-platform-ephemeral-test" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "cloud-platform-ephemeral-test" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.cloud-platform-ephemeral-test.id
+}
+
 resource "aws_organizations_account" "cloud-platform" {
   name      = "Cloud Platform"
   email     = local.account_emails["Cloud Platform"][0]
@@ -48,4 +58,9 @@ resource "aws_organizations_account" "cloud-platform" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "cloud-platform" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.cloud-platform.id
 }

--- a/terraform/organizations-accounts-security-engineering.tf
+++ b/terraform/organizations-accounts-security-engineering.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "security-operations-production" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "security-operations-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.security-operations-production.id
+}
+
 resource "aws_organizations_account" "security-engineering" {
   name      = "Security Engineering"
   email     = local.account_emails["Security Engineering"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "security-engineering" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "security-engineering" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.security-engineering.id
 }
 
 resource "aws_organizations_account" "security-operations-development" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "security-operations-development" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "security-operations-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.security-operations-development.id
+}
+
 resource "aws_organizations_account" "security-logging-platform" {
   name      = "Security Logging Platform"
   email     = local.account_emails["Security Logging Platform"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "security-logging-platform" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "security-logging-platform" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.security-logging-platform.id
 }
 
 resource "aws_organizations_account" "moj-security" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "moj-security" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-security" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-security.id
+}
+
 resource "aws_organizations_account" "security-operations-pre-production" {
   name      = "Security Operations Pre Production"
   email     = local.account_emails["Security Operations Pre Production"][0]
@@ -99,4 +124,9 @@ resource "aws_organizations_account" "security-operations-pre-production" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "security-operations-pre-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.security-operations-pre-production.id
 }

--- a/terraform/organizations-accounts-tactical-products.tf
+++ b/terraform/organizations-accounts-tactical-products.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "tp-hmcts" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "tp-hmcts" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.tp-hmcts.id
+}
+
 resource "aws_organizations_account" "tacticalproducts" {
   name      = "tacticalproducts"
   email     = local.account_emails["tacticalproducts"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "tacticalproducts" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "tacticalproducts" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.tacticalproducts.id
 }
 
 resource "aws_organizations_account" "tp-alb" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "tp-alb" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "tp-alb" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.tp-alb.id
+}
+
 resource "aws_organizations_account" "moj-intranet" {
   name      = "MOJ Intranet"
   email     = local.account_emails["MOJ Intranet"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "moj-intranet" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-intranet" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-intranet.id
 }
 
 resource "aws_organizations_account" "ministry-of-justice-courtfinder-prod" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "ministry-of-justice-courtfinder-prod" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "ministry-of-justice-courtfinder-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.ministry-of-justice-courtfinder-prod.id
+}
+
 resource "aws_organizations_account" "tp-hq" {
   name      = "TP-HQ"
   email     = local.account_emails["TP-HQ"][0]
@@ -101,6 +126,11 @@ resource "aws_organizations_account" "tp-hq" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "tp-hq" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.tp-hq.id
+}
+
 resource "aws_organizations_account" "moj-info-services-dev" {
   name      = "MoJ Info Services Dev"
   email     = local.account_emails["MoJ Info Services Dev"][0]
@@ -116,4 +146,9 @@ resource "aws_organizations_account" "moj-info-services-dev" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-info-services-dev" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-info-services-dev.id
 }

--- a/terraform/organizations-accounts-workplace-technology.tf
+++ b/terraform/organizations-accounts-workplace-technology.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "workplace-tech-proof-of-concept-developmen
   }
 }
 
+resource "aws_organizations_policy_attachment" "workplace-tech-proof-of-concept-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.workplace-tech-proof-of-concept-development.id
+}
+
 resource "aws_organizations_account" "wptpoc" {
   name      = "WPTPOC"
   email     = local.account_emails["WPTPOC"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "wptpoc" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "wptpoc" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.wptpoc.id
 }
 
 resource "aws_organizations_account" "moj-official-production" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "moj-official-production" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-official-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-official-production.id
+}
+
 resource "aws_organizations_account" "moj-official-pre-production" {
   name      = "MOJ Official (Pre-Production)"
   email     = local.account_emails["MOJ Official (Pre-Production)"][0]
@@ -67,6 +82,11 @@ resource "aws_organizations_account" "moj-official-pre-production" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-official-pre-production" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-official-pre-production.id
+}
+
 resource "aws_organizations_account" "moj-official-development" {
   name      = "MOJ Official (Development)"
   email     = local.account_emails["MOJ Official (Development)"][0]
@@ -82,4 +102,9 @@ resource "aws_organizations_account" "moj-official-development" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-official-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-official-development.id
 }

--- a/terraform/organizations-accounts-yjb.tf
+++ b/terraform/organizations-accounts-yjb.tf
@@ -16,6 +16,11 @@ resource "aws_organizations_account" "youth-justice-framework-dev" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "youth-justice-framework-dev" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.youth-justice-framework-dev.id
+}
+
 resource "aws_organizations_account" "youth-justice-framework-management" {
   name      = "Youth Justice Framework Management"
   email     = local.account_emails["Youth Justice Framework Management"][0]
@@ -31,6 +36,11 @@ resource "aws_organizations_account" "youth-justice-framework-management" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "youth-justice-framework-management" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.youth-justice-framework-management.id
 }
 
 resource "aws_organizations_account" "youth-justice-framework-pre-prod" {
@@ -50,6 +60,11 @@ resource "aws_organizations_account" "youth-justice-framework-pre-prod" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "youth-justice-framework-pre-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.youth-justice-framework-pre-prod.id
+}
+
 resource "aws_organizations_account" "youth-justice-framework-juniper" {
   name      = "Youth Justice Framework Juniper"
   email     = local.account_emails["Youth Justice Framework Juniper"][0]
@@ -65,6 +80,11 @@ resource "aws_organizations_account" "youth-justice-framework-juniper" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "youth-justice-framework-juniper" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.youth-justice-framework-juniper.id
 }
 
 resource "aws_organizations_account" "youth-justice-framework-prod" {
@@ -84,6 +104,11 @@ resource "aws_organizations_account" "youth-justice-framework-prod" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "youth-justice-framework-prod" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.youth-justice-framework-prod.id
+}
+
 resource "aws_organizations_account" "youth-justice-framework-monitoring" {
   name      = "Youth Justice Framework Monitoring"
   email     = local.account_emails["Youth Justice Framework Monitoring"][0]
@@ -99,6 +124,11 @@ resource "aws_organizations_account" "youth-justice-framework-monitoring" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "youth-justice-framework-monitoring" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.youth-justice-framework-monitoring.id
 }
 
 resource "aws_organizations_account" "youth-justice-framework-eng-tools" {
@@ -118,6 +148,11 @@ resource "aws_organizations_account" "youth-justice-framework-eng-tools" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "youth-justice-framework-eng-tools" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.youth-justice-framework-eng-tools.id
+}
+
 resource "aws_organizations_account" "youth-justice-framework-sandpit" {
   name      = "Youth Justice Framework Sandpit"
   email     = local.account_emails["Youth Justice Framework Sandpit"][0]
@@ -133,4 +168,9 @@ resource "aws_organizations_account" "youth-justice-framework-sandpit" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "youth-justice-framework-sandpit" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.youth-justice-framework-sandpit.id
 }

--- a/terraform/organizations-accounts.tf
+++ b/terraform/organizations-accounts.tf
@@ -3,9 +3,9 @@
 # rather than rely on this in the future.
 data "aws_organizations_organization" "root" {}
 
-output "account_ids" {
-  value = local.account_emails
-}
+# output "account_ids" {
+#   value = local.account_emails
+# }
 
 locals {
   account_emails = {
@@ -32,6 +32,11 @@ resource "aws_organizations_account" "bichard7-2020-prototype" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "bichard7-2020-prototype" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.bichard7-2020-prototype.id
+}
+
 resource "aws_organizations_account" "cica-development" {
   name      = "CICA Development"
   email     = local.account_emails["CICA Development"][0]
@@ -47,6 +52,11 @@ resource "aws_organizations_account" "cica-development" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "cica-development" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.cica-development.id
 }
 
 resource "aws_organizations_account" "cica-test-verify" {
@@ -66,6 +76,11 @@ resource "aws_organizations_account" "cica-test-verify" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "cica-test-verify" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.cica-test-verify.id
+}
+
 resource "aws_organizations_account" "cica-uat" {
   name      = "CICA UAT"
   email     = local.account_emails["CICA UAT"][0]
@@ -81,6 +96,11 @@ resource "aws_organizations_account" "cica-uat" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "cica-uat" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.cica-uat.id
 }
 
 resource "aws_organizations_account" "electronic-monitoring-infrastructure-dev" {
@@ -100,6 +120,11 @@ resource "aws_organizations_account" "electronic-monitoring-infrastructure-dev" 
   }
 }
 
+resource "aws_organizations_policy_attachment" "electronic-monitoring-infrastructure-dev" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.electronic-monitoring-infrastructure-dev.id
+}
+
 resource "aws_organizations_account" "modernisation-platform" {
   name      = "Modernisation Platform"
   email     = local.account_emails["Modernisation Platform"][0]
@@ -115,6 +140,11 @@ resource "aws_organizations_account" "modernisation-platform" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "modernisation-platform" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.modernisation-platform.id
 }
 
 resource "aws_organizations_account" "moj-billing-management" {
@@ -134,6 +164,11 @@ resource "aws_organizations_account" "moj-billing-management" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-billing-management" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-billing-management.id
+}
+
 resource "aws_organizations_account" "moj-official-public-key-infrastructure-dev" {
   name      = "MOJ Official (Public Key Infrastructure Dev)"
   email     = local.account_emails["MOJ Official (Public Key Infrastructure Dev)"][0]
@@ -149,6 +184,11 @@ resource "aws_organizations_account" "moj-official-public-key-infrastructure-dev
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-official-public-key-infrastructure-dev" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-official-public-key-infrastructure-dev.id
 }
 
 resource "aws_organizations_account" "moj-official-public-key-infrastructure" {
@@ -168,6 +208,11 @@ resource "aws_organizations_account" "moj-official-public-key-infrastructure" {
   }
 }
 
+resource "aws_organizations_policy_attachment" "moj-official-public-key-infrastructure" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-official-public-key-infrastructure.id
+}
+
 resource "aws_organizations_account" "moj-official-shared-services" {
   name      = "MOJ Official (Shared Services)"
   email     = local.account_emails["MOJ Official (Shared Services)"][0]
@@ -183,4 +228,9 @@ resource "aws_organizations_account" "moj-official-shared-services" {
       role_name
     ]
   }
+}
+
+resource "aws_organizations_policy_attachment" "moj-official-shared-services" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.moj-official-shared-services.id
 }


### PR DESCRIPTION
Brings clickops-created AWS Organizations policy attachments into Terraform.

Note: These have already been imported into the remote Terraform state.