### PR TITLE
Move AWS LAA to Closed accounts

### DIFF
--- a/terraform/organizations-accounts-closed-accounts.tf
+++ b/terraform/organizations-accounts-closed-accounts.tf
@@ -48,3 +48,21 @@ resource "aws_organizations_account" "moj-cla" {
     ]
   }
 }
+
+# This has MFA with a mobile number, so we can't suspend it yet, but it is closed (all resources deleted).
+resource "aws_organizations_account" "aws-laa" {
+  name      = "AWS LAA"
+  email     = local.aws_account_email_addresses["AWS LAA"][0]
+  parent_id = aws_organizations_organizational_unit.closed-accounts.id
+
+  lifecycle {
+    # If any of these attributes are changed, it attempts to destroy and recreate the account,
+    # so we should ignore the changes to prevent this from happening.
+    ignore_changes = [
+      name,
+      email,
+      iam_user_access_to_billing,
+      role_name
+    ]
+  }
+}

--- a/terraform/organizations-accounts-laa.tf
+++ b/terraform/organizations-accounts-laa.tf
@@ -45,29 +45,6 @@ resource "aws_organizations_policy_attachment" "laa-uat-restricted-regions" {
   target_id = aws_organizations_account.laa-uat.id
 }
 
-resource "aws_organizations_account" "aws-laa" {
-  name      = "AWS LAA"
-  email     = local.aws_account_email_addresses["AWS LAA"][0]
-  parent_id = aws_organizations_organizational_unit.laa.id
-
-  lifecycle {
-    # If any of these attributes are changed, it attempts to destroy and recreate the account,
-    # so we should ignore the changes to prevent this from happening.
-    ignore_changes = [
-      name,
-      email,
-      iam_user_access_to_billing,
-      role_name
-    ]
-  }
-}
-
-# Enrol AWS LAA to the restricted regions policy
-resource "aws_organizations_policy_attachment" "aws-laa-restricted-regions" {
-  policy_id = aws_organizations_policy.deny-non-eu-non-us-east-1-operations.id
-  target_id = aws_organizations_account.aws-laa.id
-}
-
 resource "aws_organizations_account" "laa-staging" {
   name      = "LAA Staging"
   email     = local.aws_account_email_addresses["LAA Staging"][0]


### PR DESCRIPTION
@said-moj has confirmed this account is no longer used, so the resources inside have been deleted (S3 objects, KMS keys, old CloudWatch logs). This will move this account to the closed accounts OU.