### PR TITLE
add cloud-ops-admin, add as admin for in all mojo and wtp accounts

### DIFF
--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -140,12 +140,44 @@ locals {
         aws_organizations_account.hmpps-community-rehabilitation-unpaid-work-production
       ]
     },
-    # MOJ Official Technical Operations (Networking)
+    # MOJ Official Technical Operations (Networking) and Cloud Ops team
     {
       github_team    = "moj-official-techops"
       permission_set = aws_ssoadmin_permission_set.administrator-access
       accounts = [
-        aws_organizations_account.moj-official-network-operations-centre
+        aws_organizations_account.moj-official-network-operations-centre,
+        aws_organizations_account.wptpoc,
+        aws_organizations_account,workplace-tech-proof-of-concept-development
+      ]
+    },
+    {
+      github_team    = "moj-official-techops"
+      permission_set = aws_ssoadmin_permission_set.read-only-access
+      accounts = [
+        aws_organizations_account.moj-official-network-operations-centre,
+        aws_organizations_account.moj-official-production,
+        aws_organizations_account.moj-official-pre-production,
+        aws_organizations_account.moj-official-development,
+        aws_organizations_account.moj-official-public-key-infrastructure-dev,
+        aws_organizations_account.moj-official-public-key-infrastructure,
+        aws_organizations_account.moj-official-shared-services,
+        aws_organizations_account.wptpoc,
+        aws_organizations_account,workplace-tech-proof-of-concept-development
+      ]
+    },
+    {
+      github_team    = "cloud-ops-admins"
+      permission_set = aws_ssoadmin_permission_set.administrator-access
+      accounts = [
+        aws_organizations_account.moj-official-network-operations-centre,
+        aws_organizations_account.moj-official-production,
+        aws_organizations_account.moj-official-pre-production,
+        aws_organizations_account.moj-official-development,
+        aws_organizations_account.moj-official-public-key-infrastructure-dev,
+        aws_organizations_account.moj-official-public-key-infrastructure,
+        aws_organizations_account.moj-official-shared-services,
+        aws_organizations_account.wptpoc,
+        aws_organizations_account,workplace-tech-proof-of-concept-development
       ]
     }
   ]

--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -147,7 +147,7 @@ locals {
       accounts = [
         aws_organizations_account.moj-official-network-operations-centre,
         aws_organizations_account.wptpoc,
-        aws_organizations_account,workplace-tech-proof-of-concept-development
+        aws_organizations_account, workplace-tech-proof-of-concept-development
       ]
     },
     {
@@ -162,7 +162,7 @@ locals {
         aws_organizations_account.moj-official-public-key-infrastructure,
         aws_organizations_account.moj-official-shared-services,
         aws_organizations_account.wptpoc,
-        aws_organizations_account,workplace-tech-proof-of-concept-development
+        aws_organizations_account, workplace-tech-proof-of-concept-development
       ]
     },
     {
@@ -177,7 +177,7 @@ locals {
         aws_organizations_account.moj-official-public-key-infrastructure,
         aws_organizations_account.moj-official-shared-services,
         aws_organizations_account.wptpoc,
-        aws_organizations_account,workplace-tech-proof-of-concept-development
+        aws_organizations_account, workplace-tech-proof-of-concept-development
       ]
     }
   ]

--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -147,7 +147,7 @@ locals {
       accounts = [
         aws_organizations_account.moj-official-network-operations-centre,
         aws_organizations_account.wptpoc,
-        aws_organizations_account, workplace-tech-proof-of-concept-development
+        aws_organizations_account.workplace-tech-proof-of-concept-development
       ]
     },
     {
@@ -162,7 +162,7 @@ locals {
         aws_organizations_account.moj-official-public-key-infrastructure,
         aws_organizations_account.moj-official-shared-services,
         aws_organizations_account.wptpoc,
-        aws_organizations_account, workplace-tech-proof-of-concept-development
+        aws_organizations_account.workplace-tech-proof-of-concept-development
       ]
     },
     {
@@ -177,7 +177,7 @@ locals {
         aws_organizations_account.moj-official-public-key-infrastructure,
         aws_organizations_account.moj-official-shared-services,
         aws_organizations_account.wptpoc,
-        aws_organizations_account, workplace-tech-proof-of-concept-development
+        aws_organizations_account.workplace-tech-proof-of-concept-development
       ]
     }
   ]


### PR DESCRIPTION
Enabling AWS SSO for MoJ Official accounts 

Add cloud-ops-admin github group as admins on MoJO/WTP accounts
Add moj-official-techops as read-only on MoJO/WTP accounts
Add moj-official-techops as read-only on WTP accounts