### PR TITLE
Enable Security Hub member accounts in eu-west-1

### DIFF
--- a/terraform/securityhub.tf
+++ b/terraform/securityhub.tf
@@ -1,7 +1,15 @@
-#################################
-# Security Hub within eu-west-2 #
-#################################
+# Accounts to attach from the AWS Organization
+# This is currently done by adding accounts on a one-by-one basis as
+# we need to onboard people singularly rather than all at once.
+# In the future we can replace all of this with a for_each on a
+# data.aws_organizations_organization.example.accounts[*].id data resource,
+# and auto_enable will be turned on so new accounts won't need to be added here.
+# Any account added here in the meanwhile will have Security Hub enabled in:
+# - eu-west-2
+# - eu-west-1
 
+# Security Hub will alert you if AWS Config (a prerequesite for Security Hub) isn't enabled
+# in the region you're adding an member account to.
 locals {
   enrolled_into_securityhub = concat([
     { id = local.caller_identity.account_id, name = "MoJ root account" },
@@ -10,12 +18,31 @@ locals {
   ], local.modernisation-platform-managed-account-ids)
 }
 
+##############################
+# Security Hub in EU regions #
+##############################
 module "securityhub-eu-west-2" {
   source = "./modules/securityhub"
 
   providers = {
     aws.root-account            = aws.aws-root-account-eu-west-2
     aws.delegated-administrator = aws.organisation-security-eu-west-2
+  }
+
+  enrolled_into_securityhub = {
+    for account in local.enrolled_into_securityhub :
+    account.name => account.id
+  }
+
+  depends_on = [aws_organizations_organization.default]
+}
+
+module "securityhub-eu-west-1" {
+  source = "./modules/securityhub"
+
+  providers = {
+    aws.root-account            = aws.aws-root-account-eu-west-1
+    aws.delegated-administrator = aws.organisation-security-eu-west-1
   }
 
   enrolled_into_securityhub = {


### PR DESCRIPTION
This PR adds member accounts to Security Hub in eu-west-1.

If a member account doesn't have AWS Config enabled in that region, Security Hub _will_ add that account and then tell you that it doesn't have AWS Config on.

Use of AWS is across both eu-west-1 and eu-west-2 in the MOJ, so we should add member accounts in both where possible to capture all usage.