### PR TITLE
Remove policy that is automatically enabled by AWS

### DIFF
--- a/terraform/organizations-accounts-organisation-management.tf
+++ b/terraform/organizations-accounts-organisation-management.tf
@@ -29,11 +29,6 @@ resource "aws_organizations_account" "organisation-logging" {
   )
 }
 
-resource "aws_organizations_policy_attachment" "organisation-logging" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_account.organisation-logging.id
-}
-
 # Organisation security account
 resource "aws_organizations_account" "organisation-security" {
   name      = "organisation-security"
@@ -56,9 +51,4 @@ resource "aws_organizations_account" "organisation-security" {
       component = "Security"
     }
   )
-}
-
-resource "aws_organizations_policy_attachment" "organisation-security" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_account.organisation-security.id
 }


### PR DESCRIPTION
AWS automatically adds these policies to the accounts when created, so we don't need to create them/attach them ourselves.