### PR TITLE
Update SCP for LAA to use a data block

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -7,5 +7,6 @@ locals {
     is-production = true
     owner         = "Hosting Leads: hosting-leads@digital.justice.gov.uk"
   }
-  caller_identity = data.aws_caller_identity.current
+  caller_identity   = data.aws_caller_identity.current
+  github_repository = "github.com/ministryofjustice/aws-root-account/blob/main/terraform"
 }

--- a/terraform/organizations-accounts.tf
+++ b/terraform/organizations-accounts.tf
@@ -3,10 +3,6 @@
 # rather than rely on this in the future.
 data "aws_organizations_organization" "root" {}
 
-# output "account_ids" {
-#   value = local.account_emails
-# }
-
 locals {
   account_emails = {
     for account in data.aws_organizations_organization.root.accounts :

--- a/terraform/organizations-policies.tf
+++ b/terraform/organizations-policies.tf
@@ -1,32 +1,38 @@
-# Note that every AWS account in an AWS organisation _must_ have at least one SCP set.
-
-# This policy is the default set by AWS for every account in an AWS organisation.
-# There is a default policy titled "FullAWSAccess" that you can't edit.
+# Note that every AWS account in an AWS organisation must have at least one SCP set.
+# By default this is the FullAWSAccess policy, that can't be edited, so is not
+# included in this Terraform.
 # See: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_examples.html
 
+# Before changing policies, please read how Organizations policy inheritance works.
+# See: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_inheritance.html
+
 # DenyCloudTrailDeleteStopUpdatePolicy
+# Organization policies aren't actually IAM policies, but we can use the
+# Terraform aws_iam_policy_document data block to create the correct JSON,
+# with the correct formatting.
+data "aws_iam_policy_document" "deny-cloudtrail-delete-stop-update-policy" {
+  version = "2012-10-17"
+  statement {
+    effect = "Deny"
+    actions = [
+      "cloudtrail:DeleteTrail",
+      "cloudtrail:StopLogging",
+      "cloudtrail:UpdateTrail"
+    ]
+    resources = ["*"]
+  }
+}
+
 resource "aws_organizations_policy" "deny-cloudtrail-delete-stop-update-policy" {
   name        = "DenyCloudTrailDeleteStopUpdatePolicy"
   description = "Denies changes to CloudTrail"
   type        = "SERVICE_CONTROL_POLICY"
+  content     = data.aws_iam_policy_document.deny-cloudtrail-delete-stop-update-policy.json
 
-  content = <<CONTENT
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "Stmt1526482768000",
-      "Effect": "Deny",
-      "Action": [
-        "cloudtrail:DeleteTrail",
-        "cloudtrail:StopLogging",
-        "cloudtrail:UpdateTrail"
-      ],
-      "Resource": [
-        "*"
-      ]
-    }
-  ]
-}
-CONTENT
+  # This policy is currently used by LAA.
+  tags = {
+    business-unit = "LAA"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "organizations-policies.tf"])
+  }
 }


### PR DESCRIPTION
Updates the SCP for LAA to use a data block, which formats policies for us.