### PR TITLE
Enrol HMPPS Delius & VCMS AWS accounts into non-eu-west-2 GuardDuty

### DIFF
--- a/terraform/guardduty.tf
+++ b/terraform/guardduty.tf
@@ -554,7 +554,7 @@ module "guardduty-eu-west-2" {
   enrolled_into_guardduty = {
     for account in local.enrolled_into_guardduty :
     account.name => account.id
-    if !contains(local.enrolled_into_guardduty_non_eu_west_2_only, account)
+    if ! contains(local.enrolled_into_guardduty_non_eu_west_2_only, account)
   }
 
   filterable_security_accounts = [aws_organizations_account.security-operations-development.id]


### PR DESCRIPTION
This PR enrols 27 HMPPS Delius & VCMS AWS accounts into central GuardDuty for all regions **apart from eu-west-2**. This enables us to gain better coverage of threat detection across all AWS regions as per [AWS best practices](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_data-sources.html#cloudtrail_global).

The 27 accounts have an integration with GuardDuty in eu-west-2 **only** that needs unpicking before enrolling them into our GuardDuty detector as a member account.

This PR creates 405 resources (15 regions x 27 accounts).