### PR TITLE
Enable trusted access for Trusted Advisor organisational view

### DIFF
--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -1,5 +1,6 @@
 resource "aws_organizations_organization" "default" {
   aws_service_access_principals = [
+    "reporting.trustedadvisor.amazonaws.com",
     "sso.amazonaws.com"
   ]
   enabled_policy_types = [


### PR DESCRIPTION
This enables trusted access for Trusted Advisor organisational view across all accounts.

See [AWS Trusted Advisor and AWS Organisations](https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-ta.html) for more information.