### PR TITLE
Create an IAM role & policy to allow MOJ DSD to access the Organizations account list

### DIFF
--- a/terraform/iam-policies.tf
+++ b/terraform/iam-policies.tf
@@ -217,3 +217,24 @@ resource "aws_iam_policy" "cost-explorer-readonly" {
   description = "A policy to allow teams to read Cost Explorer data"
   policy      = data.aws_iam_policy_document.cost-explorer-readonly.json
 }
+
+# Organizations list policy
+data "aws_iam_policy_document" "organization-accounts-readonly" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "organizations:List*",
+      "organizations:Describe*",
+      "organizations:Get*"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "organization-accounts-readonly" {
+  name        = "AWSOrganizationsListReadOnly"
+  description = "A policy to allow teams to read Organizations lists"
+  policy      = data.aws_iam_policy_document.organization-accounts-readonly.json
+}

--- a/terraform/iam-roles.tf
+++ b/terraform/iam-roles.tf
@@ -148,3 +148,29 @@ resource "aws_iam_role_policy_attachment" "cost-explorer-access" {
   role       = aws_iam_role.cost-explorer-access.name
   policy_arn = aws_iam_policy.cost-explorer-readonly.arn
 }
+
+# Organization list read-only role, assumable by teams (currently only MOJ DSD) to list Organization accounts
+data "aws_iam_policy_document" "organization-accounts-assume-role" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${aws_organizations_account.moj-digital-services.id}:root"]
+    }
+  }
+}
+
+resource "aws_iam_role" "organization-accounts-access" {
+  name               = "AWSOrganizationsListReadOnly"
+  assume_role_policy = data.aws_iam_policy_document.organization-accounts-assume-role.json
+  tags               = local.root_account
+}
+
+resource "aws_iam_role_policy_attachment" "organization-accounts-access" {
+  role       = aws_iam_role.organization-accounts-access.name
+  policy_arn = aws_iam_policy.organization-accounts-readonly.arn
+}


### PR DESCRIPTION
This role and associated policy allows the MOJ DSD AWS account to access the root organizations account list, so we don't expose account IDs in GitHub. For example, for [HMCTS Fee Remissions](https://github.com/ministryofjustice/dns-iac/blob/main/terraform/et.dsd.io.tf#L485).