### PR TITLE
Refactor Security Hub to match GuardDuty module

### DIFF
--- a/terraform/modules/securityhub/main.tf
+++ b/terraform/modules/securityhub/main.tf
@@ -3,7 +3,9 @@
 ################
 
 # Get current region
-data "aws_region" "current" {}
+data "aws_region" "current" {
+  provider = aws.root-account
+}
 
 # Get the delegated administrator account ID
 data "aws_caller_identity" "delegated-administrator" {
@@ -19,18 +21,21 @@ resource "aws_securityhub_account" "default" {
 
 # Enable Standard: AWS Foundational Security Best Practices
 resource "aws_securityhub_standards_subscription" "default-aws-foundational" {
+  provider      = aws.root-account
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0"
   depends_on    = [aws_securityhub_account.default]
 }
 
 # Enable Standard: CIS AWS Foundations
 resource "aws_securityhub_standards_subscription" "default-cis" {
+  provider      = aws.root-account
   standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
   depends_on    = [aws_securityhub_account.default]
 }
 
 # Enable Standard: PCI DSS v3.2.1
 resource "aws_securityhub_standards_subscription" "default-pci" {
+  provider      = aws.root-account
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"
   depends_on    = [aws_securityhub_account.default]
 }
@@ -44,18 +49,21 @@ resource "aws_securityhub_account" "delegated-administrator" {
 
 # Enable Standard: AWS Foundational Security Best Practices
 resource "aws_securityhub_standards_subscription" "delegated-administrator-aws-foundational" {
+  provider      = aws.delegated-administrator
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0"
   depends_on    = [aws_securityhub_account.delegated-administrator]
 }
 
 # Enable Standard: CIS AWS Foundations
 resource "aws_securityhub_standards_subscription" "delegated-administrator-cis" {
+  provider      = aws.delegated-administrator
   standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
   depends_on    = [aws_securityhub_account.delegated-administrator]
 }
 
 # Enable Standard: PCI DSS v3.2.1
 resource "aws_securityhub_standards_subscription" "delegated-administrator-pci" {
+  provider      = aws.delegated-administrator
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"
   depends_on    = [aws_securityhub_account.delegated-administrator]
 }
@@ -64,6 +72,7 @@ resource "aws_securityhub_standards_subscription" "delegated-administrator-pci" 
 # Security Hub delegated administrator #
 ########################################
 resource "aws_securityhub_organization_admin_account" "default" {
+  provider         = aws.root-account
   admin_account_id = data.aws_caller_identity.delegated-administrator.account_id
 
   # Security Hub is required to be enabled in the root and delegated administrator accounts to set

--- a/terraform/modules/securityhub/main.tf
+++ b/terraform/modules/securityhub/main.tf
@@ -1,22 +1,108 @@
+################
+# Security Hub #
+################
+
+# Get current region
 data "aws_region" "current" {}
 
-# Enable SecurityHub
-resource "aws_securityhub_account" "default" {}
+# Get the delegated administrator account ID
+data "aws_caller_identity" "delegated-administrator" {
+  provider = aws.delegated-administrator
+}
+
+####################################
+# Security Hub in the root account #
+####################################
+resource "aws_securityhub_account" "default" {
+  provider = aws.root-account
+}
 
 # Enable Standard: AWS Foundational Security Best Practices
-resource "aws_securityhub_standards_subscription" "aws-foundational" {
+resource "aws_securityhub_standards_subscription" "default-aws-foundational" {
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0"
   depends_on    = [aws_securityhub_account.default]
 }
 
 # Enable Standard: CIS AWS Foundations
-resource "aws_securityhub_standards_subscription" "cis" {
+resource "aws_securityhub_standards_subscription" "default-cis" {
   standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
   depends_on    = [aws_securityhub_account.default]
 }
 
 # Enable Standard: PCI DSS v3.2.1
-resource "aws_securityhub_standards_subscription" "pci" {
+resource "aws_securityhub_standards_subscription" "default-pci" {
   standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"
   depends_on    = [aws_securityhub_account.default]
+}
+
+#######################################################
+# Security Hub in the delegated administrator account #
+#######################################################
+resource "aws_securityhub_account" "delegated-administrator" {
+  provider = aws.delegated-administrator
+}
+
+# Enable Standard: AWS Foundational Security Best Practices
+resource "aws_securityhub_standards_subscription" "delegated-administrator-aws-foundational" {
+  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/aws-foundational-security-best-practices/v/1.0.0"
+  depends_on    = [aws_securityhub_account.delegated-administrator]
+}
+
+# Enable Standard: CIS AWS Foundations
+resource "aws_securityhub_standards_subscription" "delegated-administrator-cis" {
+  standards_arn = "arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
+  depends_on    = [aws_securityhub_account.delegated-administrator]
+}
+
+# Enable Standard: PCI DSS v3.2.1
+resource "aws_securityhub_standards_subscription" "delegated-administrator-pci" {
+  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"
+  depends_on    = [aws_securityhub_account.delegated-administrator]
+}
+
+########################################
+# Security Hub delegated administrator #
+########################################
+resource "aws_securityhub_organization_admin_account" "default" {
+  admin_account_id = data.aws_caller_identity.delegated-administrator.account_id
+
+  # Security Hub is required to be enabled in the root and delegated administrator accounts to set
+  # a delegated administrator
+  depends_on = [
+    aws_securityhub_account.default,
+    aws_securityhub_account.delegated-administrator
+  ]
+}
+
+################################
+# Security Hub member accounts #
+################################
+resource "aws_securityhub_member" "delegated-administrator" {
+  provider = aws.delegated-administrator
+
+  # Note that this resource returns an UnprocessedAccount error when a member is removed, so you need to login to the AWS console
+  # and do it manually, however, no one should be removed once enrolled.
+  # See: https://docs.aws.amazon.com/guardduty/latest/APIReference/API_UnprocessedAccount.html
+  for_each = var.enrolled_into_securityhub
+
+  # We want to add these accounts as members within the delegated administrator account
+  account_id = each.value
+  email      = "placeholder-to-avoid-terraform-drift@example.com"
+  invite     = false
+
+  # With AWS Organizations, AWS doesn't rely on the email address provided and doesn't send an invite to a member account,
+  # as privilege is inferred by the fact the account is already within Organiations.
+  # However, once a relationship is established, the SecurityHub API returns an email address, and sets `invite` to true,
+  # so Terraform returns a drift.
+  # Therefore, we can ignore_changes on both `email` and `invite`. You still need to provide an email, though, so we use
+  # placeholder-to-avoid-terraform-drift@example.com as it's a reserved domain (see: https://www.iana.org/domains/reserved)
+  lifecycle {
+    ignore_changes = [
+      email,
+      invite
+    ]
+  }
+
+  # You need to set the Security Hub organisation administrator before adding members
+  depends_on = [aws_securityhub_organization_admin_account.default]
 }

--- a/terraform/modules/securityhub/providers.tf
+++ b/terraform/modules/securityhub/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  alias = "root-account"
+}
+
+provider "aws" {
+  alias = "delegated-administrator"
+}

--- a/terraform/modules/securityhub/variables.tf
+++ b/terraform/modules/securityhub/variables.tf
@@ -1,0 +1,4 @@
+variable "enrolled_into_securityhub" {
+  description = "Map of key => values where key is the account name and the value is the account ID"
+  type        = map(any)
+}

--- a/terraform/modules/securityhub/versions.tf
+++ b/terraform/modules/securityhub/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.27.0"
     }
   }
   required_version = ">= 0.14.2"

--- a/terraform/securityhub.tf
+++ b/terraform/securityhub.tf
@@ -10,60 +10,18 @@ locals {
   ], local.modernisation-platform-managed-account-ids)
 }
 
-# Enable Security Hub for the default provider region, which is required to delegate a Security Hub administrator
-module "securityhub-default-region" {
+module "securityhub-eu-west-2" {
   source = "./modules/securityhub"
-}
 
-# Enable SecurityHub in the organisation-security account, which is required to become a delegated administrator
-module "securityhub-organisation-security-eu-west-2" {
   providers = {
-    aws = aws.organisation-security-eu-west-2
+    aws.root-account            = aws.aws-root-account-eu-west-2
+    aws.delegated-administrator = aws.organisation-security-eu-west-2
   }
 
-  source = "./modules/securityhub"
-}
-
-# Delegate administratorship of Security Hub to organisation-security
-resource "aws_securityhub_organization_admin_account" "default-region-administrator" {
-  depends_on = [
-    aws_organizations_organization.default,
-    module.securityhub-organisation-security-eu-west-2
-  ]
-  admin_account_id = aws_organizations_account.organisation-security.id
-}
-
-################################
-# Member accounts in eu-west-2 #
-################################
-
-resource "aws_securityhub_member" "eu-west-2" {
-  # Note that this resource returns an UnprocessedAccount error when a member is removed, so you need to login to the AWS console
-  # and do it manually, however, no one should be removed once enrolled.
-  # See: https://docs.aws.amazon.com/guardduty/latest/APIReference/API_UnprocessedAccount.html
-  for_each = {
+  enrolled_into_securityhub = {
     for account in local.enrolled_into_securityhub :
     account.name => account.id
   }
-  provider = aws.organisation-security-eu-west-2
 
-  # We want to add these accounts as members within the Organisation Security account
-  account_id = each.value
-  email      = "placeholder-to-avoid-terraform-drift@example.com"
-  invite     = false
-
-  depends_on = [aws_securityhub_organization_admin_account.default-region-administrator]
-
-  # With AWS Organizations, AWS doesn't rely on the email address provided and doesn't send an invite to a member account,
-  # as privilege is inferred by the fact the account is already within Organiations.
-  # However, once a relationship is established, the SecurityHub API returns an email address, and sets `invite` to true,
-  # so Terraform returns a drift.
-  # Therefore, we can ignore_changes on both `email` and `invite`. You still need to provide an email, though, so we use
-  # placeholder-to-avoid-terraform-drift@example.com as it's a reserved domain (see: https://www.iana.org/domains/reserved)
-  lifecycle {
-    ignore_changes = [
-      email,
-      invite
-    ]
-  }
+  depends_on = [aws_organizations_organization.default]
 }


### PR DESCRIPTION
This PR refactors the Security Hub module to match the GuardDuty module, allowing you to call it once for each region, which will configure:
- Security Hub in the AWS root account
- Security Hub in the delegated administrator account
- Set the delegated administrator account to the right account ID
- Enable the 3 Security Hub standards (AWS Foundational, CIS, PCI) in both accounts
- Add accounts as members to the delegated administrator