### PR TITLE
Bring AWS Organizations root policy attachment into Terraform management

### DIFF
--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -7,3 +7,10 @@ resource "aws_organizations_organization" "default" {
   ]
   feature_set = "ALL"
 }
+
+# Note that whatever is attached here is inherited by all sub-accounts
+# See: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_inheritance.html
+resource "aws_organizations_policy_attachment" "default" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organization.default.roots[0].id
+}


### PR DESCRIPTION
Brings clickops-created AWS Organizations root policy attachment into Terraform.

Note: These have already been imported into the remote Terraform state.