### PR TITLE
Upgrade to Terraform 1.0

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -40,9 +40,9 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "3.61.0"
-  constraints = ">= 3.20.0, >= 3.27.0, >= 3.28.0"
+  constraints = ">= 3.20.0, >= 3.27.0, >= 3.60.0"
   hashes = [
-    "h1:0WQSlLpN11nCeKu/k07BwcpypK0AfZDcbfkCxI/QbiE=",
+    "h1:fpZ14qQnn+uEOO2ZOlBFHgty48Ol8IOwd+ewxZ4z3zc=",
     "zh:0483ca802ddb0ae4f73144b4357ba72242c6e2641aeb460b1aa9a6f6965464b0",
     "zh:274712214ebeb0c1269cbc468e5705bb5741dc45b05c05e9793ca97f22a1baa1",
     "zh:3c6bd97a2ca809469ae38f6893348386c476cb3065b120b785353c1507401adf",

--- a/terraform/modules/guardduty/providers.tf
+++ b/terraform/modules/guardduty/providers.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  alias = "root-account"
-}
-
-provider "aws" {
-  alias = "delegated-administrator"
-}

--- a/terraform/modules/guardduty/versions.tf
+++ b/terraform/modules/guardduty/versions.tf
@@ -3,7 +3,11 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 3.27.0"
+      configuration_aliases = [
+        aws.root-account,
+        aws.delegated-administrator
+      ]
     }
   }
-  required_version = ">= 0.14.2"
+  required_version = ">= 0.15.0"
 }

--- a/terraform/modules/securityhub/main.tf
+++ b/terraform/modules/securityhub/main.tf
@@ -92,7 +92,7 @@ resource "aws_securityhub_member" "delegated-administrator" {
   # Note that this resource returns an UnprocessedAccount error when a member is removed, so you need to login to the AWS console
   # and do it manually, however, no one should be removed once enrolled.
   # See: https://docs.aws.amazon.com/guardduty/latest/APIReference/API_UnprocessedAccount.html
-  for_each = var.enrolled_into_securityhub
+  for_each = nonsensitive(var.enrolled_into_securityhub)
 
   # We want to add these accounts as members within the delegated administrator account
   account_id = each.value

--- a/terraform/modules/securityhub/providers.tf
+++ b/terraform/modules/securityhub/providers.tf
@@ -1,7 +1,0 @@
-provider "aws" {
-  alias = "root-account"
-}
-
-provider "aws" {
-  alias = "delegated-administrator"
-}

--- a/terraform/modules/securityhub/versions.tf
+++ b/terraform/modules/securityhub/versions.tf
@@ -3,7 +3,11 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 3.27.0"
+      configuration_aliases = [
+        aws.root-account,
+        aws.delegated-administrator
+      ]
     }
   }
-  required_version = ">= 0.14.2"
+  required_version = ">= 0.15.0"
 }

--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -257,7 +257,7 @@ locals {
 }
 
 resource "aws_ssoadmin_account_assignment" "account-assignments" {
-  for_each = tomap(local.teams_to_account_assignments_with_keys)
+  for_each = tomap(nonsensitive(local.teams_to_account_assignments_with_keys))
 
   # Instance
   instance_arn = local.sso_instance_arn

--- a/terraform/sso-identity-store-groups.tf
+++ b/terraform/sso-identity-store-groups.tf
@@ -1,11 +1,8 @@
-# This uses the local.groups_to_account_assignments keys, and looks up all of the groups
+# This uses the local.teams_to_account_assignments list, and looks up the teams
 # defined there (see: sso-admin-account-assignment.tf)
 
 data "aws_identitystore_group" "groups" {
-  for_each = toset([
-    for assignment in local.teams_to_account_assignments_with_keys :
-    assignment.github_team
-  ])
+  for_each = toset(distinct(local.teams_to_account_assignments[*].github_team))
 
   identity_store_id = local.sso_identity_store_id
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.14.4"
+  required_version = ">= 0.15.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.28.0"
+      version = ">= 3.60.0"
     }
   }
 }


### PR DESCRIPTION
This PR updates this repository to work with Terraform 1.0.

It does 3 things:

- Updates the GuardDuty and Security Hub modules to use `configuration_aliases` rather than provider blocks ([Alternative Provider Configurations Within Modules](https://www.terraform.io/upgrade-guides/0-15.html#alternative-provider-configurations-within-modules))
- Explicitly marks values used as part of AWS SSO and Security Hub as nonsensitive, as Terraform is conservative with value sensitivity ([Sensitive Output Values](https://www.terraform.io/upgrade-guides/0-15.html#sensitive-output-values))
- Updates the required Terraform version to be 0.15, as Terraform 1.0 is the stable continuation of 0.15 (see [the Terraform 1.0 changelog](https://github.com/hashicorp/terraform/blob/v1.0/CHANGELOG.md#100-june-08-2021) where it mentions "You can consider the v1.0 series as a direct continuation of the v0.15 series; we do not intend to issue any further releases in the v0.15 series, because all of the v1.0 releases will be only minor updates to address bugs.")