### PR TITLE
Enrol YJB accounts into GuardDuty in non-eu-west-2 regions

### DIFF
--- a/terraform/guardduty.tf
+++ b/terraform/guardduty.tf
@@ -44,6 +44,14 @@ locals {
     aws_organizations_account.vcms-non-prod,
     aws_organizations_account.probation,
     aws_organizations_account.network-architecture,
+    aws_organizations_account.youth-justice-framework-dev,
+    aws_organizations_account.youth-justice-framework-management,
+    aws_organizations_account.youth-justice-framework-pre-prod,
+    aws_organizations_account.youth-justice-framework-juniper,
+    aws_organizations_account.youth-justice-framework-prod,
+    aws_organizations_account.youth-justice-framework-monitoring,
+    aws_organizations_account.youth-justice-framework-eng-tools,
+    aws_organizations_account.youth-justice-framework-sandpit,
   ]
   enrolled_into_guardduty = concat([
     { id = local.caller_identity.account_id, name = "MoJ root account" },


### PR DESCRIPTION
This PR enrols the 8 YJB AWS accounts into central GuardDuty for all regions **apart from eu-west-2**. This enables us to gain better coverage of threat detection and continuous monitoring across all AWS regions as per the [AWS best practices](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_data-sources.html#cloudtrail_global) and the MOJ Security Guidance for GuardDuty, which specifically mentions that GuardDuty should [be enabled in all regions, all of the time](https://ministryofjustice.github.io/security-guidance/baseline-aws-accounts/#guardduty).

These 8 AWS accounts have an integration with GuardDuty in eu-west-2 **only** which needs unpicking before enrolling them into the central eu-west-2 GuardDuty detector as a member account, which provides a full organisational overview of threat detection.

This PR creates 120 resources (15 regions x 8 accounts).