### PR TITLE
Enrol YJAF Sandpit into central Security Hub

### DIFF
--- a/terraform/securityhub.tf
+++ b/terraform/securityhub.tf
@@ -48,8 +48,7 @@ locals {
     aws_organizations_account.youth-justice-framework-management.id,
     aws_organizations_account.youth-justice-framework-monitoring.id,
     aws_organizations_account.youth-justice-framework-pre-prod.id,
-    aws_organizations_account.youth-justice-framework-prod.id,
-    aws_organizations_account.youth-justice-framework-sandpit.id
+    aws_organizations_account.youth-justice-framework-prod.id
   ]
   enrolled_into_securityhub = {
     for account in aws_organizations_organization.default.accounts :


### PR DESCRIPTION
As per conversations with YJB, this PR enrols YJAF Sandpit into central Security Hub to allow them to test internal integrations before enrolling their other accounts.