### PR TITLE
Bring AWS Organizations policy attachment to the LAA OU into Terraform management

### DIFF
--- a/terraform/organizations-organizational-units.tf
+++ b/terraform/organizations-organizational-units.tf
@@ -78,6 +78,11 @@ resource "aws_organizations_organizational_unit" "laa" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "laa" {
+  policy_id = aws_organizations_policy.deny-cloudtrail-delete-stop-update-policy.id
+  target_id = aws_organizations_organizational_unit.laa.id
+}
+
 # Central Digital
 resource "aws_organizations_organizational_unit" "central-digital" {
   name      = "Central Digital"


### PR DESCRIPTION
Brings clickops-created AWS Organizations policy attachments to the LAA OU into Terraform.

Note: These have already been imported into the remote Terraform state.