### PR TITLE
Remove unused S3 buckets from management-account

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -2,16 +2,6 @@
 # S3 buckets #
 ##############
 
-# cf-templates-rkovlae8ktmg-eu-west-1
-module "cf_templates_s3_bucket" {
-  providers = {
-    aws = aws.eu-west-1
-  }
-  source = "../../modules/s3"
-
-  bucket_name = "cf-templates-rkovlae8ktmg-eu-west-1"
-}
-
 # cloudtrail--replication20210315101340520100000002
 module "cloudtrail_replication_s3_bucket" {
   providers = {
@@ -47,13 +37,6 @@ module "log_bucket_s3_bucket" {
   bucket_name = "log-bucket20210315101344444500000002"
 }
 
-# moj-aws-compute-optimizer-recommendations
-module "compute_optimizer_recommendations_s3_bucket" {
-  source = "../../modules/s3"
-
-  bucket_name = "moj-aws-compute-optimizer-recommendations"
-}
-
 # moj-aws-root-account-terraform-state
 module "terraform_state_s3_bucket" {
   source = "../../modules/s3"
@@ -73,24 +56,4 @@ module "cur_reports_quicksight_s3_bucket" {
   source = "../../modules/s3"
 
   bucket_name = "moj-cur-reports-quicksight"
-}
-
-# moj-iam-credential-reports
-module "iam_credential_reports_s3_bucket" {
-  providers = {
-    aws = aws.eu-west-1
-  }
-  source = "../../modules/s3"
-
-  bucket_name = "moj-iam-credential-reports"
-}
-
-# tagging-policy-reports-20210308075228229500000001
-module "tagging_policy_reports_s3_bucket" {
-  providers = {
-    aws = aws.us-east-1
-  }
-  source = "../../modules/s3"
-
-  bucket_name = "tagging-policy-reports-20210308075228229500000001"
 }


### PR DESCRIPTION
This PR removes the following buckets as they are unused:

- `cf_templates_s3_bucket`, which was originally used to store a CloudFormation stack for IAM credential reports, which has not worked for some time
- `compute_optimizer_recommendations_s3_bucket`, which was configured to store [Compute Optimizer recommendations](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-recommendations.html), but was never used
- `iam_credential_reports_s3_bucket` which stored IAM credential reports (last access key usage, last login, etc) - this was last run in 2017
- `tagging_policy_reports_s3_bucket`, which was configured to store [Tagging Policy reports](https://docs.aws.amazon.com/ARG/latest/userguide/tag-policies-orgs-evaluating-org-wide-compliance.html). It was last run in 2019.