### PR TITLE
Add S3 resources to module and bring management-account up to date

### DIFF
--- a/management-account/terraform/data.tf
+++ b/management-account/terraform/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -9,15 +9,109 @@ module "cloudtrail_replication_s3_bucket" {
   }
   source = "../../modules/s3"
 
-  bucket_name = "cloudtrail--replication20210315101340520100000002"
+  bucket_name   = "cloudtrail--replication20210315101340520100000002"
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.cloudtrail_replication_s3_bucket.json
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = module.cloudtrail.kms_key_arn
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cloudtrail_replication_s3_bucket" {
+  statement {
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      "arn:aws:s3:::cloudtrail--replication20210315101340520100000002/*",
+      "arn:aws:s3:::cloudtrail--replication20210315101340520100000002"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 }
 
 # cloudtrail-20210315101356188000000003
 module "cloudtrail_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_name = "cloudtrail-20210315101356188000000003"
-  bucket_acl  = "log-delivery-write"
+  bucket_name   = "cloudtrail-20210315101356188000000003"
+  bucket_acl    = "log-delivery-write"
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.cloudtrail_s3_bucket.json
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm     = "aws:kms"
+        kms_master_key_id = module.cloudtrail.kms_key_arn
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cloudtrail_s3_bucket" {
+  statement {
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      "arn:aws:s3:::cloudtrail-20210315101356188000000003/*",
+      "arn:aws:s3:::cloudtrail-20210315101356188000000003"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetBucketAcl"]
+    resources = ["arn:aws:s3:::cloudtrail-20210315101356188000000003"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::cloudtrail-20210315101356188000000003/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
 }
 
 # log-bucket-replication20210315101330747900000001
@@ -27,14 +121,78 @@ module "log_bucket_replication_s3_bucket" {
   }
   source = "../../modules/s3"
 
-  bucket_name = "log-bucket-replication20210315101330747900000001"
+  bucket_name   = "log-bucket-replication20210315101330747900000001"
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.log_bucket_replication_s3_bucket.json
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "log_bucket_replication_s3_bucket" {
+  statement {
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      "arn:aws:s3:::log-bucket-replication20210315101330747900000001/*",
+      "arn:aws:s3:::log-bucket-replication20210315101330747900000001"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 }
 
 # log-bucket20210315101344444500000002
 module "log_bucket_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_name = "log-bucket20210315101344444500000002"
+  bucket_name   = "log-bucket20210315101344444500000002"
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.log_bucket_s3_bucket.json
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}
+
+data "aws_iam_policy_document" "log_bucket_s3_bucket" {
+  statement {
+    effect  = "Deny"
+    actions = ["s3:*"]
+    resources = [
+      "arn:aws:s3:::log-bucket20210315101344444500000002/*",
+      "arn:aws:s3:::log-bucket20210315101344444500000002"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
 }
 
 # moj-aws-root-account-terraform-state
@@ -42,18 +200,88 @@ module "terraform_state_s3_bucket" {
   source = "../../modules/s3"
 
   bucket_name = "moj-aws-root-account-terraform-state"
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
 }
 
 # moj-cur-reports
 module "cur_reports_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_name = "moj-cur-reports"
+  bucket_name   = "moj-cur-reports"
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.cur_reports_s3_bucket.json
+}
+
+data "aws_iam_policy_document" "cur_reports_s3_bucket" {
+  version = "2008-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketPolicy",
+      "s3:GetBucketAcl"
+    ]
+    resources = ["arn:aws:s3:::moj-cur-reports"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::386209384616:root"]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::moj-cur-reports/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::386209384616:root"]
+    }
+  }
 }
 
 # moj-cur-reports-quicksight
 module "cur_reports_quicksight_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_name = "moj-cur-reports-quicksight"
+  bucket_name   = "moj-cur-reports-quicksight"
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.cur_reports_quicksight_s3_policy.json
+}
+
+data "aws_iam_policy_document" "cur_reports_quicksight_s3_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketPolicy",
+      "s3:GetBucketAcl"
+    ]
+    resources = ["arn:aws:s3:::moj-cur-reports-quicksight"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::386209384616:root"]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::moj-cur-reports-quicksight/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::386209384616:root"]
+    }
+  }
 }

