### PR TITLE
Bring AWS Organizations OU policy attachments into Terraform management

### DIFF
--- a/terraform/organizations-organizational-units.tf
+++ b/terraform/organizations-organizational-units.tf
@@ -4,9 +4,19 @@ resource "aws_organizations_organizational_unit" "closed-accounts" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "closed-accounts-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.closed-accounts.id
+}
+
 resource "aws_organizations_organizational_unit" "closed-accounts-remove" {
   name      = "Remove"
   parent_id = aws_organizations_organizational_unit.closed-accounts.id
+}
+
+resource "aws_organizations_policy_attachment" "closed-accounts-remove-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.closed-accounts-remove.id
 }
 
 # OPG
@@ -15,9 +25,19 @@ resource "aws_organizations_organizational_unit" "opg" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "opg-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.opg.id
+}
+
 resource "aws_organizations_organizational_unit" "opg-lpa-refunds" {
   name      = "LPA Refunds"
   parent_id = aws_organizations_organizational_unit.opg.id
+}
+
+resource "aws_organizations_policy_attachment" "opg-lpa-refunds-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.opg-lpa-refunds.id
 }
 
 resource "aws_organizations_organizational_unit" "opg-sirius" {
@@ -25,9 +45,19 @@ resource "aws_organizations_organizational_unit" "opg-sirius" {
   parent_id = aws_organizations_organizational_unit.opg.id
 }
 
+resource "aws_organizations_policy_attachment" "opg-sirius-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.opg-sirius.id
+}
+
 resource "aws_organizations_organizational_unit" "opg-digideps" {
   name      = "DigiDeps"
   parent_id = aws_organizations_organizational_unit.opg.id
+}
+
+resource "aws_organizations_policy_attachment" "opg-digideps-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.opg-digideps.id
 }
 
 resource "aws_organizations_organizational_unit" "opg-make-an-lpa" {
@@ -35,14 +65,29 @@ resource "aws_organizations_organizational_unit" "opg-make-an-lpa" {
   parent_id = aws_organizations_organizational_unit.opg.id
 }
 
+resource "aws_organizations_policy_attachment" "opg-make-an-lpa-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.opg-make-an-lpa.id
+}
+
 resource "aws_organizations_organizational_unit" "opg-digicop" {
   name      = "DigiCop"
   parent_id = aws_organizations_organizational_unit.opg.id
 }
 
+resource "aws_organizations_policy_attachment" "opg-digicop-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.opg-digicop.id
+}
+
 resource "aws_organizations_organizational_unit" "opg-use-my-lpa" {
   name      = "Use My LPA"
   parent_id = aws_organizations_organizational_unit.opg.id
+}
+
+resource "aws_organizations_policy_attachment" "opg-use-my-lpa-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.opg-use-my-lpa.id
 }
 
 # HMPPS
@@ -51,9 +96,19 @@ resource "aws_organizations_organizational_unit" "hmpps" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.hmpps.id
+}
+
 resource "aws_organizations_organizational_unit" "hmpps-vcms" {
   name      = "VCMS"
   parent_id = aws_organizations_organizational_unit.hmpps.id
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-vcms-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.hmpps-vcms.id
 }
 
 resource "aws_organizations_organizational_unit" "hmpps-delius" {
@@ -61,9 +116,19 @@ resource "aws_organizations_organizational_unit" "hmpps-delius" {
   parent_id = aws_organizations_organizational_unit.hmpps.id
 }
 
+resource "aws_organizations_policy_attachment" "hmpps-delius-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.hmpps-delius.id
+}
+
 resource "aws_organizations_organizational_unit" "hmpps-electronic-monitoring" {
   name      = "Electronic Monitoring"
   parent_id = aws_organizations_organizational_unit.hmpps.id
+}
+
+resource "aws_organizations_policy_attachment" "hmpps-electronic-monitoring-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
 }
 
 # YJB
@@ -72,10 +137,20 @@ resource "aws_organizations_organizational_unit" "yjb" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "yjb-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.yjb.id
+}
+
 # LAA
 resource "aws_organizations_organizational_unit" "laa" {
   name      = "LAA"
   parent_id = aws_organizations_organization.default.roots[0].id
+}
+
+resource "aws_organizations_policy_attachment" "laa-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.laa.id
 }
 
 resource "aws_organizations_policy_attachment" "laa" {
@@ -89,15 +164,30 @@ resource "aws_organizations_organizational_unit" "central-digital" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "central-digital-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.central-digital.id
+}
+
 # Platforms & Architecture
 resource "aws_organizations_organizational_unit" "platforms-and-architecture" {
   name      = "Platforms & Architecture"
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "platforms-and-architecture-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.platforms-and-architecture.id
+}
+
 resource "aws_organizations_organizational_unit" "platforms-and-architecture-cloud-platform" {
   name      = "Cloud Platform"
   parent_id = aws_organizations_organizational_unit.platforms-and-architecture.id
+}
+
+resource "aws_organizations_policy_attachment" "platforms-and-architecture-cloud-platform-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.platforms-and-architecture-cloud-platform.id
 }
 
 # There are more OUs within the Modernisation Platform, but they are managed elsewhere
@@ -107,10 +197,20 @@ resource "aws_organizations_organizational_unit" "platforms-and-architecture-mod
   parent_id = aws_organizations_organizational_unit.platforms-and-architecture.id
 }
 
+resource "aws_organizations_policy_attachment" "platforms-and-architecture-modernisation-platform-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform.id
+}
+
 # Security Engineering
 resource "aws_organizations_organizational_unit" "security-engineering" {
   name      = "Security Engineering"
   parent_id = aws_organizations_organization.default.roots[0].id
+}
+
+resource "aws_organizations_policy_attachment" "security-engineering-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.security-engineering.id
 }
 
 # Workplace Technology
@@ -119,10 +219,20 @@ resource "aws_organizations_organizational_unit" "workplace-technology" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "workplace-technology-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.workplace-technology.id
+}
+
 # Analytics Platform
 resource "aws_organizations_organizational_unit" "analytics-platform" {
   name      = "Analytics Platform"
   parent_id = aws_organizations_organization.default.roots[0].id
+}
+
+resource "aws_organizations_policy_attachment" "analytics-platform-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.analytics-platform.id
 }
 
 # Tactical Products
@@ -131,14 +241,29 @@ resource "aws_organizations_organizational_unit" "tactical-products" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "tactical-products-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.tactical-products.id
+}
+
 # CICA
 resource "aws_organizations_organizational_unit" "cica" {
   name      = "CICA"
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "cica-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.cica.id
+}
+
 # HMCTS
 resource "aws_organizations_organizational_unit" "hmcts" {
   name      = "HMCTS"
   parent_id = aws_organizations_organization.default.roots[0].id
+}
+
+resource "aws_organizations_policy_attachment" "hmcts-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.hmcts.id
 }


### PR DESCRIPTION
Brings clickops-created AWS Organizations OU policy attachments into Terraform.

Note: These have already been imported into the remote Terraform state.