### PR TITLE
Bring security-operations account assignment into Terraform management

### DIFF
--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -55,6 +55,16 @@ locals {
       accounts = [
         aws_organizations_account.organisation-security
       ]
+    },
+    # Security Operations
+    {
+      github_team    = "secops"
+      permission_set = aws_ssoadmin_permission_set.administrator-access
+      accounts = [
+        aws_organizations_account.security-operations-development,
+        aws_organizations_account.security-operations-pre-production,
+        aws_organizations_account.security-operations-production
+      ]
     }
   ]
   teams_to_account_assignments_association_list = flatten([


### PR DESCRIPTION
This brings the `secops` GitHub team account assignments into Terraform management.