### PR TITLE
Bring AWS SSO account assignments for OPG into Terraform management

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -37,20 +37,20 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.23.0"
-  constraints = ">= 3.23.0"
+  version     = "3.25.0"
+  constraints = ">= 3.24.0"
   hashes = [
-    "h1:tSznQxPJvolDnmqqaTK9SsJ0bluTws7OAWcnc1t0ABs=",
-    "zh:30b0733027c00472618da998bc77967c692e238ae117c07e046fdd7336b83fa3",
-    "zh:3677550a8bef8e01c67cb615407dc8a69d32f4e36017033cd6f71a831c99d5de",
-    "zh:3c2fb4c14bfd43cf20ee25d0068ce09f1d48758408b8f1c88a096cea243612b3",
-    "zh:5577543322003693c4fe24a69ed0d47e58f867426fd704fac94cf5c16d3d6153",
-    "zh:6771f09d76ad01ffc04baa3bce7a3eed09f6a8a949274ffbd9d11756a58a4329",
-    "zh:7a57b79d304d17cf52ee3ddce91679f6b4289c5bdda2e31b763bf7d512e542d9",
-    "zh:815fb027e17bfe754b05367d20bd0694726a95a99b81e8d939ddd44e2b1f05a9",
-    "zh:a3d67db5ec0f4e9750eb19676a9a1aff36b0721e276a4ba789f42b991bf5951c",
-    "zh:cd67ff33860ad578172c19412ce608ba818e7590083197df2b793f870d6f50a3",
-    "zh:fbe0835055d1260fb77ad19a32a8726248ba7ac187f6c463ded90737b4cea8e6",
+    "h1:oyaXLqVhtPnHDnwk2yU9qP4dTgfPHyuo27mX/ljeCTQ=",
+    "zh:2d3c65461bc63ec39bce7b5afdbed9a3b4dd5c2c8ee94616ad1866e24cf9b8f0",
+    "zh:2fb2ea6ccac30b909b603e183433737a30c58ec1f9a6a8b5565f0f051490c07a",
+    "zh:31a5f192c8cf29fb677cd639824f9a685578a2564c6b790517db33ea56229045",
+    "zh:437a12cf9a4d7bc92c9bf14ee7e224d5d3545cbd2154ba113ae82c4bb68edc27",
+    "zh:4bbdc3155a5dea90b2d50adfa460b0759c4dd959efaf7f66b2a0385a53b469b2",
+    "zh:63a8cd523ba31358692a34a06e111d88769576ac6d0e5adad8e0b4ae0a2d8882",
+    "zh:c4301ce86e8cb2c464949bb99e729ffe7b0c55eaf34b82ba526bb5039bca36f3",
+    "zh:c97b84861c6c550b8d2feb12d089660fffbf51dc7d660dcc9d54d4a7b3c2c882",
+    "zh:d6a103570e2d5c387b068fac4b88654dfa21d44ca1bdfa4bc8ab94c88effd71a",
+    "zh:f08cf2faf960a8ca374ac860f37c31c88ed2bab460116ac74678e0591babaac5",
   ]
 }
 

