### PR TITLE
Add SSO Read only access for MP eng to moj-master

### DIFF
--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -74,6 +74,16 @@ locals {
         aws_organizations_account.modernisation-platform
       ]
     },
+
+    # Modernisation Platform engineers
+    {
+      github_team    = "modernisation-platform-engineers"
+      permission_set = aws_ssoadmin_permission_set.aws-sso-readonly
+      accounts = [
+        { id = local.caller_identity.account_id, name = "MoJ root account" }
+      ]
+    },
+
     # Cloud Platform (Webops) access
     {
       github_team    = "webops"


### PR DESCRIPTION
Modernisation platform engineers need read only access to AWS SSO so
that they can trouble shoot SSO failures for modernisation platform
users.