### PR TITLE
Remove p-FullAWSAccess SCP from Terraform management for OUs

### DIFF
--- a/terraform/organizations-organizational-units.tf
+++ b/terraform/organizations-organizational-units.tf
@@ -4,30 +4,15 @@ resource "aws_organizations_organizational_unit" "organisation-management" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
-resource "aws_organizations_policy_attachment" "organisation-management-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.organisation-management.id
-}
-
 # Closed accounts
 resource "aws_organizations_organizational_unit" "closed-accounts" {
   name      = "Closed accounts"
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
-resource "aws_organizations_policy_attachment" "closed-accounts-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.closed-accounts.id
-}
-
 resource "aws_organizations_organizational_unit" "closed-accounts-remove" {
   name      = "Remove"
   parent_id = aws_organizations_organizational_unit.closed-accounts.id
-}
-
-resource "aws_organizations_policy_attachment" "closed-accounts-remove-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.closed-accounts-remove.id
 }
 
 # OPG
@@ -36,19 +21,9 @@ resource "aws_organizations_organizational_unit" "opg" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
-resource "aws_organizations_policy_attachment" "opg-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.opg.id
-}
-
 resource "aws_organizations_organizational_unit" "opg-lpa-refunds" {
   name      = "LPA Refunds"
   parent_id = aws_organizations_organizational_unit.opg.id
-}
-
-resource "aws_organizations_policy_attachment" "opg-lpa-refunds-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.opg-lpa-refunds.id
 }
 
 resource "aws_organizations_organizational_unit" "opg-sirius" {
@@ -56,19 +31,9 @@ resource "aws_organizations_organizational_unit" "opg-sirius" {
   parent_id = aws_organizations_organizational_unit.opg.id
 }
 
-resource "aws_organizations_policy_attachment" "opg-sirius-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.opg-sirius.id
-}
-
 resource "aws_organizations_organizational_unit" "opg-digideps" {
   name      = "DigiDeps"
   parent_id = aws_organizations_organizational_unit.opg.id
-}
-
-resource "aws_organizations_policy_attachment" "opg-digideps-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.opg-digideps.id
 }
 
 resource "aws_organizations_organizational_unit" "opg-make-an-lpa" {
@@ -76,29 +41,14 @@ resource "aws_organizations_organizational_unit" "opg-make-an-lpa" {
   parent_id = aws_organizations_organizational_unit.opg.id
 }
 
-resource "aws_organizations_policy_attachment" "opg-make-an-lpa-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.opg-make-an-lpa.id
-}
-
 resource "aws_organizations_organizational_unit" "opg-digicop" {
   name      = "DigiCop"
   parent_id = aws_organizations_organizational_unit.opg.id
 }
 
-resource "aws_organizations_policy_attachment" "opg-digicop-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.opg-digicop.id
-}
-
 resource "aws_organizations_organizational_unit" "opg-use-my-lpa" {
   name      = "Use My LPA"
   parent_id = aws_organizations_organizational_unit.opg.id
-}
-
-resource "aws_organizations_policy_attachment" "opg-use-my-lpa-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.opg-use-my-lpa.id
 }
 
 # HMPPS
