### PR TITLE
Add versions.tf to AWS Config modules

### DIFF
--- a/terraform/modules/config-aggregation-bucket/versions.tf
+++ b/terraform/modules/config-aggregation-bucket/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.27.0"
+    }
+  }
+  required_version = ">= 0.15.0"
+}

--- a/terraform/modules/config-aggregation-sns/versions.tf
+++ b/terraform/modules/config-aggregation-sns/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.27.0"
+    }
+  }
+  required_version = ">= 0.15.0"
+}

--- a/terraform/modules/config-iam-role/versions.tf
+++ b/terraform/modules/config-iam-role/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.27.0"
+    }
+  }
+  required_version = ">= 0.15.0"
+}

--- a/terraform/modules/config/versions.tf
+++ b/terraform/modules/config/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.27.0"
+    }
+  }
+  required_version = ">= 0.15.0"
+}


### PR DESCRIPTION
This PR adds missing `versions.tf` files for modules within this repository; to fix Terraform warnings regarding missing default provider declarations.