### PR TITLE
Terraform 0.14: include lockfile, set minimum version

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,71 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/alexkappa/auth0" {
+  version = "0.16.1"
+  hashes = [
+    "h1:Yuan3uU/eISWfu9f7JMG8WackUOMnrrh3LFywdxqMek=",
+    "zh:173017f420275c617881602a35fda7beb6e097d6d32fbdbb035046b4a90a4136",
+    "zh:2422e7e41fea5e9578e9fd5c71376ab48328141b90ffd7e2c0823d581b309563",
+    "zh:433c7cac260c7882d4f889d097907ea779fb7d890366109ca9c3d18ad056aac9",
+    "zh:4368896d4515a9e07c06d5ec761a2153be9a7b4f0dc2228414dd1d10a95d40a3",
+    "zh:4dcf47b68d30412ace73ba3e51c8a6cc93606426e65872c5d94d7f8d6a12efe5",
+    "zh:5666872e5bf24f5bb8a6e34fe1f76f32bf57ae042ae1d6988781f406145cb494",
+    "zh:85ddd1c107bfcdc54fbe5812f93961345a47b36ebf8a0588f507100e86389a8e",
+    "zh:a53c2db134e3bbf07762673f183527a9954ee9b0456435a36d5461f498cce314",
+    "zh:ae490c036433874fc7b447a414c172a4ad27a1bbcbb5a320e37dd359d3e3f73a",
+    "zh:cf9a19a3d36d159b624f47869ad8d7abc225f4e619121c5917c62dcfb9834ebf",
+    "zh:d6d09902c8de5480d3ecc4cf3a29ac4bb36975ab93b21a5d96ca0ab95a3d99d8",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.0.0"
+  hashes = [
+    "h1:eOUi4EO4QTgPuz+gmD8xy2LTTxNfyc9txyc9PDARth8=",
+    "zh:1c3300a6686481ed0b3ce456949805b5c55f901b77108543046f12118a102914",
+    "zh:2d44bcc8a5ea3f2c2ff54ca4c4b273cdc3500ad8bb6929eec6722bb9d10a9714",
+    "zh:4be17c4e06a74ca30a3c9e88446e453ad16c493b2ddef872a6580dbfe618a1b4",
+    "zh:50c216a6c672b51d67ece37ce69c121acbcd5c8d24b899e876c61bc09989f69f",
+    "zh:90d6ad51fecab8d2f086aab9ed45020f1a9d3627dbc95edda11af8e3f87082d9",
+    "zh:d147427135330b4940a85a0f552e2c1f83a0d1ccdcc82c36a2d311b7f85dbd38",
+    "zh:dd4b8c0b113e37fd83ceab0f8a203ccfa39caaca5551c70a94fa61e900902932",
+    "zh:e30ef64a2ed0c2a6e8d1e29b8da8b05b4a303e256478a4b410af81c81cbcbc23",
+    "zh:e5a81379810d3e1f380b7145d0ecee4a69ab4e80184f77b66cd4411b86aca6a8",
+    "zh:f9a0a2a72721e7e047e83053173b3a68a7d53e2a22719cc2d9234dbee46c466c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "3.20.0"
+  hashes = [
+    "h1:Wk7JYiEIslHQorVPWnofRNYUAjyro6IehY/d/Yfmbr8=",
+    "zh:1b53d410c21332750be561092d412d83014fa0656e00f940944d2e7b07b1b9ec",
+    "zh:307bf780790462fe547fe23f8e38a4c178437f3a9dd725f9aa63c6d8c6cbf25d",
+    "zh:5818a978b9766b23a190716b85aad3a4731d33ddb8a81080cf3ef6e4bd68a003",
+    "zh:5f68eb4779208e21d9657b9ff492aa5f6496efea7994bdec1d302f88b0b65f34",
+    "zh:6028208a7b3738801cd9f3376efa40a1e55f4bb8184584f7387b08c054e43c4c",
+    "zh:8130269e2d8c80ea9136dcd26cfeb4e1fac83bda4aab0db70f36651a7b22365d",
+    "zh:9dd4a07beb89606e051b64ab05d75e1c1616389871a55065676b370aebaed8e5",
+    "zh:b7194500db431ba862ea8008db56a5decececda1f904ed8842d2b0f1a04eea9d",
+    "zh:ec214b7341137e6dd47754b843ed16fe3e1d32832537042ee81a64a3ccdbb4bd",
+    "zh:ec2973e04f3cb853895e51f6ec56660574610b860ee3de669ccbb1f04d1089c9",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.0.0"
+  hashes = [
+    "h1:6S7hqjmUnoAZ5D/0F1VlJZKSJsUIBh7Ro0tLjGpKO0g=",
+    "zh:07949780dd6a1d43e7b46950f6e6976581d9724102cb5388d3411a1b6f476bde",
+    "zh:0a4f4636ff93f0644affa8474465dd8c9252946437ad025b28fc9f6603534a24",
+    "zh:0dd7e05a974c649950d1a21d7015d3753324ae52ebdd1744b144bc409ca4b3e8",
+    "zh:2b881032b9aa9d227ac712f614056d050bcdcc67df0dc79e2b2cb76a197059ad",
+    "zh:38feb4787b4570335459ca75a55389df1a7570bdca8cdf5df4c2876afe3c14b4",
+    "zh:40f7e0aaef3b1f4c2ca2bb1189e3fe9af8c296da129423986d1d99ccc8cfb86c",
+    "zh:56b361f64f0f0df5c4f958ae2f0e6f8ba192f35b720b9d3ae1be068fabcf73d9",
+    "zh:5fadb5880cd31c2105f635ded92b9b16f918c1dd989627a4ce62c04939223909",
+    "zh:61fa0be9c14c8c4109cfb7be8d54a80c56d35dbae49d3231cddb59831e7e5a4d",
+    "zh:853774bf97fbc4a784d5af5a4ca0090848430781ae6cfc586adeb48f7c44af79",
+  ]
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14.2"
   required_providers {
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
Includes the new HCL lockfile for Terraform 0.14 and sets the minimum version to 0.14.2.