@@ -107,19 +57,9 @@ resource "aws_organizations_organizational_unit" "hmpps" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
-resource "aws_organizations_policy_attachment" "hmpps-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.hmpps.id
-}
-
 resource "aws_organizations_organizational_unit" "hmpps-vcms" {
   name      = "VCMS"
   parent_id = aws_organizations_organizational_unit.hmpps.id
-}
-
-resource "aws_organizations_policy_attachment" "hmpps-vcms-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.hmpps-vcms.id
 }
 
 resource "aws_organizations_organizational_unit" "hmpps-delius" {
@@ -127,19 +67,9 @@ resource "aws_organizations_organizational_unit" "hmpps-delius" {
   parent_id = aws_organizations_organizational_unit.hmpps.id
 }
 
-resource "aws_organizations_policy_attachment" "hmpps-delius-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.hmpps-delius.id
-}
-
 resource "aws_organizations_organizational_unit" "hmpps-electronic-monitoring" {
   name      = "Electronic Monitoring"
   parent_id = aws_organizations_organizational_unit.hmpps.id
-}
-
-resource "aws_organizations_policy_attachment" "hmpps-electronic-monitoring-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.hmpps-electronic-monitoring.id
 }
 
 resource "aws_organizations_organizational_unit" "hmpps-electronic-monitoring-acquisitive-crime" {
@@ -159,20 +89,10 @@ resource "aws_organizations_organizational_unit" "yjb" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
-resource "aws_organizations_policy_attachment" "yjb-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.yjb.id
-}
-
 # LAA
 resource "aws_organizations_organizational_unit" "laa" {
   name      = "LAA"
   parent_id = aws_organizations_organization.default.roots[0].id
-}
-
-resource "aws_organizations_policy_attachment" "laa-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.laa.id
 }
 
 resource "aws_organizations_policy_attachment" "laa" {
@@ -186,20 +106,10 @@ resource "aws_organizations_organizational_unit" "central-digital" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
-resource "aws_organizations_policy_attachment" "central-digital-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.central-digital.id
-}
-
 # Platforms & Architecture
 resource "aws_organizations_organizational_unit" "platforms-and-architecture" {
   name      = "Platforms & Architecture"
   parent_id = aws_organizations_organization.default.roots[0].id
-}
-
-resource "aws_organizations_policy_attachment" "platforms-and-architecture-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.platforms-and-architecture.id
 }
 
 resource "aws_organizations_organizational_unit" "platforms-and-architecture-cloud-platform" {
@@ -207,21 +117,11 @@ resource "aws_organizations_organizational_unit" "platforms-and-architecture-clo
   parent_id = aws_organizations_organizational_unit.platforms-and-architecture.id
 }
 
-resource "aws_organizations_policy_attachment" "platforms-and-architecture-cloud-platform-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.platforms-and-architecture-cloud-platform.id
-}
-
 # There are more OUs within the Modernisation Platform, but they are managed elsewhere
 # See: https://github.com/ministryofjustice/modernisation-platform
 resource "aws_organizations_organizational_unit" "platforms-and-architecture-modernisation-platform" {
   name      = "Modernisation Platform"
   parent_id = aws_organizations_organizational_unit.platforms-and-architecture.id
-}
-
-resource "aws_organizations_policy_attachment" "platforms-and-architecture-modernisation-platform-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.platforms-and-architecture-modernisation-platform.id
 }
 
 # Enrol all accounts within the Modernisation Platform OU (current and future) to the restricted regions policy
@@ -236,20 +136,10 @@ resource "aws_organizations_organizational_unit" "security-engineering" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
-resource "aws_organizations_policy_attachment" "security-engineering-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.security-engineering.id
-}
-
 # Workplace Technology
 resource "aws_organizations_organizational_unit" "workplace-technology" {
   name      = "Workplace Technology"
   parent_id = aws_organizations_organization.default.roots[0].id
-}
-
-resource "aws_organizations_policy_attachment" "workplace-technology-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.workplace-technology.id
 }
 
 # Analytics Platform
@@ -258,20 +148,10 @@ resource "aws_organizations_organizational_unit" "analytics-platform" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
-resource "aws_organizations_policy_attachment" "analytics-platform-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.analytics-platform.id
-}
-
 # Tactical Products
 resource "aws_organizations_organizational_unit" "tactical-products" {
   name      = "Tactical Products"
   parent_id = aws_organizations_organization.default.roots[0].id
-}
-
-resource "aws_organizations_policy_attachment" "tactical-products-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.tactical-products.id
 }
 
 # CICA
@@ -280,18 +160,8 @@ resource "aws_organizations_organizational_unit" "cica" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
-resource "aws_organizations_policy_attachment" "cica-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.cica.id
-}
-
 # HMCTS
 resource "aws_organizations_organizational_unit" "hmcts" {
   name      = "HMCTS"
   parent_id = aws_organizations_organization.default.roots[0].id
-}
-
-resource "aws_organizations_policy_attachment" "hmcts-ou-full-access" {
-  policy_id = "p-FullAWSAccess"
-  target_id = aws_organizations_organizational_unit.hmcts.id
 }


### PR DESCRIPTION
As with #165, AWS automatically add the `p-FullAWSAccess` to organisational units within AWS Organizations upon creation.

See #165 for more details and the thoughts around this PR.

Note that [this PR leaves custom SCPs in Terraform management](https://github.com/ministryofjustice/aws-root-account/compare/remove-pfullawsaccess-from-ous?expand=1#diff-aa022d03ea45745fef3bfc2e9b52e914dea09442863b43e78354d98b50add1dcL228) as part of the deny list strategy.