### PR TITLE
Enable GuardDuty for eu-west-2 and add a delegated administrator

### DIFF
--- a/terraform/guardduty.tf
+++ b/terraform/guardduty.tf
@@ -1,0 +1,10 @@
+# Enable GuardDuty for the calling region
+resource "aws_guardduty_detector" "default-region" {
+  enable = true
+}
+
+# Delegate administratorship of GuardDuty to the organisation-security account
+resource "aws_guardduty_organization_admin_account" "default-region-administrator" {
+  depends_on       = [aws_organizations_organization.default]
+  admin_account_id = aws_organizations_account.organisation-security.id
+}

--- a/terraform/iam-roles.tf
+++ b/terraform/iam-roles.tf
@@ -3,6 +3,10 @@ resource "aws_iam_service_linked_role" "compute-optimizer" {
   aws_service_name = "compute-optimizer.amazonaws.com"
 }
 
+resource "aws_iam_service_linked_role" "guardduty" {
+  aws_service_name = "guardduty.amazonaws.com"
+}
+
 resource "aws_iam_service_linked_role" "organizations" {
   aws_service_name = "organizations.amazonaws.com"
   description      = "Service-linked role used by AWS Organizations to enable integration of other AWS services with Organizations."

--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -1,6 +1,7 @@
 resource "aws_organizations_organization" "default" {
   aws_service_access_principals = [
     "compute-optimizer.amazonaws.com",
+    "guardduty.amazonaws.com",
     "ram.amazonaws.com",
     "reporting.trustedadvisor.amazonaws.com",
     "sso.amazonaws.com",


### PR DESCRIPTION
Enables GuardDuty at an organisational level, and for `eu-west-2`, to test delegated administratorship of the service with @TomTucka.

The [documentation specifies](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html) that current organisation accounts need to be added _manually_ (and enabled manually) so this _shouldn't_ affect accounts within the organisation just yet.