### PR TITLE
Add ViewOnly with Secrets Manager access for AWS SSO for Modernisation Platform

### DIFF
--- a/terraform/sso-admin-permission-sets.tf
+++ b/terraform/sso-admin-permission-sets.tf
@@ -161,19 +161,15 @@ data "aws_iam_policy_document" "secretsmanager-and-ssm" {
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",
       "secretsmanager:ListSecretVersionIds",
-      "secretsmanager:CreateSecret",
       "secretsmanager:PutSecretValue",
       "secretsmanager:UpdateSecret",
       "secretsmanager:RestoreSecret",
-      "secretsmanager:DeleteSecret",
       "ssm:PutParameter",
-      "ssm:DeleteParameter",
       "ssm:GetParameterHistory",
       "ssm:GetParametersByPath",
       "ssm:GetParameters",
       "ssm:GetParameter",
       "ssm:DescribeParameters",
-      "ssm:DeleteParameters"
     ]
 
     resources = ["*"]

--- a/terraform/sso-admin-permission-sets.tf
+++ b/terraform/sso-admin-permission-sets.tf
@@ -156,7 +156,7 @@ resource "aws_ssoadmin_managed_policy_attachment" "modernisation-platform-viewer
 
 data "aws_iam_policy_document" "secretsmanager-and-ssm" {
   statement {
-    actions =  [
+    actions = [
       "secretsmanager:GetResourcePolicy",
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",


### PR DESCRIPTION
This PR provides an AWS SSO permission set for Modernisation Platform to use where they want to:

- provide read-only access to the AWS console
- allow write access to Secrets Manager and SSM to initialise values