### PR TITLE
Attach mandatory and optional tag policies to the organisation root to allow evaluation for all AWS accounts

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -38,7 +38,7 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.27.0"
-  constraints = ">= 3.24.0"
+  constraints = ">= 3.20.0, >= 3.24.0"
   hashes = [
     "h1:lJaA23rrNSgLEumcW7Y0KKvno5isVVNNIEV5pT92O8E=",
     "zh:2986eb5a1ffbb0336c6390aad533b62efc832aa8aa5460d523e1f2daa4f42f79",

--- a/terraform/organizations-organizational-units.tf
+++ b/terraform/organizations-organizational-units.tf
@@ -219,18 +219,6 @@ resource "aws_organizations_policy_attachment" "platforms-and-architecture-moder
   target_id = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform.id
 }
 
-# Enrol all accounts within the Modernisation Platform OU (current and future) to tag policies
-# Note that when you attach a tag policy, it can take 48 hours to evaluate compliance.
-resource "aws_organizations_policy_attachment" "modernisation-platform-mandatory-tags-policy" {
-  policy_id = aws_organizations_policy.mandatory-tags.id
-  target_id = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform.id
-}
-
-resource "aws_organizations_policy_attachment" "modernisation-platform-optional-tags-policy" {
-  policy_id = aws_organizations_policy.optional-tags.id
-  target_id = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform.id
-}
-
 # Security Engineering
 resource "aws_organizations_organizational_unit" "security-engineering" {
   name      = "Security Engineering"

--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -23,6 +23,19 @@ resource "aws_organizations_policy_attachment" "default" {
   target_id = aws_organizations_organization.default.roots[0].id
 }
 
+# Enrol all accounts within the AWS Organization to unenforced tag policies
+# Note that when you attach a tag policy, it can take 48 hours to evaluate compliance
+# See: https://docs.aws.amazon.com/organizations/latest/userguide/attach-tag-policy.html
+resource "aws_organizations_policy_attachment" "mandatory-tags-policy" {
+  policy_id = aws_organizations_policy.mandatory-tags.id
+  target_id = aws_organizations_organization.default.roots[0].id
+}
+
+resource "aws_organizations_policy_attachment" "optional-tags-policy" {
+  policy_id = aws_organizations_policy.optional-tags.id
+  target_id = aws_organizations_organization.default.roots[0].id
+}
+
 # If you're going to create a new account using this Terraform,
 # note that you'll have to import any aws_organizations_policy_attachment resources manually as
 # Terraform will fail to create them (as AWS attaches them on your behalf).


### PR DESCRIPTION
This moves the use of Tag Policies for both [Mandatory](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#mandatory) and [Optional](https://ministryofjustice.github.io/technical-guidance/documentation/standards/documenting-infrastructure-owners.html#optional) tags, as defined in the Technical Guidance, to the organisation root rather than just the Modernisation Platform.

This will allow AWS Organization users to evaluate their _own_ tag compliance in their accounts, and also allow AWS Organization administrators to evaluate the _whole_ organisations tag compliance within the organisation management account.

Note:
- these policies are not [enforced](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies-enforcement.html) for evaluation during resource creation
- [untagged resources don’t appear as noncompliant in results](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies-create.html)
- it can take up to [48 hours for compliance evaluation](https://docs.aws.amazon.com/ARG/latest/userguide/tag-policies-arg-evaluating-org-wide-compliance.html) from creation or change of these policies