### PR TITLE
Remove "Allow all" SCPs in favour of FullAWSAccess

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -247,31 +247,6 @@ resource "aws_organizations_policy_attachment" "deny_cloudtrail_delete_stop_upda
   target_id = aws_organizations_organizational_unit.laa.id
 }
 
-######################################
-# Modernisation Platform Core OU SCP #
-######################################
-resource "aws_organizations_policy" "modernisation_platform_core_ou_scp" {
-  name        = "Modernisation Platform Core OU SCP"
-  description = "Restricts permissions for all OUs and accounts under the Modernisation Platform Core OU"
-  type        = "SERVICE_CONTROL_POLICY"
-
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
-  }
-
-  content = data.aws_iam_policy_document.modernisation_platform_core_ou_scp.json
-}
-
-data "aws_iam_policy_document" "modernisation_platform_core_ou_scp" {
-  statement {
-    effect    = "Allow"
-    actions   = ["*"]
-    resources = ["*"]
-  }
-}
-
 #####################################################
 # Modernisation Platform Core OU SCP - Prevent Root #
 #####################################################
@@ -386,31 +361,6 @@ data "aws_iam_policy_document" "modernisation_platform_member_ou_scp_prevent_roo
   }
 }
 
-####################################################
-# Modernisation Platform Member Unrestriced OU SCP #
-####################################################
-resource "aws_organizations_policy" "modernisation_platform_member_unrestriced_ou_scp" {
-  name        = "Modernisation Platform Member Unrestriced OU SCP"
-  description = "Restricts permissions for all OUs and accounts under the Modernisation Platform Member Unrestriced OU"
-  type        = "SERVICE_CONTROL_POLICY"
-
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
-  }
-
-  content = data.aws_iam_policy_document.modernisation_platform_member_unrestriced_ou_scp.json
-}
-
-data "aws_iam_policy_document" "modernisation_platform_member_unrestriced_ou_scp" {
-  statement {
-    effect    = "Allow"
-    actions   = ["*"]
-    resources = ["*"]
-  }
-}
-
 ####################################################################
 # Modernisation Platform Member Unrestricted OU SCP - Prevent Root #
 ####################################################################
@@ -445,30 +395,5 @@ data "aws_iam_policy_document" "modernisation_platform_member_unrestricted_ou_sc
       variable = "aws:PrincipalArn"
       values   = ["arn:aws:iam::*:root"]
     }
-  }
-}
-
-#####################################################
-# Modernisation Platform Member unrestricted OU SCP #
-#####################################################
-resource "aws_organizations_policy" "modernisation_platform_member_unrestricted_ou_scp" {
-  name        = "Modernisation Platform Member unrestricted OU SCP"
-  description = "Restricts permissions for all OUs and accounts under the Modernisation Platform Member unrestricted OU"
-  type        = "SERVICE_CONTROL_POLICY"
-
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
-  }
-
-  content = data.aws_iam_policy_document.modernisation_platform_member_unrestricted_ou_scp.json
-}
-
-data "aws_iam_policy_document" "modernisation_platform_member_unrestricted_ou_scp" {
-  statement {
-    effect    = "Allow"
-    actions   = ["*"]
-    resources = ["*"]
   }
 }


### PR DESCRIPTION
The three SCPs being removed in this PR all use statement:

```hcl
  statement {
    effect    = "Allow"
    actions   = ["*"]
    resources = ["*"]
  }
```

With AWS Organizations, each AWS account created will automatically have the FullAWSAccess policy attached _and_ inherited from the organizational root. This policy has the same statement:

```hcl
  statement {
    effect    = "Allow"
    actions   = ["*"]
    resources = ["*"]
  }
```

The [default strategy used in AWS Organizations](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps_strategies.html) is to use SCPs as a deny-list, rather than an allow list. This means that these SCPs will have no effect because the Organization already has full access via the `FullAWSAccess` policy.