### PR TITLE
Bring managed policy attachments for AWS SSO Permission Sets into Terraform management

### DIFF
--- a/terraform/sso-admin-permission-sets.tf
+++ b/terraform/sso-admin-permission-sets.tf
@@ -1,8 +1,21 @@
+# Note that permission sets are akin to IAM roles and attachments are IAM policies
+# to provide privileged access to assigned AWS accounts.
+
+###########################
+# Generic permission sets #
+###########################
+
 # AdministratorAccess
 resource "aws_ssoadmin_permission_set" "administrator-access" {
   name             = "AdministratorAccess"
   instance_arn     = local.sso_instance_arn
   session_duration = "PT1H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "administrator-access-policy" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.administrator-access.arn
 }
 
 # ViewOnlyAccess
@@ -12,11 +25,23 @@ resource "aws_ssoadmin_permission_set" "view-only-access" {
   session_duration = "PT1H"
 }
 
+resource "aws_ssoadmin_managed_policy_attachment" "view-only-access-policy" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.view-only-access.arn
+}
+
 # SecurityAudit
 resource "aws_ssoadmin_permission_set" "security-audit" {
   name             = "SecurityAudit"
   instance_arn     = local.sso_instance_arn
   session_duration = "PT1H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "security-audit-policy" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+  permission_set_arn = aws_ssoadmin_permission_set.security-audit.arn
 }
 
 # AWSSSOReadOnly
@@ -27,11 +52,23 @@ resource "aws_ssoadmin_permission_set" "aws-sso-readonly" {
   session_duration = "PT1H"
 }
 
+resource "aws_ssoadmin_managed_policy_attachment" "aws-sso-readonly-policy" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AWSSSOReadOnly"
+  permission_set_arn = aws_ssoadmin_permission_set.aws-sso-readonly.arn
+}
+
 # DashboardAccess
 resource "aws_ssoadmin_permission_set" "dashboard-access" {
   name             = "DashboardAccess"
   instance_arn     = local.sso_instance_arn
   session_duration = "PT1H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "dashboard-access-policy" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.dashboard-access.arn
 }
 
 ################################
@@ -46,6 +83,30 @@ resource "aws_ssoadmin_permission_set" "opg-security-audit" {
   session_duration = "PT1H"
 }
 
+resource "aws_ssoadmin_managed_policy_attachment" "opg-security-audit-policy-guardduty" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AmazonGuardDutyReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.opg-security-audit.arn
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "opg-security-audit-policy-security" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+  permission_set_arn = aws_ssoadmin_permission_set.opg-security-audit.arn
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "opg-security-audit-policy-security-hub" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AWSSecurityHubReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.opg-security-audit.arn
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "opg-security-audit-policy-cloudtrail" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.opg-security-audit.arn
+}
+
 # opg-viewer
 resource "aws_ssoadmin_permission_set" "opg-viewer" {
   name             = "opg-viewer"
@@ -54,10 +115,22 @@ resource "aws_ssoadmin_permission_set" "opg-viewer" {
   session_duration = "PT2H"
 }
 
+resource "aws_ssoadmin_managed_policy_attachment" "opg-viewer-policy" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.opg-viewer.arn
+}
+
 # opg-breakglass
 resource "aws_ssoadmin_permission_set" "opg-breakglass" {
   name             = "opg-breakglass"
   description      = "Breakglass role given to the webops engineers at OPG incase of emergencies"
   instance_arn     = local.sso_instance_arn
   session_duration = "PT1H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "opg-breakglass-policy" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.opg-breakglass.arn
 }


### PR DESCRIPTION
This brings attached policies for AWS SSO Permission Sets into Terraform management.

>NB: These have already been imported into Terraform.