### PR TITLE
Add SCP for Closed accounts: deny all actions on all resources

### DIFF
--- a/terraform/organizations-organizational-units.tf
+++ b/terraform/organizations-organizational-units.tf
@@ -10,6 +10,11 @@ resource "aws_organizations_organizational_unit" "closed-accounts" {
   parent_id = aws_organizations_organization.default.roots[0].id
 }
 
+resource "aws_organizations_policy_attachment" "closed-accounts-deny-all" {
+  policy_id = aws_organizations_policy.deny-all.id
+  target_id = aws_organizations_organizational_unit.closed-accounts.id
+}
+
 # OPG
 resource "aws_organizations_organizational_unit" "opg" {
   name      = "OPG"

--- a/terraform/organizations-service-control-policies.tf
+++ b/terraform/organizations-service-control-policies.tf
@@ -141,3 +141,27 @@ resource "aws_organizations_policy" "deny-root-user" {
     source-code   = join("", [local.github_repository, "/organizations-service-control-policies.tf"])
   }
 }
+
+# Denies access to anything (for suspended accounts)
+data "aws_iam_policy_document" "deny-all" {
+  version = "2021-10-17"
+
+  statement {
+    effect    = "Deny"
+    actions   = ["*"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_organizations_policy" "deny-all" {
+  name        = "Deny all actions on all resources"
+  description = "Denies the ability to do anything within an AWS account"
+  type        = "SERVICE_CONTROL_POLICY"
+  content     = data.aws_iam_policy_document.deny-all.json
+
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/organizations-service-control-policies.tf"])
+  }
+}


### PR DESCRIPTION
Some AWS accounts in Closed accounts cannot be suspended due to historic MFA configurations. This SCP denies all actions on all resources in the accounts within Closed accounts, to ensure they are no longer used.