### PR TITLE
Add detach policy permissions

### DIFF
--- a/terraform/iam-policies.tf
+++ b/terraform/iam-policies.tf
@@ -165,6 +165,7 @@ data "aws_iam_policy_document" "terraform-organisation-management-policy-scp" {
       "organizations:AttachPolicy",
       "organizations:CreatePolicy",
       "organizations:UpdatePolicy",
+      "organizations:DetachPolicy",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
This group needs to be able to detach policies as well as edit them, this is so that the policies can be temporarily detached to allow deletion of accounts.