### PR TITLE
Remove MOJ PeopleFinder

### DIFF
--- a/terraform/organizations-accounts-closed-accounts.tf
+++ b/terraform/organizations-accounts-closed-accounts.tf
@@ -32,23 +32,6 @@ resource "aws_organizations_account" "moj-security-closed" {
   }
 }
 
-resource "aws_organizations_account" "moj-peoplefinder" {
-  name      = "MoJ PeopleFinder"
-  email     = local.aws_account_email_addresses["MoJ PeopleFinder"][0]
-  parent_id = aws_organizations_organizational_unit.closed-accounts.id
-
-  lifecycle {
-    # If any of these attributes are changed, it attempts to destroy and recreate the account,
-    # so we should ignore the changes to prevent this from happening.
-    ignore_changes = [
-      name,
-      email,
-      iam_user_access_to_billing,
-      role_name
-    ]
-  }
-}
-
 resource "aws_organizations_account" "parliamentary-questions" {
   name      = "Parliamentary Questions"
   email     = local.aws_account_email_addresses["Parliamentary Questions"][0]


### PR DESCRIPTION
The `MoJ PeopleFinder` AWS account is now closed after it's 90-day cool-off-period, this removes it from Terraform so it doesn't attempt to recreate it.