### PR TITLE
Update organisation-security tags for GuardDuty

### DIFF
--- a/terraform/guardduty-publishing-destination.tf
+++ b/terraform/guardduty-publishing-destination.tf
@@ -124,7 +124,11 @@ resource "aws_s3_bucket" "guardduty-bucket" {
     enabled = true
   }
 
-  tags = local.root_account
+  tags = merge(
+    local.tags-organisation-management, {
+      component = "Security"
+    }
+  )
 }
 
 resource "aws_s3_bucket_policy" "guardduty-bucket-policy" {
@@ -181,5 +185,9 @@ resource "aws_kms_key" "guardduty" {
   enable_key_rotation     = true
   policy                  = data.aws_iam_policy_document.guardduty-kms-key-policy.json
 
-  tags = local.root_account
+  tags = merge(
+    local.tags-organisation-management, {
+      component = "Security"
+    }
+  )
 }

--- a/terraform/organizations-accounts-organisation-management.tf
+++ b/terraform/organizations-accounts-organisation-management.tf
@@ -1,7 +1,11 @@
 locals {
   tags-organisation-management = {
-    business-unit = "Platforms"
-    application   = "Organisation Management"
+    application            = "Organisation Management"
+    business-unit          = "Platforms"
+    infrastructure-support = "Hosting Leads: hosting-leads@digital.justice.gov.uk"
+    is-production          = true
+    owner                  = "Hosting Leads: hosting-leads@digital.justice.gov.uk"
+    source-code            = "github.com/ministryofjustice/aws-root-account"
   }
 }
 


### PR DESCRIPTION
Correctly tag the GuardDuty bucket and KMS key