### PR TITLE
Enrol VCMS and Delius Core non-production accounts into Security Hub

### DIFF
--- a/terraform/securityhub.tf
+++ b/terraform/securityhub.tf
@@ -13,11 +13,13 @@
 locals {
   enrolled_into_securityhub = concat([
     { id = local.caller_identity.account_id, name = "MoJ root account" },
+    aws_organizations_account.delius-core-non-prod,
     aws_organizations_account.laa-development,
     aws_organizations_account.laa-staging,
     aws_organizations_account.laa-test,
     aws_organizations_account.legal-aid-agency,
     aws_organizations_account.modernisation-platform,
+    aws_organizations_account.vcms-non-prod,
   ], local.modernisation-platform-managed-account-ids)
 }
 


### PR DESCRIPTION
This PR enrols the VCMS and Delius Core non-production accounts into AWS Security Hub central reporting.