### PR TITLE
Auto-enable S3 logs to be analysed for GuardDuty

### DIFF
--- a/terraform/modules/guardduty/main.tf
+++ b/terraform/modules/guardduty/main.tf
@@ -43,6 +43,13 @@ resource "aws_guardduty_detector" "delegated-administrator" {
   # See: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html#guardduty_findings_cloudwatch_notification_frequency
   finding_publishing_frequency = "FIFTEEN_MINUTES"
 
+  # Enable S3 logs to be analysed in GuardDuty
+  datasources {
+    s3_logs {
+      enable = true
+    }
+  }
+
   tags = var.administrator_tags
 }
 
@@ -64,6 +71,13 @@ resource "aws_guardduty_organization_configuration" "delegated-administrator" {
 
   detector_id = aws_guardduty_detector.delegated-administrator.id
   auto_enable = var.auto_enable
+
+  # Auto-enable S3 logs to be analysed for new accounts in the AWS Organization
+  datasources {
+    s3_logs {
+      auto_enable = true
+    }
+  }
 }
 
 ####################################


### PR DESCRIPTION
This PR auto-enables S3 logs to be analysed for GuardDuty for new accounts added or created within the AWS Organization. It does not retrospectively enable S3 logs, which needs to be done manually.