### PR TITLE
AWS SSO: webops access to Cloud Platform & Cloud Platform Ephemeral Test

### DIFF
--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -79,7 +79,9 @@ locals {
       github_team    = "webops"
       permission_set = aws_ssoadmin_permission_set.administrator-access
       accounts = [
-        aws_organizations_account.moj-digital-services
+        aws_organizations_account.moj-digital-services,
+        aws_organizations_account.cloud-platform,
+        aws_organizations_account.cloud-platform-ephemeral-test,
       ]
     },
     # Electronic Monitoring


### PR DESCRIPTION
Gives the GitHub team @ministryofjustice/webops access to `Cloud Platform` and `Cloud Platform Ephemeral Test`.