### PR TITLE
Add eu-west-1 provider & bring S3 buckets into Terraform management

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,6 +8,13 @@ terraform {
   }
 }
 
+# Default provider, as everything should be in eu-west-2 by default
 provider "aws" {
   region = "eu-west-2"
+}
+
+# eu-west-1 provider, for anything that needs to be in eu-west-2
+provider "aws" {
+  alias  = "aws-root-account-eu-west-1"
+  region = "eu-west-1"
 }

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,3 +1,5 @@
+# S3 buckets in eu-west-2
+## S3 bucket to store Terraform state
 resource "aws_s3_bucket" "aws-root-account-terraform-state" {
   bucket = "moj-aws-root-account-terraform-state"
   acl    = "private"
@@ -21,4 +23,41 @@ resource "aws_s3_bucket_public_access_block" "aws-root-account-terraform-state" 
   bucket              = aws_s3_bucket.aws-root-account-terraform-state.id
   block_public_acls   = true
   block_public_policy = true
+}
+
+## S3 bucket for moj-cur-reports
+resource "aws_s3_bucket" "moj-cur-reports" {
+  bucket = "moj-cur-reports"
+  acl    = "private"
+}
+
+# S3 buckets in Ireland
+## S3 bucket for moj-iam-credential-reports
+resource "aws_s3_bucket" "moj-iam-credential-reports" {
+  provider = aws.aws-root-account-eu-west-1
+  bucket   = "moj-iam-credential-reports"
+  acl      = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+}
+
+## S3 bucket for cf-templates-rkovlae8ktmg-eu-west-1
+resource "aws_s3_bucket" "cf-templates-rkovlae8ktmg-eu-west-1" {
+  provider = aws.aws-root-account-eu-west-1
+  bucket   = "cf-templates-rkovlae8ktmg-eu-west-1"
+  acl      = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Brings clickops-created S3 buckets into Terraform, including buckets in eu-west-1.

Note: These have already been imported into the remote Terraform state.