### PR TITLE
Enrol Modernisation Platform OU into tag policy compliance reporting

### DIFF
--- a/terraform/organizations-organizational-units.tf
+++ b/terraform/organizations-organizational-units.tf
@@ -219,6 +219,18 @@ resource "aws_organizations_policy_attachment" "platforms-and-architecture-moder
   target_id = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform.id
 }
 
+# Enrol all accounts within the Modernisation Platform OU (current and future) to tag policies
+# Note that when you attach a tag policy, it can take 48 hours to evaluate compliance.
+resource "aws_organizations_policy_attachment" "modernisation-platform-mandatory-tags-policy" {
+  policy_id = aws_organizations_policy.mandatory-tags.id
+  target_id = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform.id
+}
+
+resource "aws_organizations_policy_attachment" "modernisation-platform-optional-tags-policy" {
+  policy_id = aws_organizations_policy.optional-tags.id
+  target_id = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform.id
+}
+
 # Security Engineering
 resource "aws_organizations_organizational_unit" "security-engineering" {
   name      = "Security Engineering"

--- a/terraform/organizations-tag-policies.tf
+++ b/terraform/organizations-tag-policies.tf
@@ -95,15 +95,3 @@ resource "aws_organizations_policy" "optional-tags" {
 }
 CONTENT
 }
-
-# We can test the tag policies on the Modernisation Platform account
-# Note that when you attach a tag policy, it can take 48 hours to evaluate compliance.
-resource "aws_organizations_policy_attachment" "modernisation-platform-mandatory-tags-policy" {
-  policy_id = aws_organizations_policy.mandatory-tags.id
-  target_id = aws_organizations_account.modernisation-platform.id
-}
-
-resource "aws_organizations_policy_attachment" "modernisation-platform-optional-tags-policy" {
-  policy_id = aws_organizations_policy.optional-tags.id
-  target_id = aws_organizations_account.modernisation-platform.id
-}


### PR DESCRIPTION
This enrols all accounts within the Modernisation Platform OU into the Organizational Tag Policy, which generates a compliancy report for tagged resources.

Note that when you attach a tag policy, it can take 48 hours to evaluate compliance.