### PR TITLE
Give hmpps-ems-moj-soc Security Audit permissions on EMS Shared Logging

### DIFF
--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -109,6 +109,14 @@ locals {
         aws_organizations_account.electronic-monitoring-tagging-hardware-test
       ]
     },
+    # Electronic Monitoring MOJ SOC Integration
+    {
+      github_team    = "hmpps-ems-moj-soc"
+      permission_set = aws_ssoadmin_permission_set.security-audit
+      accounts = [
+        aws_organizations_account.electronic-monitoring-shared-logging
+      ]
+    },
     # HMPPS Community Rehabilitation
     {
       github_team    = "hmpps-jenkins-admin"


### PR DESCRIPTION
Hi,

This PR is to give the [hmpps-ems-moj-soc team](https://github.com/orgs/ministryofjustice/teams/hmpps-ems-moj-soc) access to EMS Shared Logging via MOJ SSO