### PR TITLE
GuardDuty: Add variable to allow auto-enabling per region

### DIFF
--- a/terraform/modules/guardduty/main.tf
+++ b/terraform/modules/guardduty/main.tf
@@ -51,6 +51,16 @@ resource "aws_guardduty_organization_admin_account" "default" {
   depends_on = [aws_guardduty_detector.delegated-administrator]
 }
 
+##################################################################
+# Auto-enable GuardDuty for new accounts in the AWS Organization #
+##################################################################
+resource "aws_guardduty_organization_configuration" "delegated-administrator" {
+  provider = aws.delegated-administrator
+
+  detector_id = aws_guardduty_detector.delegated-administrator.id
+  auto_enable = var.auto_enable
+}
+
 ####################################
 # GuardDuty publishing destination #
 ####################################

--- a/terraform/modules/guardduty/variables.tf
+++ b/terraform/modules/guardduty/variables.tf
@@ -30,3 +30,9 @@ variable "filterable_security_accounts" {
   type        = list(string)
   default     = []
 }
+
+variable "auto_enable" {
+  description = "Whether to auto-enable GuardDuty in new AWS accounts"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This PR adds the `aws_guardduty_organization_configuration` resource to the GuardDuty module, to allow us to automatically enable GuardDuty for all accounts in a region.

This removes the need to keep adding accounts to the `local.enrolled_into_guardduty` variable as they're created, and should dramatically reduce the amount of resources Terraform manages (i.e. for regions where it's enabled, we won't have to specify each account as a `aws_guardduty_member`).