### PR TITLE
Remove closed accounts: MOJ Intranet

### DIFF
--- a/terraform/organizations-accounts-closed-accounts.tf
+++ b/terraform/organizations-accounts-closed-accounts.tf
@@ -32,23 +32,6 @@ resource "aws_organizations_account" "moj-security-closed" {
   }
 }
 
-resource "aws_organizations_account" "moj-intranet" {
-  name      = "MOJ Intranet"
-  email     = local.aws_account_email_addresses["MOJ Intranet"][0]
-  parent_id = aws_organizations_organizational_unit.closed-accounts.id
-
-  lifecycle {
-    # If any of these attributes are changed, it attempts to destroy and recreate the account,
-    # so we should ignore the changes to prevent this from happening.
-    ignore_changes = [
-      name,
-      email,
-      iam_user_access_to_billing,
-      role_name
-    ]
-  }
-}
-
 resource "aws_organizations_account" "get-help-with-child-arrangements" {
   name      = "Get help with child arrangements"
   email     = local.aws_account_email_addresses["Get help with child arrangements"][0]


### PR DESCRIPTION
Removes MOJ Intranet which is now closed and have finished its [90-day cool-off period](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_close.html).

