### PR TITLE
Enable CloudTrail for this AWS account

### DIFF
--- a/terraform/cloudtrail.tf
+++ b/terraform/cloudtrail.tf
@@ -1,0 +1,8 @@
+module "cloudtrail" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines//modules/cloudtrail"
+  providers = {
+    aws.replication-region = aws.aws-root-account-eu-west-1
+  }
+  replication_role_arn = module.iam_s3_replication_role.role.arn
+  tags                 = local.root_account
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -6,3 +6,13 @@ resource "aws_iam_account_alias" "default" {
 module "iam_password_policy" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-baselines//modules/iam"
 }
+
+# IAM role for S3 bucket replication
+module "iam_s3_replication_role" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=v1.0.0"
+  buckets = [
+    module.cloudtrail.s3_bucket.arn,
+    module.cloudtrail.log_bucket.arn
+  ]
+  tags = local.root_account
+}


### PR DESCRIPTION
This PR enables a multi-region CloudTrail trail using the [modernisation-platform-terraform-baselines CloudTrail module](https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/tree/main/modules/cloudtrail).

Note that this isn't an organisation trail.