### PR TITLE
Enable Resource Access Manager for the organisation

### DIFF
--- a/terraform/iam-roles.tf
+++ b/terraform/iam-roles.tf
@@ -4,6 +4,10 @@ resource "aws_iam_service_linked_role" "organizations" {
   description      = "Service-linked role used by AWS Organizations to enable integration of other AWS services with Organizations."
 }
 
+resource "aws_iam_service_linked_role" "resource-access-manager" {
+  aws_service_name = "ram.amazonaws.com"
+}
+
 resource "aws_iam_service_linked_role" "securityhub" {
   aws_service_name = "securityhub.amazonaws.com"
   description      = "A service-linked role required for AWS Security Hub to access your resources."

--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -1,5 +1,6 @@
 resource "aws_organizations_organization" "default" {
   aws_service_access_principals = [
+    "ram.amazonaws.com",
     "reporting.trustedadvisor.amazonaws.com",
     "sso.amazonaws.com"
   ]


### PR DESCRIPTION
Creates the service-linked role for AWS Resource Access Manager and the service access policy for the prinicpal `ram.amazonaws.`com to enable AWS Resource Access Manager across the organisation.