--- a/modules/cloudtrail/outputs.tf
+++ b/modules/cloudtrail/outputs.tf
@@ -1,0 +1,3 @@
+output "kms_key_arn" {
+  value = aws_kms_key.cloudtrail.arn
+}

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,4 +1,7 @@
-#tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-specify-public-access-block tfsec:ignore:aws-s3-specify-public-access-block tfsec:ignore:aws-s3-enable-versioning tfsec:ignore:aws-s3-block-public-acls tfsec:ignore:aws-s3-block-public-policy tfsec:ignore:aws-s3-ignore-public-acls tfsec:ignore:aws-s3-no-public-buckets tfsec:ignore:aws-s3-encryption-customer-key
+#############
+# S3 bucket #
+#############
+#tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "default" {
   bucket        = var.bucket_name
   force_destroy = var.force_destroy
@@ -6,7 +9,77 @@ resource "aws_s3_bucket" "default" {
   tags = var.additional_tags
 }
 
+##############
+# Bucket ACL #
+##############
 resource "aws_s3_bucket_acl" "default" {
   bucket = aws_s3_bucket.default.id
   acl    = var.bucket_acl
+}
+
+#####################
+# Bucket versioning #
+#####################
+resource "aws_s3_bucket_versioning" "default" {
+  for_each = var.enable_versioning ? toset(["enabled"]) : []
+
+  bucket = aws_s3_bucket.default.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+#####################
+# SSE configuration #
+#####################
+resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+  for_each = length(keys(var.server_side_encryption_configuration)) > 0 ? toset(["enabled"]) : []
+
+  bucket = aws_s3_bucket.default.id
+
+  dynamic "rule" {
+    for_each = try(flatten([var.server_side_encryption_configuration["rule"]]), [])
+
+    content {
+      bucket_key_enabled = try(rule.value.bucket_key_enabled, null)
+
+      dynamic "apply_server_side_encryption_by_default" {
+        for_each = try([rule.value.apply_server_side_encryption_by_default], [])
+
+        content {
+          sse_algorithm     = apply_server_side_encryption_by_default.value.sse_algorithm
+          kms_master_key_id = try(apply_server_side_encryption_by_default.value.kms_master_key_id, null)
+        }
+      }
+    }
+  }
+}
+
+###################
+# Bucket policies #
+###################
+resource "aws_s3_bucket_policy" "default" {
+  for_each = var.attach_policy ? toset(["enabled"]) : []
+
+  bucket = aws_s3_bucket.default.id
+  policy = data.aws_iam_policy_document.combined["enabled"].json
+}
+
+data "aws_iam_policy_document" "combined" {
+  for_each = var.attach_policy ? toset(["enabled"]) : []
+
+  source_policy_documents = compact([var.policy])
+}
+
+##############################
+# Bucket public access block #
+##############################
+resource "aws_s3_bucket_public_access_block" "default" {
+  bucket = aws_s3_bucket.default.id
+
+  block_public_acls       = var.block_public_acls
+  block_public_policy     = var.block_public_policy
+  ignore_public_acls      = var.ignore_public_acls
+  restrict_public_buckets = var.restrict_public_buckets
 }

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -12,6 +12,46 @@ variable "bucket_acl" {
   default = "private"
 }
 
+variable "attach_policy" {
+  type    = bool
+  default = false
+}
+
+variable "policy" {
+  type    = string
+  default = null
+}
+
+variable "enable_versioning" {
+  type    = bool
+  default = true
+}
+
+variable "block_public_acls" {
+  type    = bool
+  default = true
+}
+
+variable "block_public_policy" {
+  type    = bool
+  default = true
+}
+
+variable "ignore_public_acls" {
+  type    = bool
+  default = true
+}
+
+variable "restrict_public_buckets" {
+  type    = bool
+  default = true
+}
+
+variable "server_side_encryption_configuration" {
+  type    = any
+  default = {}
+}
+
 variable "additional_tags" {
   type    = map(any)
   default = {}


### PR DESCRIPTION
This PR updates the S3 module to include:

- `aws_s3_bucket_versioning`
- `aws_s3_bucket_server_side_encryption_configuration`
- `aws_s3_bucket_policy`
- `aws_s3_bucket_public_access_block`

It also brings the S3 buckets in the `management-account` up to date with these resources.