### PR TITLE
Enrol Cloud Platform Ephemeral Test and Cloud Platform TGW accounts to GuardDuty

### DIFF
--- a/terraform/guardduty.tf
+++ b/terraform/guardduty.tf
@@ -13,6 +13,8 @@
 locals {
   enrolled_into_guardduty = concat([
     { id = local.caller_identity.account_id, name = "MoJ root account" },
+    aws_organizations_account.cloud-platform-ephemeral-test,
+    aws_organizations_account.cloud-platform-transit-gateways,
     aws_organizations_account.modernisation-platform,
     aws_organizations_account.moj-official-development,
     aws_organizations_account.moj-official-pre-production,


### PR DESCRIPTION
Enrols Cloud Platform Ephemeral Test and Cloud Platform TGW accounts into centrally managed GuardDuty.