### PR TITLE
Delegate Security Hub administration to organisation-security

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -37,20 +37,20 @@ provider "registry.terraform.io/hashicorp/archive" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.27.0"
-  constraints = ">= 3.20.0, >= 3.24.0"
+  version     = "3.28.0"
+  constraints = ">= 3.20.0, >= 3.28.0"
   hashes = [
-    "h1:lJaA23rrNSgLEumcW7Y0KKvno5isVVNNIEV5pT92O8E=",
-    "zh:2986eb5a1ffbb0336c6390aad533b62efc832aa8aa5460d523e1f2daa4f42f79",
-    "zh:825317cdb80860833125a856c0befc877cba22d41c631c5a7ca22400693d4356",
-    "zh:a47aad668cc74058f508c56c5407cd715dbb9b6389aa68d37543e897895db43f",
-    "zh:c0011502d0eb4637918127c3987a8cc07a015ea00f74f4956fd111c736286a4d",
-    "zh:d5088ab51043bb2239132f4ed3760292b6aa4f7296232e4b8017f8c5c34f051a",
-    "zh:d893658e983eb17a23a8124c79a910cc729cb1d751d5509b8e756101c828ad91",
-    "zh:dcc4384ee79ea9492c87eb01e664f7f6b1f1d156471476f30b28336c9d9a4aec",
-    "zh:e4abfaf013f31791cd029af7b6f989f73e3efca28fe2917057b428d051c4085f",
-    "zh:f2a4d9446d23afe2a42421e7d5f902d34451fb31b7787b5e3aef95c08fec5ced",
-    "zh:f54a6af10b077db9dc11556c27f59ba5c60e1b2ba96fe3aa9cd90d8c67d980f6",
+    "h1:0cCqlVoOAj4YOi61kVpqoxu1bdAmB67z6uZf+lsHJOw=",
+    "zh:1fee7fce319be5bea7df2e95f28a78a04e15c18bad5eb56dcc0ecc324c97f4b8",
+    "zh:2383ff31ef7411f7d4bef1ee288f0f79bec41cf220ac94c2b31f6a702b26f984",
+    "zh:2f450372a8aa7d32f62524159a5930e0251ba34f491d66f00239452a6d575921",
+    "zh:379d4fdc16a2245b50959f5bfcb24c71fb74b292b6cf9c2d267b6ce94dddd208",
+    "zh:9fd1078759edd79548ec52c6853668a69f22803c92c0ac202f5c43c1ace63ac0",
+    "zh:aef544e720ce79f97875cc4ef5dd163922e9f47a496e663d0a272e881d2dd32e",
+    "zh:e2f28ba5bde0403f3273e80860a80ab5e63420e0142c0e8e283b651b750a8ffe",
+    "zh:ebc859186fcdd4700cc7091a8ecf4e06cc6d2eceadaeadda0d0e49efc6456325",
+    "zh:ee7bced0660945206c6226de35ae465b52e406b12e9ff1075186af37962caa6f",
+    "zh:f33063481894f951ff1e76b94a8311041a4bd3f1f1f01d1a8580d6c893e13c2c",
   ]
 }
 

--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -5,6 +5,7 @@ resource "aws_organizations_organization" "default" {
     "guardduty.amazonaws.com",
     "ram.amazonaws.com",
     "reporting.trustedadvisor.amazonaws.com",
+    "securityhub.amazonaws.com",
     "sso.amazonaws.com",
     "storage-lens.s3.amazonaws.com",
     "tagpolicies.tag.amazonaws.com"

--- a/terraform/securityhub.tf
+++ b/terraform/securityhub.tf
@@ -1,8 +1,26 @@
-#####################################
-# Security Hub for AWS root account #
-#####################################
+#################################
+# Security Hub within eu-west-2 #
+#################################
 
-# Enable SecurityHub and subscriptions within the default region for the root account
+# Enable Security Hub for the default provider region, which is required to delegate a Security Hub administrator
 module "securityhub-default-region" {
   source = "./modules/securityhub"
+}
+
+# Enable SecurityHub in the organisation-security account, which is required to become a delegated administrator
+module "securityhub-organisation-security-eu-west-2" {
+  providers = {
+    aws = aws.organisation-security-eu-west-2
+  }
+
+  source = "./modules/securityhub"
+}
+
+# Delegate administratorship of Security Hub to organisation-security
+resource "aws_securityhub_organization_admin_account" "default-region-administrator" {
+  depends_on = [
+    aws_organizations_organization.default,
+    module.securityhub-organisation-security-eu-west-2
+  ]
+  admin_account_id = aws_organizations_account.organisation-security.id
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.24.0"
+      version = ">= 3.28.0"
     }
   }
 }


### PR DESCRIPTION
This PR:

- constrains the `terraform-provider-aws` version to [3.28.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.28.0), which introduced `aws_securityhub_organization_admin_account` to set a delegated administrator for Security Hub
- gives Security Hub trusted access throughout the organisation, so accounts can be enrolled without invitations
- enables Security Hub in the delegated administrator account, `organisation-security`
- sets the delegated administrator to `organisation-security`, ready to enrol accounts