### PR TITLE
Update alexkappa/auth0 to 0.19.0 and hashicorp/aws to 3.27.0

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -2,20 +2,20 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/alexkappa/auth0" {
-  version = "0.17.2"
+  version = "0.19.0"
   hashes = [
-    "h1:fczvIzd1nmRETP0Ogk8XJ8cNmCQ9wHCUkh/s2Mf/jfI=",
-    "zh:1586417f3f0f32cab7b952970e009b28845391e6fb79a867c908f2326289e667",
-    "zh:23e4ddbf39fa5de0ed741ab2d9ff4d43bc2af5aa1199c27732ed60e78c54e1b9",
-    "zh:25a5717abef4ee5939c494681874fac696af88daf3872b1bad537927232a2ff1",
-    "zh:44f9479c5e2f0db0d339710a70dce12af3be625d4f4436d9495c8fda1fa6c779",
-    "zh:78bd5d9823837cc98cf3e1c86768c6b3f4a71890ec9df8f60e08734a11a5ab11",
-    "zh:887b124824e71d9d843cee5df4d0e96129c7f3eccc9ea7b5b5b93f0c3dc76cbb",
-    "zh:ac2254d0323ef2d84eb50c368ce950f17d4ac35ecca46b8bca530511da8a3612",
-    "zh:bbd953d47ee3540bc012184ea6ff8bf8fab03dcb6a7a67f1b63331d0311f2837",
-    "zh:c0bd0d8917101c7baf2d0183f2e164a09deeeddb8394a2d16ce9b0da4d8f033c",
-    "zh:d15f72ebead3c6a3ccd2bbf4b42885dbccab9535f137c6d44d71980cca727dfe",
-    "zh:ec300dcee88c04339fb1c0b37ea70794af01941eed658a50fc3b1dfb5a548aac",
+    "h1:ONbwl2UvL8exYyLefLPlShBt7xijDoIn/GLctKLd7lM=",
+    "zh:1bc909571c0ed37d0f7c555df1bff8e9489130a53eb6f9e50f4d814be0789e1f",
+    "zh:383bcd81fcdf4691a018e2c2cc90eef39d0bf2a36aa25c1de1bdcc036ed4be3d",
+    "zh:6f047c3d574436a4b24055f1839c78bc49602c1121366d005ec5db9cc047c2c6",
+    "zh:8e60fc337fd1b2025a01bc68573dea104dde714eecd1aa5c73cb591ca92b6068",
+    "zh:b56bd3a9b3dcd28ae40ad32163eb91470e3069241e083e79caa89e3a77b2821e",
+    "zh:bcc65938c3408ec73c2f78aec43c410ef203bb3d8c4627331e672d64abdb2595",
+    "zh:bcfb0a045ed3dad7cf61ffb0c6a904b980f554796aac03c40ee19b98f1f5db8b",
+    "zh:eb3eb4fcc9f89a707456130de1a75e6625dacde4d17ce257852a45314ac29181",
+    "zh:f465d6e3c4083e9e6d96571cc017406f766648a3ca0c455385c71a171995b495",
+    "zh:fc531d2cad0bc4ee2c5bdbf8a696835c83a0a4c06e90c95216c2e96d37986fb9",
+    "zh:fe454fb9b08f2143a7f00b8754fa103500833cbd325c53fedab70e96b3e70d00",
   ]
 }
 
@@ -37,20 +37,20 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.25.0"
+  version     = "3.27.0"
   constraints = ">= 3.24.0"
   hashes = [
-    "h1:oyaXLqVhtPnHDnwk2yU9qP4dTgfPHyuo27mX/ljeCTQ=",
-    "zh:2d3c65461bc63ec39bce7b5afdbed9a3b4dd5c2c8ee94616ad1866e24cf9b8f0",
-    "zh:2fb2ea6ccac30b909b603e183433737a30c58ec1f9a6a8b5565f0f051490c07a",
-    "zh:31a5f192c8cf29fb677cd639824f9a685578a2564c6b790517db33ea56229045",
-    "zh:437a12cf9a4d7bc92c9bf14ee7e224d5d3545cbd2154ba113ae82c4bb68edc27",
-    "zh:4bbdc3155a5dea90b2d50adfa460b0759c4dd959efaf7f66b2a0385a53b469b2",
-    "zh:63a8cd523ba31358692a34a06e111d88769576ac6d0e5adad8e0b4ae0a2d8882",
-    "zh:c4301ce86e8cb2c464949bb99e729ffe7b0c55eaf34b82ba526bb5039bca36f3",
-    "zh:c97b84861c6c550b8d2feb12d089660fffbf51dc7d660dcc9d54d4a7b3c2c882",
-    "zh:d6a103570e2d5c387b068fac4b88654dfa21d44ca1bdfa4bc8ab94c88effd71a",
-    "zh:f08cf2faf960a8ca374ac860f37c31c88ed2bab460116ac74678e0591babaac5",
+    "h1:lJaA23rrNSgLEumcW7Y0KKvno5isVVNNIEV5pT92O8E=",
+    "zh:2986eb5a1ffbb0336c6390aad533b62efc832aa8aa5460d523e1f2daa4f42f79",
+    "zh:825317cdb80860833125a856c0befc877cba22d41c631c5a7ca22400693d4356",
+    "zh:a47aad668cc74058f508c56c5407cd715dbb9b6389aa68d37543e897895db43f",
+    "zh:c0011502d0eb4637918127c3987a8cc07a015ea00f74f4956fd111c736286a4d",
+    "zh:d5088ab51043bb2239132f4ed3760292b6aa4f7296232e4b8017f8c5c34f051a",
+    "zh:d893658e983eb17a23a8124c79a910cc729cb1d751d5509b8e756101c828ad91",
+    "zh:dcc4384ee79ea9492c87eb01e664f7f6b1f1d156471476f30b28336c9d9a4aec",
+    "zh:e4abfaf013f31791cd029af7b6f989f73e3efca28fe2917057b428d051c4085f",
+    "zh:f2a4d9446d23afe2a42421e7d5f902d34451fb31b7787b5e3aef95c08fec5ced",
+    "zh:f54a6af10b077db9dc11556c27f59ba5c60e1b2ba96fe3aa9cd90d8c67d980f6",
   ]
 }
 


### PR DESCRIPTION
This constrains `terraform init` to use at least alexkappa/auth0@0.19.0 and hashicorp/aws@3.27.0.