### PR TITLE
Prepare organisation-security Terraform

### DIFF
--- a/organisation-security/terraform/data.tf
+++ b/organisation-security/terraform/data.tf
@@ -1,0 +1,3 @@
+data "aws_organizations_organization" "default" {
+  provider = aws.root
+}

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  organisation_security_account_id = coalesce([
+    for account in data.aws_organizations_organization.default.accounts :
+    account.id
+    if account.name == "organisation-security"
+  ]...)
+}

--- a/organisation-security/terraform/main.tf
+++ b/organisation-security/terraform/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  # `backend` blocks do not support variables, so the bucket name is hard-coded here
+  backend "s3" {
+    bucket  = "moj-aws-root-account-terraform-state"
+    region  = "eu-west-2"
+    key     = "organisation-security/terraform.tfstate"
+    encrypt = true
+  }
+}

--- a/organisation-security/terraform/providers.tf
+++ b/organisation-security/terraform/providers.tf
@@ -1,7 +1,18 @@
+# Root provider, for getting the organisation-security account ID
+
+provider "aws" {
+  alias  = "root"
+  region = "eu-west-2"
+}
+
 # Default provider
 
 provider "aws" {
   region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 # us-* providers
@@ -9,21 +20,37 @@ provider "aws" {
 provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "us-east-2"
   region = "us-east-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "us-west-1"
   region = "us-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "us-west-2"
   region = "us-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 # af-* providers
@@ -31,6 +58,10 @@ provider "aws" {
 provider "aws" {
   alias  = "af-south-1"
   region = "af-south-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 # ap-* providers
@@ -38,41 +69,73 @@ provider "aws" {
 provider "aws" {
   alias  = "ap-east-1"
   region = "ap-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "ap-southeast-3"
   region = "ap-southeast-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "ap-south-1"
   region = "ap-south-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "ap-northeast-3"
   region = "ap-northeast-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "ap-northeast-2"
   region = "ap-northeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "ap-southeast-1"
   region = "ap-southeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "ap-southeast-2"
   region = "ap-southeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "ap-northeast-1"
   region = "ap-northeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 # ca-* providers
@@ -80,6 +143,10 @@ provider "aws" {
 provider "aws" {
   alias  = "ca-central-1"
   region = "ca-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 # eu-* providers
@@ -87,31 +154,55 @@ provider "aws" {
 provider "aws" {
   alias  = "eu-central-1"
   region = "eu-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "eu-west-1"
   region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "eu-west-2"
   region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "eu-south-1"
   region = "eu-south-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "eu-west-3"
   region = "eu-west-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 provider "aws" {
   alias  = "eu-north-1"
   region = "eu-north-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 # me-* providers
@@ -119,6 +210,10 @@ provider "aws" {
 provider "aws" {
   alias  = "me-south-1"
   region = "me-south-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }
 
 # sa-* providers
@@ -126,4 +221,8 @@ provider "aws" {
 provider "aws" {
   alias  = "sa-east-1"
   region = "sa-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+  }
 }


### PR DESCRIPTION
This PR prepares `organisation-security` Terraform by:

- configures a Terraform backend in S3
- getting the organisation-security account ID from the root account
- setting the role to assume into the `organisation-security` account as a Terraform provider