### PR TITLE
Add permission to delete OUs

### DIFF
--- a/terraform/iam-policies.tf
+++ b/terraform/iam-policies.tf
@@ -149,6 +149,17 @@ data "aws_iam_policy_document" "terraform-organisation-management-policy-scp" {
     ]
     resources = ["*"]
   }
+  statement {
+    sid    = "AllowDeleteOUs"
+    effect = "Allow"
+    actions = [
+      # Note temporary for reorganising the ou structure, to be deleted after
+      "organizations:DeleteOrganizationalUnit"
+    ]
+    resources = [
+      "*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "terraform-organisation-management-policy-scp" {


### PR DESCRIPTION
In order to move the ous under the new OU structure we have to delete
the ous and recreate them.  We can't do this without this permission.
This won't be needed after this excercise so it can be reverted after.