### PR TITLE
Add OU and accounts for Organisation Management

### DIFF
--- a/terraform/organizations-accounts-organisation-management.tf
+++ b/terraform/organizations-accounts-organisation-management.tf
@@ -1,0 +1,64 @@
+locals {
+  tags-organisation-management = {
+    business-unit = "Platforms"
+    application   = "Organisation Management"
+  }
+}
+
+# Organisation logging account
+resource "aws_organizations_account" "organisation-logging" {
+  name      = "organisation-logging"
+  email     = replace(local.aws_account_email_addresses_template, "{email}", "organisation-logging")
+  parent_id = aws_organizations_organizational_unit.organisation-management.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+
+  tags = merge(
+    local.tags-organisation-management, {
+      component = "Logging"
+    }
+  )
+}
+
+resource "aws_organizations_policy_attachment" "organisation-logging" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.organisation-logging.id
+}
+
+# Organisation security account
+resource "aws_organizations_account" "organisation-security" {
+  name      = "organisation-security"
+  email     = replace(local.aws_account_email_addresses_template, "{email}", "organisation-security")
+  parent_id = aws_organizations_organizational_unit.organisation-management.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+
+  tags = merge(
+    local.tags-organisation-management, {
+      component = "Security"
+    }
+  )
+}
+
+resource "aws_organizations_policy_attachment" "organisation-security" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.organisation-security.id
+}

--- a/terraform/organizations-organizational-units.tf
+++ b/terraform/organizations-organizational-units.tf
@@ -1,3 +1,14 @@
+# Organisation Management accounts
+resource "aws_organizations_organizational_unit" "organisation-management" {
+  name      = "Organisation Management"
+  parent_id = aws_organizations_organization.default.roots[0].id
+}
+
+resource "aws_organizations_policy_attachment" "organisation-management-ou-full-access" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_organizational_unit.organisation-management.id
+}
+
 # Closed accounts
 resource "aws_organizations_organizational_unit" "closed-accounts" {
   name      = "Closed accounts"

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -34,7 +34,7 @@ data "aws_secretsmanager_secret_version" "aws_saml" {
 # Email addresses for AWS accounts.
 # There is a manually added "template" key for templating email addresses for new accounts configured in this account,
 # so you can do:
-# `email = replace(local.aws_account_email_addresses_template, "$${email}", "account-name")`
+# `email = replace(local.aws_account_email_addresses_template, "{email}", "account-name")`
 # Accounts that were configured before this can use:
 # `email = local.aws_account_email_addresses["account-name"][0]`
 resource "aws_secretsmanager_secret" "aws_account_email_addresses" {


### PR DESCRIPTION
This creates a new OU, called Organisation Management. It creates two accounts within, `organisation-logging`, and `organisation-security` for delegated administratorship of AWS security services.