### PR TITLE
Revert "Add permission to delete OUs"

### DIFF
--- a/terraform/iam-policies.tf
+++ b/terraform/iam-policies.tf
@@ -149,17 +149,6 @@ data "aws_iam_policy_document" "terraform-organisation-management-policy-scp" {
     ]
     resources = ["*"]
   }
-  statement {
-    sid    = "AllowDeleteOUs"
-    effect = "Allow"
-    actions = [
-      # Note temporary for reorganising the ou structure, to be deleted after
-      "organizations:DeleteOrganizationalUnit"
-    ]
-    resources = [
-      "*"
-    ]
-  }
 }
 
 resource "aws_iam_policy" "terraform-organisation-management-policy-scp" {


### PR DESCRIPTION
Reverts ministryofjustice/aws-root-account#229

This permission was only needed as it's not possible to move OUs, only delete and create them.  Now the OUs are in the correct place we can revert this permission.