### PR TITLE
Remove unused groups and their policy attachments

### DIFF
--- a/terraform/iam-groups.tf
+++ b/terraform/iam-groups.tf
@@ -9,17 +9,6 @@ resource "aws_iam_group_policy_attachment" "admins_administratoraccess" {
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
-# IAM group: Artifact
-resource "aws_iam_group" "artifacts" {
-  name = "Artifact"
-}
-
-# Attach custom policy to the Artifact group
-resource "aws_iam_group_policy_attachment" "artfiact_artifact_full_access" {
-  group      = aws_iam_group.artifacts.name
-  policy_arn = aws_iam_policy.artifact_full_access.arn
-}
-
 # IAM group: AWSOrganisationsAdmin
 resource "aws_iam_group" "aws_organisations_service_admins" {
   name = "AWSOrganisationsAdmin"
@@ -46,15 +35,4 @@ resource "aws_iam_group" "billing_full_access" {
 resource "aws_iam_group_policy_attachment" "billing_full_access_policy" {
   group      = aws_iam_group.billing_full_access.name
   policy_arn = aws_iam_policy.billing-full-access.arn
-}
-
-# IAM group: IAMReadOnlyGroup
-resource "aws_iam_group" "iam_read_only_group" {
-  name = "IAMReadOnlyGroup"
-}
-
-# Attach custom policy to the IAMReadOnlyGroup group
-resource "aws_iam_group_policy_attachment" "iam_read_only_group_policy" {
-  group      = aws_iam_group.iam_read_only_group.name
-  policy_arn = aws_iam_policy.iam-readonly-assume-role-policy.arn
 }

--- a/terraform/iam-policies.tf
+++ b/terraform/iam-policies.tf
@@ -1,29 +1,3 @@
-resource "aws_iam_policy" "artifact_full_access" {
-  name        = "Artifact_access_Full"
-  description = "Allow access to AWS Artifact"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "artifact:Get"
-            ],
-            "Resource": [
-                "arn:aws:artifact:::report-package/Certifications and Attestations/SOC/*",
-                "arn:aws:artifact:::report-package/Certifications and Attestations/PCI/*",
-                "arn:aws:artifact:::report-package/Certifications and Attestations/ISO/*",
-                "arn:aws:artifact:::report-package/Alignment Documents/Healthcare/*",
-                "arn:aws:artifact:::report-package/Certifications and Attestations/PSN/*"
-            ]
-        }
-    ]
-}
-EOF
-}
-
 resource "aws_iam_policy" "aws-readonly-billing-access-policy" {
   name        = "aws-readonly-billing-access-policy"
   description = "This policy provides readonly access to AWS Billing Service - Cost Explorer, Billing Data"
@@ -109,22 +83,6 @@ resource "aws_iam_policy" "billing-full-access" {
             ]
         }
     ]
-}
-EOF
-}
-
-resource "aws_iam_policy" "iam-readonly-assume-role-policy" {
-  name        = "IAMReadOnlyAssumeRolePolicy"
-  description = "A policy that allows IAM Read Only access to Target Account Resources"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": {
-        "Action": "sts:AssumeRole",
-        "Resource": "arn:aws:iam::*:role/IAMReadOnlyAccessRole",
-        "Effect": "Allow"
-    }
 }
 EOF
 }


### PR DESCRIPTION
Removes the unused `Artifact` and `IAMReadOnlyGroup` and their attachments and self-defined policies.