### PR TITLE
Bring organisation-security-auditor account assignment into Terraform management

### DIFF
--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -1,5 +1,6 @@
 locals {
   teams_to_account_assignments = [
+    # OPG
     {
       github_team    = "opg"
       permission_set = aws_ssoadmin_permission_set.opg-viewer,
@@ -45,6 +46,14 @@ locals {
         aws_organizations_account.opg-use-my-lpa-development,
         aws_organizations_account.opg-use-my-lpa-preproduction,
         aws_organizations_account.opg-use-my-lpa-production
+      ]
+    },
+    # organisation-security
+    {
+      github_team    = "organisation-security-auditor"
+      permission_set = aws_ssoadmin_permission_set.security-audit,
+      accounts = [
+        aws_organizations_account.organisation-security
       ]
     }
   ]


### PR DESCRIPTION
This brings the [organisation-security-auditor](https://github.com/orgs/ministryofjustice/teams/organisation-security-auditor)  access to the organisation-security account into Terraform management.