### PR TITLE
Enrol HMPPS Performance Hub into central GuardDuty

### DIFF
--- a/terraform/guardduty.tf
+++ b/terraform/guardduty.tf
@@ -45,6 +45,7 @@ locals {
     aws_organizations_account.electronic-monitoring-tagging-hardware-test,
     aws_organizations_account.hmpps-dev,
     aws_organizations_account.hmpps-management,
+    aws_organizations_account.hmpps-performance-hub,
     aws_organizations_account.hmpps-prod,
     aws_organizations_account.laa-uat,
     aws_organizations_account.legal-aid-agency,


### PR DESCRIPTION
Enrols the `HMPPS Performance Hub` account into central GuardDuty.