### PR TITLE
Enable Config trusted access

### DIFF
--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -2,6 +2,7 @@ resource "aws_organizations_organization" "default" {
   aws_service_access_principals = [
     "access-analyzer.amazonaws.com",
     "compute-optimizer.amazonaws.com",
+    "config.amazonaws.com",
     "guardduty.amazonaws.com",
     "health.amazonaws.com",
     "ram.amazonaws.com",


### PR DESCRIPTION
This PR enables Config's trusted access, to allow implementation of a [multi-region, multi-account aggregator](https://docs.aws.amazon.com/config/latest/developerguide/aggregate-data.html) in the delegated administrator account.