### PR TITLE
Enrol Security Operations Development into AWS GuardDuty

### DIFF
--- a/terraform/guardduty.tf
+++ b/terraform/guardduty.tf
@@ -26,7 +26,8 @@ locals {
     aws_organizations_account.moj-opg-shared-development,
     aws_organizations_account.moj-opg-shared-production,
     aws_organizations_account.opg-shared,
-    aws_organizations_account.organisation-logging
+    aws_organizations_account.organisation-logging,
+    aws_organizations_account.security-operations-development
   ], local.modernisation-platform-managed-account-ids)
 }
 


### PR DESCRIPTION
Enrols the Security Operations Development account into AWS GuardDuty.