### PR TITLE
Update iam_s3_replication_role to v3.0.0

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -9,7 +9,7 @@ module "iam_password_policy" {
 
 # IAM role for S3 bucket replication
 module "iam_s3_replication_role" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=v1.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role?ref=v3.0.0"
   buckets = [
     module.cloudtrail.s3_bucket.arn,
     module.cloudtrail.log_bucket.arn


### PR DESCRIPTION
This PR requires #272.

- `iam_s3_replication_role` [v2.0.0](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role/commit/6152a007d6debcd3407908836aba4c808ed4751f) requires Terraform v1.0, in which #272 resolves for this repository
- `iam_s3_replication_role` [v3.0.0](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket-replication-role/commit/0f69ab864bad75c9cd2c6ba96fae73f546754b62) amends the policy to allow targeted bucket permissions and extra actions related to replication

Resolves ministryofjustice/operations-engineering#195.