### PR TITLE
add ec2:create and snap image for palo alto deployments

### DIFF
--- a/terraform/sso-admin-permission-sets.tf
+++ b/terraform/sso-admin-permission-sets.tf
@@ -269,6 +269,8 @@ resource "aws_ssoadmin_managed_policy_attachment" "techops-operator-policy" {
 data "aws_iam_policy_document" "techops-operator-additional" {
   statement {
     actions = [
+      "ec2:CreateSnapshot",
+      "ec2:CreateImage",
       "ec2:StartInstances",
       "ec2:StopInstances",
       "ec2:RebootInstances",


### PR DESCRIPTION
The network operations team needs to create images for the VM-Series Palo Alto firewalls, this action should allow them to update the firewall VM image for the pipeline deployment.