### PR TITLE
Enable GuardDuty in Asia Pacific (Osaka)

### DIFF
--- a/terraform/guardduty.tf
+++ b/terraform/guardduty.tf
@@ -246,6 +246,37 @@ module "guardduty-ap-south-1" {
   ]
 }
 
+module "guardduty-ap-northeast-3" {
+  source = "./modules/guardduty"
+
+  providers = {
+    aws.root-account            = aws.aws-root-account-ap-northeast-3
+    aws.delegated-administrator = aws.organisation-security-ap-northeast-3
+  }
+
+  # Automatically enable GuardDuty for ap-northeast-3
+  auto_enable = true
+
+  # Enrol accounts created prior to the auto_enable flag being set
+  enrolled_into_guardduty = local.enrolled_into_guardduty
+
+  destination_arn = aws_s3_bucket.guardduty-bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+  filterable_security_accounts = [aws_organizations_account.security-operations-development.id]
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags-organisation-management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_organizations_organization.default,
+    aws_s3_bucket_policy.guardduty-bucket-policy
+  ]
+}
+
 module "guardduty-ap-northeast-2" {
   source = "./modules/guardduty"
 

--- a/terraform/providers-organisation-security.tf
+++ b/terraform/providers-organisation-security.tf
@@ -52,6 +52,16 @@ provider "aws" {
   }
 }
 
+# ap-northeast-3
+provider "aws" {
+  region = "ap-northeast-3"
+  alias  = "organisation-security-ap-northeast-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation-security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
 # ap-northeast-2
 provider "aws" {
   region = "ap-northeast-2"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -37,6 +37,12 @@ provider "aws" {
   alias  = "aws-root-account-ap-south-1"
 }
 
+# ap-northeast-3
+provider "aws" {
+  region = "ap-northeast-3"
+  alias  = "aws-root-account-ap-northeast-3"
+}
+
 # ap-northeast-2
 provider "aws" {
   region = "ap-northeast-2"


### PR DESCRIPTION
Asia Pacific (Osaka) was [made generally available on 1st March 2021](https://aws.amazon.com/blogs/aws/aws-asia-pacific-osaka-region-now-open-to-all-with-three-azs-more-services/), so this PR enables GuardDuty in that region.