### PR TITLE
Update Mod Platform Developer role to include SSM session permissions

### DIFF
--- a/terraform/sso-admin-permission-sets.tf
+++ b/terraform/sso-admin-permission-sets.tf
@@ -185,6 +185,11 @@ data "aws_iam_policy_document" "modernisation-platform-developer-additional" {
       "ssm:GetParameters",
       "ssm:GetParameter",
       "ssm:DescribeParameters",
+      "ssm:StartSession",
+      "ssm:TerminateSession",
+      "ssm:ResumeSession",
+      "ssm:DescribeSessions",
+      "ssm:GetConnectionStatus"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
In order for Developers to make use of the bastions provided by the Mod 
Platform these permissions need to be added to their role.