### PR TITLE
Give MP developer role kms decrypt

### DIFF
--- a/terraform/sso-admin-permission-sets.tf
+++ b/terraform/sso-admin-permission-sets.tf
@@ -189,7 +189,8 @@ data "aws_iam_policy_document" "modernisation-platform-developer-additional" {
       "ssm:TerminateSession",
       "ssm:ResumeSession",
       "ssm:DescribeSessions",
-      "ssm:GetConnectionStatus"
+      "ssm:GetConnectionStatus",
+      "kms:Decrypt*"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
Turns out the ReadOnlyAccess role doesn't have kms decrypt permissions.
Adding here to allow developers to decrypt KMS encrypted items (if the
KMS policy allows them to)