### PR TITLE
Give techops read only to MP network account

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -264,6 +264,13 @@ locals {
       ]
     },
     {
+      github_team        = "moj-official-techops",
+      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
+      account_ids = [
+        local.modernisation_platform_environment_management["core-network-services-production"]
+      ]
+    },
+    {
       github_team        = "cloud-ops-alz-admins",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [


### PR DESCRIPTION
This will help with any future networking investigations enabling the
Tech Services and Network ops team to see Modernisation Platform
networking account for Transit Gateway route tables, attachments etc.