### PR TITLE
Move Cloud Networks PSN to Workplace Technology OU

### DIFF
--- a/terraform/organizations-accounts-central-digital.tf
+++ b/terraform/organizations-accounts-central-digital.tf
@@ -1,21 +1,4 @@
 # Central Digital OU
-resource "aws_organizations_account" "cloud-networks-psn" {
-  name      = "Cloud Networks PSN"
-  email     = local.aws_account_email_addresses["Cloud Networks PSN"][0]
-  parent_id = aws_organizations_organizational_unit.central-digital.id
-
-  lifecycle {
-    # If any of these attributes are changed, it attempts to destroy and recreate the account,
-    # so we should ignore the changes to prevent this from happening.
-    ignore_changes = [
-      name,
-      email,
-      iam_user_access_to_billing,
-      role_name
-    ]
-  }
-}
-
 resource "aws_organizations_account" "moj-digital-services" {
   name      = "MoJ Digital Services"
   email     = local.aws_account_email_addresses["MoJ Digital Services"][0]

--- a/terraform/organizations-accounts-workplace-technology.tf
+++ b/terraform/organizations-accounts-workplace-technology.tf
@@ -6,6 +6,23 @@ locals {
 }
 
 # Workplace Technology OU
+resource "aws_organizations_account" "cloud-networks-psn" {
+  name      = "Cloud Networks PSN"
+  email     = local.aws_account_email_addresses["Cloud Networks PSN"][0]
+  parent_id = aws_organizations_organizational_unit.workplace-technology.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}
+
 resource "aws_organizations_account" "workplace-tech-proof-of-concept-development" {
   name      = "Workplace Tech Proof Of Concept Development"
   email     = local.aws_account_email_addresses["Workplace Tech Proof Of Concept Development"][0]


### PR DESCRIPTION
`Cloud Networks PSN` is owned by Technology Services, so this moves the account to the correct organisational unit.