### PR TITLE
Update GitHub workflows to pin latest versions

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -6,7 +6,7 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - uses: ministryofjustice/github-actions/code-formatter@main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -14,14 +14,14 @@ jobs:
       matrix:
         directory: ["management-account", "organisation-security"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
           path: ~/.tflint.d/plugins
           key: tflint-${{ hashFiles('.tflint.hcl') }}
-      - uses: terraform-linters/setup-tflint@v1
+      - uses: terraform-linters/setup-tflint@v2
         with:
-          tflint_version: v0.34.1
+          tflint_version: v0.35.0
       - run: tflint --version
       - run: tflint --init
       - run: tflint -f compact

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         directory: ["management-account", "organisation-security"]
     steps:
-      - uses: actions/checkout@main
-      - uses: tfsec/tfsec-sarif-action@master
+      - uses: actions/checkout@v3
+      - uses: tfsec/tfsec-sarif-action@v0.1.0
         with:
           sarif_file: tfsec.sarif
           working_directory: ${{ matrix.directory }}

--- a/management-account/terraform/.tflint.hcl
+++ b/management-account/terraform/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.12.0"
+  version = "0.13.2"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/organisation-security/terraform/.tflint.hcl
+++ b/organisation-security/terraform/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.12.0"
+  version = "0.13.2"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 


### PR DESCRIPTION
This PR:

- pins `actions/checkout` to `actions/checkout@v3`
- ~updates `terraform-linters/setup-tflint` to `terraform-linters/setup-tflint@v2`~ (#413 superseded this) and updates the `tflint` version
- pins `tfsec/tfsec-sarif-action` to `tfsec/tfsec-sarif-action@v0.1.0`