### PR TITLE
Enable region aggregation in Security Hub

### DIFF
--- a/terraform/modules/securityhub/main.tf
+++ b/terraform/modules/securityhub/main.tf
@@ -83,6 +83,18 @@ resource "aws_securityhub_organization_admin_account" "default" {
   ]
 }
 
+# Enable region aggregation in the delegated administrator account
+resource "aws_securityhub_finding_aggregator" "delegated-administrator" {
+  for_each = var.aggregation_region == true ? toset(["aggregator"]) : toset([])
+
+  provider = aws.delegated-administrator
+
+  linking_mode = "ALL_REGIONS"
+  depends_on = [
+    aws_securityhub_organization_admin_account.default
+  ]
+}
+
 ################################
 # Security Hub member accounts #
 ################################

--- a/terraform/modules/securityhub/variables.tf
+++ b/terraform/modules/securityhub/variables.tf
@@ -2,3 +2,9 @@ variable "enrolled_into_securityhub" {
   description = "Map of key => values where key is the account name and the value is the account ID"
   type        = map(any)
 }
+
+variable "aggregation_region" {
+  description = "Whether to use this region for all region aggregation"
+  type        = bool
+  default     = false
+}

--- a/terraform/securityhub.tf
+++ b/terraform/securityhub.tf
@@ -123,6 +123,8 @@ module "securityhub-eu-west-2" {
     aws.delegated-administrator = aws.organisation-security-eu-west-2
   }
 
+  aggregation_region = true
+
   enrolled_into_securityhub = {
     for account in local.enrolled_into_securityhub :
     account.name => account.id


### PR DESCRIPTION
This PR enables region aggregation for Security Hub findings into `eu-west-2` using the new Terraform resource, [securityhub_finding_aggregator](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_finding_aggregator).