### PR TITLE
Give MP eng team read only access to moj off prod

### DIFF
--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -74,12 +74,20 @@ locals {
         aws_organizations_account.modernisation-platform
       ]
     },
-    # Modernisation Platform engineers
+    # Modernisation Platform engineers sso read only
     {
       github_team    = "modernisation-platform-engineers"
       permission_set = aws_ssoadmin_permission_set.aws-sso-readonly
       accounts = [
         { id = local.caller_identity.account_id, name = "MoJ root account" }
+      ]
+    },
+    # Modernisation Platform engineers read only
+    {
+      github_team    = "modernisation-platform-engineers"
+      permission_set = aws_ssoadmin_permission_set.read-only-access
+      accounts = [
+        aws_organizations_account.moj-official-production
       ]
     },
     # Cloud Platform (Webops) access


### PR DESCRIPTION
Give the modernisation-platform-engineers team read only access to the
moj-official-production account. This is to allow the viewing of
transit gateways and associated route tables.