### PR TITLE
Simplify Security Hub enrolment

### DIFF
--- a/terraform/modules/securityhub/variables.tf
+++ b/terraform/modules/securityhub/variables.tf
@@ -1,6 +1,7 @@
 variable "enrolled_into_securityhub" {
   description = "Map of key => values where key is the account name and the value is the account ID"
   type        = map(any)
+  default     = {}
 }
 
 variable "aggregation_region" {

--- a/terraform/securityhub.tf
+++ b/terraform/securityhub.tf
@@ -11,122 +11,53 @@
 # Security Hub will alert you if AWS Config (a prerequesite for Security Hub) isn't enabled
 # in the region you're adding an member account to.
 locals {
-  enrolled_into_securityhub = concat([
-    { id = local.caller_identity.account_id, name = "MoJ root account" },
-    aws_organizations_account.alfresco-non-prod,
-    aws_organizations_account.analytical-platform-data-engineering,
-    aws_organizations_account.analytical-platform-development,
-    aws_organizations_account.analytical-platform-landing,
-    aws_organizations_account.analytical-platform-production,
-    aws_organizations_account.analytics-platform-development,
-    aws_organizations_account.cica,
-    aws_organizations_account.cica-development,
-    aws_organizations_account.cica-test-verify,
-    aws_organizations_account.cica-uat,
-    aws_organizations_account.cloud-platform,
-    aws_organizations_account.cloud-platform-ephemeral-test,
-    aws_organizations_account.cloud-platform-transit-gateways,
-    aws_organizations_account.delius-core-non-prod,
-    aws_organizations_account.delius-new-tech-non-prod,
-    aws_organizations_account.electronic-monitoring-acquisitive-crime-development,
-    aws_organizations_account.electronic-monitoring-acquisitive-crime-preproduction,
-    aws_organizations_account.electronic-monitoring-acquisitive-crime-production,
-    aws_organizations_account.electronic-monitoring-acquisitive-crime-test,
-    aws_organizations_account.electronic-monitoring-archive-query-service,
-    aws_organizations_account.electronic-monitoring-identity-access-management,
-    aws_organizations_account.electronic-monitoring-infrastructure-dev,
-    aws_organizations_account.electronic-monitoring-monitoring-mapping-dev,
-    aws_organizations_account.electronic-monitoring-monitoring-mapping-pre-prod,
-    aws_organizations_account.electronic-monitoring-monitoring-mapping-prod,
-    aws_organizations_account.electronic-monitoring-monitoring-mapping-test,
-    aws_organizations_account.electronic-monitoring-protective-monitoring,
-    aws_organizations_account.electronic-monitoring-shared-logging,
-    aws_organizations_account.electronic-monitoring-shared-networking,
-    aws_organizations_account.electronic-monitoring-shared-networking-non-prod,
-    aws_organizations_account.electronic-monitoring-tagging-hardware-pre-prod,
-    aws_organizations_account.electronic-monitoring-tagging-hardware-prod,
-    aws_organizations_account.electronic-monitoring-tagging-hardware-test,
-    aws_organizations_account.hmpps-co-financing-organisation,
-    aws_organizations_account.hmpps-community-rehabilitation-jira-non-production,
-    aws_organizations_account.hmpps-community-rehabilitation-jira-production,
-    aws_organizations_account.hmpps-community-rehabilitation-jitbit-non-production,
-    aws_organizations_account.hmpps-community-rehabilitation-jitbit-production,
-    aws_organizations_account.hmpps-community-rehabilitation-unpaid-work-non-production,
-    aws_organizations_account.hmpps-community-rehabilitation-unpaid-work-production,
-    aws_organizations_account.hmpps-delius-mis-non-prod,
-    aws_organizations_account.hmpps-delius-performance,
-    aws_organizations_account.hmpps-delius-po-test-1,
-    aws_organizations_account.hmpps-delius-po-test-2,
-    aws_organizations_account.hmpps-delius-pre-production,
-    aws_organizations_account.hmpps-delius-stage,
-    aws_organizations_account.hmpps-delius-test,
-    aws_organizations_account.hmpps-delius-training,
-    aws_organizations_account.hmpps-delius-training-test,
-    aws_organizations_account.hmpps-dev,
-    aws_organizations_account.hmpps-engineering-production,
-    aws_organizations_account.hmpps-management,
-    aws_organizations_account.hmpps-probation-production,
-    aws_organizations_account.hmpps-prod,
-    aws_organizations_account.hmpps-security-audit,
-    aws_organizations_account.hmpps-victim-case-management-system-integration,
-    aws_organizations_account.hmpps-victim-case-management-system-performance,
-    aws_organizations_account.hmpps-victim-case-management-system-pre-production,
-    aws_organizations_account.hmpps-victim-case-management-system-production,
-    aws_organizations_account.hmpps-victim-case-management-system-stage,
-    aws_organizations_account.hmpps-victim-case-management-system-test,
-    aws_organizations_account.laa-cloudtrail,
-    aws_organizations_account.laa-development,
-    aws_organizations_account.laa-production,
-    aws_organizations_account.laa-shared-services,
-    aws_organizations_account.laa-staging,
-    aws_organizations_account.laa-test,
-    aws_organizations_account.laa-uat,
-    aws_organizations_account.legal-aid-agency,
-    aws_organizations_account.ministry-of-justice-courtfinder-prod,
-    aws_organizations_account.modernisation-platform,
-    aws_organizations_account.moj-analytics-platform,
-    aws_organizations_account.moj-cla,
-    aws_organizations_account.moj-digital-services,
-    aws_organizations_account.moj-info-services-dev,
-    aws_organizations_account.moj-lpa-preproduction,
-    aws_organizations_account.moj-official-development,
-    aws_organizations_account.moj-official-network-operations-centre,
-    aws_organizations_account.moj-official-pre-production,
-    aws_organizations_account.moj-official-production,
-    aws_organizations_account.moj-official-public-key-infrastructure,
-    aws_organizations_account.moj-official-public-key-infrastructure-dev,
-    aws_organizations_account.moj-official-shared-services,
-    aws_organizations_account.moj-opg-lpa-production,
-    aws_organizations_account.moj-opg-lpa-refunds-preproduction,
-    aws_organizations_account.moj-opg-lpa-refunds-production,
-    aws_organizations_account.moj-opg-shared-development,
-    aws_organizations_account.moj-opg-shared-production,
-    aws_organizations_account.moj-opg-sirius-preproduction,
-    aws_organizations_account.moj-security,
-    aws_organizations_account.network-architecture,
-    aws_organizations_account.opg-backups,
-    aws_organizations_account.opg-digi-deps-preprod,
-    aws_organizations_account.opg-digi-deps-prod,
-    aws_organizations_account.opg-sirius-backup,
-    aws_organizations_account.opg-sirius-production,
-    aws_organizations_account.opg-use-my-lpa-development,
-    aws_organizations_account.opg-use-my-lpa-preproduction,
-    aws_organizations_account.opg-use-my-lpa-production,
-    aws_organizations_account.probation,
-    aws_organizations_account.probation-management-non-prod,
-    aws_organizations_account.public-sector-prison-industries,
-    aws_organizations_account.security-engineering,
-    aws_organizations_account.security-logging-platform,
-    aws_organizations_account.security-operations-development,
-    aws_organizations_account.security-operations-pre-production,
-    aws_organizations_account.security-operations-production,
-    aws_organizations_account.strategic-partner-gateway-non-production,
-    aws_organizations_account.tacticalproducts,
-    aws_organizations_account.tp-hmcts,
-    aws_organizations_account.vcms-non-prod,
-    aws_organizations_account.workplace-tech-proof-of-concept-development,
-    aws_organizations_account.wptpoc,
-  ], local.modernisation-platform-managed-account-ids)
+  not_enrolled_into_securityhub = [
+    aws_organizations_account.aws-laa.id,
+    aws_organizations_account.cloud-networks-psn.id,
+    aws_organizations_account.hmcts-fee-remissions.id,
+    aws_organizations_account.hmpps-check-my-diary-development.id,
+    aws_organizations_account.hmpps-check-my-diary-prod.id,
+    aws_organizations_account.hmpps-delius-mis-test.id,
+    aws_organizations_account.hmpps-delius-po-test.id,
+    aws_organizations_account.hmpps-performance-hub.id,
+    aws_organizations_account.hmpps-security-poc.id,
+    aws_organizations_account.manchester-traffic-dev.id,
+    aws_organizations_account.moj-lpa-development.id,
+    aws_organizations_account.moj-opg-digicop-development.id,
+    aws_organizations_account.moj-opg-digicop-preproduction.id,
+    aws_organizations_account.moj-opg-digicop-production.id,
+    aws_organizations_account.moj-opg-identity.id,
+    aws_organizations_account.moj-opg-lpa-refunds-development.id,
+    aws_organizations_account.moj-opg-management.id,
+    aws_organizations_account.moj-opg-sandbox.id,
+    aws_organizations_account.moj-opg-sirius-development.id,
+    aws_organizations_account.moj-opg-sirius-production.id,
+    aws_organizations_account.noms-api.id,
+    aws_organizations_account.opg-digi-deps-dev.id,
+    aws_organizations_account.opg-lpa-production.id,
+    aws_organizations_account.opg-refund-develop.id,
+    aws_organizations_account.opg-refund-production.id,
+    aws_organizations_account.opg-shared.id,
+    aws_organizations_account.opg-sirius-dev.id,
+    aws_organizations_account.organisation-logging.id,
+    aws_organizations_account.patterns.id,
+    aws_organizations_account.platforms-non-production.id,
+    aws_organizations_account.youth-justice-framework-dev.id,
+    aws_organizations_account.youth-justice-framework-eng-tools.id,
+    aws_organizations_account.youth-justice-framework-juniper.id,
+    aws_organizations_account.youth-justice-framework-management.id,
+    aws_organizations_account.youth-justice-framework-monitoring.id,
+    aws_organizations_account.youth-justice-framework-pre-prod.id,
+    aws_organizations_account.youth-justice-framework-prod.id,
+    aws_organizations_account.youth-justice-framework-sandpit.id
+  ]
+  enrolled_into_securityhub = {
+    for account in aws_organizations_organization.default.accounts :
+    account.name => account.id
+    # Don't enrol the organisation-security account (as it'll already be enabled as the delegated administrator)
+    # Don't enrol suspended or removed (i.e. deleted) accounts
+    if account.status == "ACTIVE" && account.name != "organisation-security" && !contains(local.not_enrolled_into_securityhub, account.id)
+  }
 }
 
 ##############################
@@ -142,10 +73,7 @@ module "securityhub-eu-west-2" {
 
   aggregation_region = true
 
-  enrolled_into_securityhub = {
-    for account in local.enrolled_into_securityhub :
-    account.name => account.id
-  }
+  enrolled_into_securityhub = local.enrolled_into_securityhub
 
   depends_on = [aws_organizations_organization.default]
 }
@@ -158,10 +86,7 @@ module "securityhub-eu-west-1" {
     aws.delegated-administrator = aws.organisation-security-eu-west-1
   }
 
-  enrolled_into_securityhub = {
-    for account in local.enrolled_into_securityhub :
-    account.name => account.id
-  }
+  enrolled_into_securityhub = local.enrolled_into_securityhub
 
   depends_on = [aws_organizations_organization.default]
 }


### PR DESCRIPTION
This PR inverts enrolment lists from "enrolled" to filtering out "not enrolled" to match [GuardDuty](https://github.com/ministryofjustice/aws-root-account/blob/main/terraform/guardduty.tf#L39).