### PR TITLE
add azure team to the MoJO AWS accounts

### DIFF
--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -180,6 +180,22 @@ locals {
       ]
     },
     {
+      github_team    = "cloud-ops-alz-admins"
+      permission_set = aws_ssoadmin_permission_set.administrator-access
+      accounts = [
+        aws_organizations_account.moj-official-development
+      ]
+    },
+    {
+      github_team    = "cloud-ops-alz-admins"
+      permission_set = aws_ssoadmin_permission_set.read-only-access
+      accounts = [
+        aws_organizations_account.moj-official-production,
+        aws_organizations_account.moj-official-pre-production,
+        aws_organizations_account.moj-official-shared-services,
+      ]
+    },
+    {
       github_team    = "hmpps-migration"
       permission_set = aws_ssoadmin_permission_set.read-only-access
       accounts = [


### PR DESCRIPTION
For Azure Landing Zone team.
Assign admin role to MoJO Development
Assign read-only to all other MoJO accounts including, Shared Services, Prep, Prod.