### PR TITLE
Remove 'Closed accounts / Remove' organizational unit

### DIFF
--- a/management-account/terraform/organizations-organizational-units.tf
+++ b/management-account/terraform/organizations-organizational-units.tf
@@ -34,13 +34,6 @@ resource "aws_organizations_organizational_unit" "closed_accounts" {
   tags      = {}
 }
 
-# Remove
-resource "aws_organizations_organizational_unit" "closed_accounts_remove" {
-  name      = "Remove"
-  parent_id = aws_organizations_organizational_unit.closed_accounts.id
-  tags      = {}
-}
-
 #########
 # HMCTS #
 #########


### PR DESCRIPTION
This organizational unit isn't used, so can be removed.