### PR TITLE
Remove AWS account 'MOJ CLA'

### DIFF
--- a/management-account/terraform/organizations-accounts-closed-accounts.tf
+++ b/management-account/terraform/organizations-accounts-closed-accounts.tf
@@ -15,23 +15,6 @@ resource "aws_organizations_account" "aws_laa" {
   }
 }
 
-resource "aws_organizations_account" "moj_cla" {
-  name                       = "MoJ CLA"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "cla-dev")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
-  tags                       = {}
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "money_to_prisoners" {
   name                       = "Money To Prisoners"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "moneytoprisoners")


### PR DESCRIPTION
This PR removes the AWS account "MOJ CLA" as it is past its [post-closure period](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-closing.html#post-closure-period).