### PR TITLE
Refactor GuardDuty configuration into a module for easier setup across regions

### DIFF
--- a/terraform/modules/guardduty/main.tf
+++ b/terraform/modules/guardduty/main.tf
@@ -1,0 +1,86 @@
+#############
+# GuardDuty #
+#############
+
+# Get the delegated administrator account ID
+data "aws_caller_identity" "delegated-administrator" {
+  provider = aws.delegated-administrator
+}
+
+#################################
+# GuardDuty in the root account #
+#################################
+resource "aws_guardduty_detector" "default" {
+  provider = aws.root-account
+
+  # Set enable to false if you want to suspend GuardDuty.
+  # This allows you to keep historical findings rather than removing the resource
+  # block, which will destroy all historical findings
+  enable = true
+
+  tags = var.root_tags
+}
+
+####################################################
+# GuardDuty in the delegated administrator account #
+####################################################
+resource "aws_guardduty_detector" "delegated-administrator" {
+  provider = aws.delegated-administrator
+
+  # Set enable to false if you want to suspend GuardDuty.
+  # This allows you to keep historical findings rather than removing the resource
+  # block, which will destroy all historical findings
+  enable = true
+
+  # This will send GuardDuty notifications every 15 minutes, rather than every
+  # 6 hours (default)
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
+
+  tags = var.administrator_tags
+}
+
+#####################################
+# GuardDuty delegated administrator #
+#####################################
+resource "aws_guardduty_organization_admin_account" "default" {
+  admin_account_id = data.aws_caller_identity.delegated-administrator.account_id
+
+  # GuardDuty is required to be turned on in the account before you set it as the delegated administrator
+  depends_on = [aws_guardduty_detector.delegated-administrator]
+}
+
+####################################
+# GuardDuty publishing destination #
+####################################
+resource "aws_guardduty_publishing_destination" "delegated-administrator" {
+  provider = aws.delegated-administrator
+
+  detector_id     = aws_guardduty_detector.delegated-administrator.id
+  destination_arn = var.destination_arn
+  kms_key_arn     = var.kms_key_arn
+}
+
+#############################
+# GuardDuty member accounts #
+#############################
+resource "aws_guardduty_member" "delegated-administrator" {
+  provider = aws.delegated-administrator
+
+  for_each = var.enrolled_into_guardduty
+
+  # We want to add these accounts as members within the delegated administrator account
+  account_id  = each.value
+  detector_id = aws_guardduty_detector.delegated-administrator.id
+  email       = "fake@email.com"
+  invite      = true
+
+  # With AWS Organizations, AWS doesn't rely on the email address provided to invite a member account,
+  # as privilege is inferred by the fact that the account is already within Organizations.
+  # However, once a relationship is established, the GuardDuty API returns an email address, so Terraform returns a drift.
+  # Therefore, we can ignore_changes to an email address. You still need to provide one, though, so we use fake@email.com.
+  lifecycle {
+    ignore_changes = [
+      email
+    ]
+  }
+}

--- a/terraform/modules/guardduty/providers.tf
+++ b/terraform/modules/guardduty/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  alias = "root-account"
+}
+
+provider "aws" {
+  alias = "delegated-administrator"
+}

--- a/terraform/modules/guardduty/variables.tf
+++ b/terraform/modules/guardduty/variables.tf
@@ -1,0 +1,26 @@
+variable "enrolled_into_guardduty" {
+  description = "Map of key => values where key is the account name and the value is the account ID"
+  type        = map(any)
+}
+
+variable "kms_key_arn" {
+  description = "KMS key ARN for encrypting GuardDuty findings in S3"
+  type        = string
+}
+
+variable "destination_arn" {
+  description = "S3 bucket ARN where findings get exported to"
+  type        = string
+}
+
+variable "root_tags" {
+  description = "Tags to apply to resources created in the root account, if applicable"
+  type        = map(any)
+  default     = {}
+}
+
+variable "administrator_tags" {
+  description = "Tags to apply to resources created in the delegated administrator account, if applicable"
+  type        = map(any)
+  default     = {}
+}

--- a/terraform/modules/guardduty/versions.tf
+++ b/terraform/modules/guardduty/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.27.0"
+    }
+  }
+  required_version = ">= 0.14.2"
+}


### PR DESCRIPTION
This PR replicates our current GuardDuty configuration within a self-contained module.

At the moment we replicate resource blocks to enable the same GuardDuty configuration across regions, such as in:

- [eu-west-2](https://github.com/ministryofjustice/aws-root-account/blob/main/terraform/guardduty.tf), and
- [eu-west-1](https://github.com/ministryofjustice/aws-root-account/blob/main/terraform/guardduty-eu-west-1.tf), which has the same configuration

However, we can reduce the replication here by using the module to enable GuardDuty in regions without having to replicate all of the resource blocks.