### PR TITLE
UML-1881 - Set up SSO Access for Use a LPA team

### DIFF
--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -11,7 +11,7 @@ locals {
         aws_organizations_account.moj-opg-shared-development,
         aws_organizations_account.moj-opg-sandbox,
         aws_organizations_account.opg-use-my-lpa-development,
-        aws_organizations_account.opg-use-my-lpa-preproduction,
+        aws_organizations_account.opg-use-my-lpa-preproduction
       ]
     },
     {
@@ -56,7 +56,7 @@ locals {
       accounts = [
         aws_organizations_account.moj-opg-shared-development,
         aws_organizations_account.opg-use-my-lpa-development,
-        aws_organizations_account.opg-use-my-lpa-preproduction,
+        aws_organizations_account.opg-use-my-lpa-preproduction
       ]
     },
     {

--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -12,7 +12,6 @@ locals {
         aws_organizations_account.moj-opg-sandbox,
         aws_organizations_account.opg-use-my-lpa-development,
         aws_organizations_account.opg-use-my-lpa-preproduction,
-        aws_organizations_account.opg-use-my-lpa-production
       ]
     },
     {

--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -51,7 +51,7 @@ locals {
       ]
     },
     {
-      github_team    = "opg-use-an-lpa ",
+      github_team    = "opg-use-an-lpa",
       permission_set = aws_ssoadmin_permission_set.opg-breakglass,
       accounts = [
         aws_organizations_account.moj-opg-shared-development,
@@ -60,7 +60,7 @@ locals {
       ]
     },
     {
-      github_team    = "opg-use-an-lpa ",
+      github_team    = "opg-use-an-lpa",
       permission_set = aws_ssoadmin_permission_set.opg-operator,
       accounts = [
         aws_organizations_account.moj-opg-identity,

--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -9,7 +9,10 @@ locals {
         aws_organizations_account.moj-opg-shared-production,
         aws_organizations_account.moj-opg-management,
         aws_organizations_account.moj-opg-shared-development,
-        aws_organizations_account.moj-opg-sandbox
+        aws_organizations_account.moj-opg-sandbox,
+        aws_organizations_account.opg-use-my-lpa-development,
+        aws_organizations_account.opg-use-my-lpa-preproduction,
+        aws_organizations_account.opg-use-my-lpa-production
       ]
     },
     {
@@ -50,14 +53,20 @@ locals {
     },
     {
       github_team    = "opg-use-an-lpa ",
+      permission_set = aws_ssoadmin_permission_set.opg-breakglass,
+      accounts = [
+        aws_organizations_account.moj-opg-shared-development,
+        aws_organizations_account.opg-use-my-lpa-development,
+        aws_organizations_account.opg-use-my-lpa-preproduction,
+      ]
+    },
+    {
+      github_team    = "opg-use-an-lpa ",
       permission_set = aws_ssoadmin_permission_set.opg-operator,
       accounts = [
         aws_organizations_account.moj-opg-identity,
         aws_organizations_account.moj-opg-management,
-        aws_organizations_account.moj-opg-shared-development,
         aws_organizations_account.moj-opg-shared-production,
-        aws_organizations_account.opg-use-my-lpa-development,
-        aws_organizations_account.opg-use-my-lpa-preproduction,
         aws_organizations_account.opg-use-my-lpa-production
       ]
     },

--- a/terraform/sso-admin-account-assignments.tf
+++ b/terraform/sso-admin-account-assignments.tf
@@ -48,6 +48,19 @@ locals {
         aws_organizations_account.opg-use-my-lpa-production
       ]
     },
+    {
+      github_team    = "opg-use-an-lpa ",
+      permission_set = aws_ssoadmin_permission_set.opg-operator,
+      accounts = [
+        aws_organizations_account.moj-opg-identity,
+        aws_organizations_account.moj-opg-management,
+        aws_organizations_account.moj-opg-shared-development,
+        aws_organizations_account.moj-opg-shared-production,
+        aws_organizations_account.opg-use-my-lpa-development,
+        aws_organizations_account.opg-use-my-lpa-preproduction,
+        aws_organizations_account.opg-use-my-lpa-production
+      ]
+    },
     # organisation-security
     {
       github_team    = "organisation-security-auditor"

--- a/terraform/sso-admin-permission-sets.tf
+++ b/terraform/sso-admin-permission-sets.tf
@@ -147,6 +147,148 @@ resource "aws_ssoadmin_managed_policy_attachment" "opg-viewer-policy" {
   permission_set_arn = aws_ssoadmin_permission_set.opg-viewer.arn
 }
 
+# opg-operator
+resource "aws_ssoadmin_permission_set" "opg-operator" {
+  name             = "opg-operator"
+  description      = "Standard operator role given to an OPG Digital product's team members"
+  instance_arn     = local.sso_instance_arn
+  session_duration = "PT2H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "opg-operator-policy" {
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.opg-operator.arn
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "opg-operator-policy-additional" {
+  inline_policy      = data.aws_iam_policy_document.opg-operator-policy-additional.json
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.opg-operator.arn
+}
+data "aws_iam_policy_document" "opg-operator-policy-additional" {
+  statement {
+    sid       = "AdminsManageSecrets"
+    effect    = "Allow"
+    actions   = ["secretsmanager:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ViewBillingInfo"
+    effect = "Allow"
+
+    actions = [
+      "aws-portal:*",
+      "budget:*",
+      "cur:*",
+    ]
+
+    resources = ["*"]
+  }
+  statement {
+    sid    = "UalCiIdentityCognitoAccess"
+    effect = "Allow"
+    actions = [
+      "cognito:*",
+      "cognito-idp:*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Support"
+    effect = "Allow"
+
+    actions = [
+      "support:*",
+      "trustedadvisor:*",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "SNSSubscriptions"
+    effect = "Allow"
+
+    actions = [
+      "sns:subscribe",
+      "sns:unsubscribe",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ECSRunTask"
+    effect = "Allow"
+
+    actions = [
+      "ecs:RunTask",
+      "iam:PassRole",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "APIGatewayInvoke"
+    effect = "Allow"
+
+    actions = [
+      "execute-api:Invoke",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "DynamoDBDescribeTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:*Describe*",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ForbidDynamoDBAccess1"
+    effect = "Deny"
+
+    actions = [
+      "dynamodb:*Batch*",
+      "dynamodb:*Create*",
+      "dynamodb:*Delete*",
+      "dynamodb:*Get*",
+      "dynamodb:*List*",
+      "dynamodb:*Update*",
+      "dynamodb:*Tag*",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ForbidDynamoDBAccess2"
+    effect = "Deny"
+
+    actions = [
+      "dynamodb:ConditionCheckItem",
+      "dynamodb:PurchaseReservedCapacityOfferings",
+      "dynamodb:PutItem",
+      "dynamodb:Query",
+      "dynamodb:RestoreTableFromBackup",
+      "dynamodb:RestoreTableToPointInTime",
+      "dynamodb:Scan",
+    ]
+
+    resources = ["*"]
+  }
+}
+
 # opg-breakglass
 resource "aws_ssoadmin_permission_set" "opg-breakglass" {
   name             = "opg-breakglass"


### PR DESCRIPTION
# Purpose
releated to ticket https://opgtransform.atlassian.net/browse/UML-1881
Provide SSO access for team so;
- we can avoid the password given procedure that relies on keypass
- we can grant access more directly to non-developers (a simpler assume role journey)
- we can switch over to using SSO with aws-vault avoiding the need for access keys

# Approach
- create a account assignments for ual github team with admin (for non-production) and operator (for production) roles
- create permission sets for ual admin
- create permission sets for ual operator (restrict access to PII areas, grant access to services used day to day)
- allow viewer access to ual development and preproduction accounts