### PR TITLE
Increase SSO timeout for mp developer role

### DIFF
--- a/terraform/sso-admin-permission-sets.tf
+++ b/terraform/sso-admin-permission-sets.tf
@@ -160,7 +160,7 @@ resource "aws_ssoadmin_managed_policy_attachment" "opg-breakglass-policy" {
 resource "aws_ssoadmin_permission_set" "modernisation-platform-developer" {
   name             = "modernisation-platform-developer"
   instance_arn     = local.sso_instance_arn
-  session_duration = "PT1H"
+  session_duration = "PT8H"
 }
 
 resource "aws_ssoadmin_managed_policy_attachment" "modernisation-platform-developer-policy" {


### PR DESCRIPTION
The timeout can be set between 1-12 hours
(https://docs.aws.amazon.com/singlesignon/latest/userguide/howtosessionduration.html)
Following feedback from developers that it was timing out quiet often we
are increasing this to 8 so that a full working day can be completed in
a single sign on.