--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -1,0 +1,82 @@
+locals {
+  teams_to_account_assignments = [
+    {
+      github_team    = "opg"
+      permission_set = aws_ssoadmin_permission_set.opg-viewer,
+      accounts = [
+        aws_organizations_account.moj-opg-identity,
+        aws_organizations_account.moj-opg-shared-production,
+        aws_organizations_account.moj-opg-management,
+        aws_organizations_account.moj-opg-shared-development,
+        aws_organizations_account.moj-opg-sandbox
+      ]
+    },
+    {
+      github_team    = "opg-secops",
+      permission_set = aws_ssoadmin_permission_set.opg-security-audit,
+      accounts = [
+        aws_organizations_account.moj-lpa-development,
+        aws_organizations_account.moj-lpa-preproduction,
+        aws_organizations_account.moj-opg-digicop-development,
+        aws_organizations_account.moj-opg-digicop-preproduction,
+        aws_organizations_account.moj-opg-digicop-production,
+        aws_organizations_account.moj-opg-identity,
+        aws_organizations_account.moj-opg-lpa-production,
+        aws_organizations_account.moj-opg-lpa-refunds-development,
+        aws_organizations_account.moj-opg-lpa-refunds-preproduction,
+        aws_organizations_account.moj-opg-lpa-refunds-production,
+        aws_organizations_account.moj-opg-management,
+        aws_organizations_account.moj-opg-sandbox,
+        aws_organizations_account.moj-opg-shared-development,
+        aws_organizations_account.moj-opg-shared-production,
+        aws_organizations_account.moj-opg-sirius-development,
+        aws_organizations_account.moj-opg-sirius-preproduction,
+        aws_organizations_account.moj-opg-sirius-production,
+        aws_organizations_account.opg-backups,
+        aws_organizations_account.opg-digi-deps-dev,
+        aws_organizations_account.opg-digi-deps-preprod,
+        aws_organizations_account.opg-digi-deps-prod,
+        aws_organizations_account.opg-lpa-production,
+        aws_organizations_account.opg-refund-develop,
+        aws_organizations_account.opg-refund-production,
+        aws_organizations_account.opg-sirius-backup,
+        aws_organizations_account.opg-sirius-dev,
+        aws_organizations_account.opg-sirius-production,
+        aws_organizations_account.opg-use-my-lpa-development,
+        aws_organizations_account.opg-use-my-lpa-preproduction,
+        aws_organizations_account.opg-use-my-lpa-production
+      ]
+    }
+  ]
+  teams_to_account_assignments_association_list = flatten([
+    for assignment in local.teams_to_account_assignments : [
+      for account in assignment.accounts : {
+        account        = account
+        github_team    = assignment["github_team"]
+        permission_set = assignment["permission_set"]
+      }
+    ]
+  ])
+  teams_to_account_assignments_with_keys = {
+    for item in local.teams_to_account_assignments_association_list :
+    "${item.account.name}-${item.github_team}-${item.permission_set.name}" => item
+  }
+}
+
+resource "aws_ssoadmin_account_assignment" "account-assignments" {
+  for_each = tomap(local.teams_to_account_assignments_with_keys)
+
+  # Instance
+  instance_arn = local.sso_instance_arn
+
+  # Permission set to give
+  permission_set_arn = each.value.permission_set.arn
+
+  # GitHub team to give the permission set to
+  principal_id   = data.aws_identitystore_group.groups[each.value.github_team].group_id
+  principal_type = "GROUP"
+
+  # Account ID to give the group permission to access
+  target_id   = each.value.account.id
+  target_type = "AWS_ACCOUNT"
+}

--- a/terraform/sso-admin.tf
+++ b/terraform/sso-admin.tf
@@ -3,5 +3,6 @@
 data "aws_ssoadmin_instances" "default" {}
 
 locals {
-  sso_instance_arn = coalesce(data.aws_ssoadmin_instances.default.arns...)
+  sso_instance_arn      = coalesce(data.aws_ssoadmin_instances.default.arns...)
+  sso_identity_store_id = coalesce(data.aws_ssoadmin_instances.default.identity_store_ids...)
 }

--- a/terraform/sso-identity-store-groups.tf
+++ b/terraform/sso-identity-store-groups.tf
@@ -1,0 +1,16 @@
+# This uses the local.groups_to_account_assignments keys, and looks up all of the groups
+# defined there (see: sso-admin-account-assignment.tf)
+
+data "aws_identitystore_group" "groups" {
+  for_each = toset([
+    for assignment in local.teams_to_account_assignments_with_keys :
+    assignment.github_team
+  ])
+
+  identity_store_id = local.sso_identity_store_id
+
+  filter {
+    attribute_path  = "DisplayName"
+    attribute_value = each.value
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.14.2"
+  required_version = ">= 0.14.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.23.0"
+      version = ">= 3.24.0"
     }
   }
 }


### PR DESCRIPTION
This PR:

- sets the minimum version of the Terraform AWS provider to 3.24.0, which includes the [AWS SSO account assignment](https://github.com/hashicorp/terraform-provider-aws/blob/master/CHANGELOG.md#3240-january-14-2021) resource
- brings the account assignments for the permission sets "opg-security-audit" and "opg-viewer" into Terraform management for the GitHub teams `opg` and `opg-secops`