### PR TITLE
Enable VPC IPAM for IP address management

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ for organisational audit, governance, security, and cost optimisation.
 | [Single Sign-On (SSO)](https://docs.aws.amazon.com/singlesignon/latest/userguide/what-is.html) | [yes](https://github.com/ministryofjustice/aws-root-account/blob/main/terraform/sso.tf) | :white_check_mark: yes | Trusted access |
 | [Systems Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/Explorer-resource-data-sync.html) | no | :x: no | no |
 | [Trusted Advisor (Organisational overview)](https://docs.aws.amazon.com/organizations/latest/userguide/services-that-can-integrate-ta.html) | [yes](https://github.com/ministryofjustice/aws-root-account/blob/main/terraform/organizations.tf#L11) | :white_check_mark: yes | Trusted access |
-| [VPC IP Address Manager (IPAM)](https://docs.aws.amazon.com/vpc/latest/ipam/enable-integ-ipam.html) | no | :x: no | no |
+| [VPC IP Address Manager (IPAM)](https://docs.aws.amazon.com/vpc/latest/ipam/enable-integ-ipam.html) | [yes](https://github.com/ministryofjustice/aws-root-account/blob/main/terraform/vpc-ipam.tf) | :white_check_mark: yes | Trusted access with a delegated administrator |

--- a/terraform/modules/vpc-ipam/main.tf
+++ b/terraform/modules/vpc-ipam/main.tf
@@ -1,0 +1,49 @@
+#############################
+# VPC IP Address Management #
+#############################
+
+# Get current region
+data "aws_region" "current" {
+  provider = aws.root-account
+}
+
+# Get the organization management account ID
+data "aws_caller_identity" "default" {
+  provider = aws.root-account
+}
+
+# Get the delegated administrator account ID
+data "aws_caller_identity" "delegated-administrator" {
+  provider = aws.delegated-administrator
+}
+
+#####################################################
+# VPC IP Address Management delegated administrator #
+#####################################################
+
+resource "aws_vpc_ipam_organization_admin_account" "default" {
+  provider = aws.root-account
+
+  delegated_admin_account_id = data.aws_caller_identity.delegated-administrator.account_id
+}
+
+#############################
+# VPC IP Address Management #
+#############################
+
+# Note that this resource configures two default scopes: public and private
+
+resource "aws_vpc_ipam" "default" {
+  provider = aws.delegated-administrator
+
+  dynamic "operating_regions" {
+    for_each = var.operating_regions
+    content {
+      region_name = operating_regions.value
+    }
+  }
+
+  depends_on = [
+    aws_vpc_ipam_organization_admin_account.default
+  ]
+}

--- a/terraform/modules/vpc-ipam/variables.tf
+++ b/terraform/modules/vpc-ipam/variables.tf
@@ -1,0 +1,22 @@
+variable "operating_regions" {
+  type = list(any)
+  default = [
+    "ap-northeast-1",
+    "ap-northeast-2",
+    "ap-northeast-3",
+    "ap-south-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ca-central-1",
+    "eu-central-1",
+    "eu-north-1",
+    "eu-west-1",
+    "eu-west-2",
+    "eu-west-3",
+    "sa-east-1",
+    "us-east-1",
+    "us-east-2",
+    "us-west-1",
+    "us-west-2",
+  ]
+}

--- a/terraform/modules/vpc-ipam/versions.tf
+++ b/terraform/modules/vpc-ipam/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.27.0"
+      configuration_aliases = [
+        aws.root-account,
+        aws.delegated-administrator
+      ]
+    }
+  }
+  required_version = ">= 0.15.0"
+}

--- a/terraform/organizations.tf
+++ b/terraform/organizations.tf
@@ -7,6 +7,7 @@ resource "aws_organizations_organization" "default" {
     "guardduty.amazonaws.com",
     "health.amazonaws.com",
     "inspector2.amazonaws.com",
+    "ipam.amazonaws.com",
     "ram.amazonaws.com",
     "reporting.trustedadvisor.amazonaws.com",
     "securityhub.amazonaws.com",

--- a/terraform/vpc-ipam.tf
+++ b/terraform/vpc-ipam.tf
@@ -1,0 +1,14 @@
+#############################
+# VPC IP Address Management #
+#############################
+
+module "vpc-ipam" {
+  source = "./modules/vpc-ipam"
+
+  providers = {
+    aws.root-account            = aws.aws-root-account-eu-west-2
+    aws.delegated-administrator = aws.organisation-security-eu-west-2
+  }
+
+  depends_on = [aws_organizations_organization.default]
+}


### PR DESCRIPTION
This PR enables [VPC IP Address Management](https://aws.amazon.com/about-aws/whats-new/2021/12/amazon-virtual-private-cloud-vpc-announces-ip-address-manager-ipam/) across the organisation. This allows for an overview of in-use CIDR blocks and IP ranges across the AWS Organization.

In the future, this may be used to automate planning, tracking, and monitoring of IP addresses for MOJ Official networks and Modernisation Platform subnet sets.