### PR TITLE
Revert "Remove policy that is automatically enabled by AWS"

### DIFF
--- a/terraform/organizations-accounts-organisation-management.tf
+++ b/terraform/organizations-accounts-organisation-management.tf
@@ -29,6 +29,11 @@ resource "aws_organizations_account" "organisation-logging" {
   )
 }
 
+resource "aws_organizations_policy_attachment" "organisation-logging" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.organisation-logging.id
+}
+
 # Organisation security account
 resource "aws_organizations_account" "organisation-security" {
   name      = "organisation-security"
@@ -51,4 +56,9 @@ resource "aws_organizations_account" "organisation-security" {
       component = "Security"
     }
   )
+}
+
+resource "aws_organizations_policy_attachment" "organisation-security" {
+  policy_id = "p-FullAWSAccess"
+  target_id = aws_organizations_account.organisation-security.id
 }

--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -18,3 +18,8 @@ resource "aws_organizations_policy_attachment" "default" {
   policy_id = "p-FullAWSAccess"
   target_id = aws_organizations_organization.default.roots[0].id
 }
+
+# If you're going to create a new account using this Terraform,
+# note that you'll have to import any aws_organizations_policy_attachment resources manually as
+# Terraform will fail to create them (as AWS attaches them on your behalf).
+# When it does fail, import it into Terraform, so we can explicitly track what policies accounts have.


### PR DESCRIPTION
Reverts ministryofjustice/aws-root-account#78

Reverts as per @SteveMarshall comment on #78. We'll import these so it's explicit, and add a note for anyone who would create an account in this way.