### PR TITLE
Create alternate contacts for active accounts only

### DIFF
--- a/terraform/alternate-contacts.tf
+++ b/terraform/alternate-contacts.tf
@@ -15,6 +15,7 @@ locals {
   alternate_contacts_accounts = {
     for account in aws_organizations_organization.default.accounts :
     account.name => account.id
+    if account.status == "ACTIVE"
   }
 }
 


### PR DESCRIPTION
This PR filters the account list for alternate contacts to only set the alternate contact on _active_ accounts.