### PR TITLE
Enable AWS Compute Optimizer for the organisation

### DIFF
--- a/terraform/iam-roles.tf
+++ b/terraform/iam-roles.tf
@@ -1,4 +1,8 @@
 # Service-linked roles
+resource "aws_iam_service_linked_role" "compute-optimizer" {
+  aws_service_name = "compute-optimizer.amazonaws.com"
+}
+
 resource "aws_iam_service_linked_role" "organizations" {
   aws_service_name = "organizations.amazonaws.com"
   description      = "Service-linked role used by AWS Organizations to enable integration of other AWS services with Organizations."

--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -1,5 +1,6 @@
 resource "aws_organizations_organization" "default" {
   aws_service_access_principals = [
+    "compute-optimizer.amazonaws.com",
     "reporting.trustedadvisor.amazonaws.com",
     "sso.amazonaws.com"
   ]


### PR DESCRIPTION
Creates the service-linked role for AWS Compute Optimizer and the service access policy for the prinicpal `compute-optimizer.amazonaws.com` to enable AWS Compute Optimizer across the organisation.