### PR TITLE
Enrol LAA Test into central Security Hub

### DIFF
--- a/terraform/securityhub.tf
+++ b/terraform/securityhub.tf
@@ -5,6 +5,7 @@
 locals {
   enrolled_into_securityhub = concat([
     { id = local.caller_identity.account_id, name = "MoJ root account" },
+    aws_organizations_account.laa-test,
     aws_organizations_account.modernisation-platform,
   ], local.modernisation-platform-managed-account-ids)
 }


### PR DESCRIPTION
We want to test enrolling an AWS account that has _Config_ enabled, but not _Security Hub_, to see if it:

- enables Security Hub in the region
- turns on the standards set by the root account