### PR TITLE
Add an explicit depends_on to wait for the GuardDuty delegated administrator before adding members

### DIFF
--- a/terraform/modules/guardduty/main.tf
+++ b/terraform/modules/guardduty/main.tf
@@ -85,4 +85,7 @@ resource "aws_guardduty_member" "delegated-administrator" {
       email
     ]
   }
+
+  # You need to set the GuardDuty organisation administrator before adding members
+  depends_on = [aws_guardduty_organization_admin_account.default]
 }


### PR DESCRIPTION
This PR adds an explicit `depends_on` so GuardDuty waits for the administratorship to be delegated before starting to add members to it.