### PR TITLE
Firewall Manager: two policies, one with auto-remediation and one without

### DIFF
--- a/organisation-security/terraform/data.tf
+++ b/organisation-security/terraform/data.tf
@@ -1,3 +1,27 @@
 data "aws_organizations_organization" "default" {
   provider = aws.root
 }
+
+data "aws_organizations_organizational_units" "organizational_units" {
+  parent_id = data.aws_organizations_organization.default.roots[0].id
+}
+
+data "aws_organizations_organizational_units" "platforms_and_architecture" {
+  parent_id = local.ou_platforms_and_architecture_id
+}
+
+data "aws_organizations_organizational_units" "modernisation_platform" {
+  parent_id = local.ou_modernisation_platform_id
+}
+
+data "aws_organizations_organizational_units" "modernisation_platform_core" {
+  parent_id = local.ou_modernisation_platform_core_id
+}
+
+data "aws_organizations_organizational_units" "modernisation_platform_member" {
+  parent_id = local.ou_modernisation_platform_member_id
+}
+
+data "aws_organizations_organizational_units" "modernisation_platform_unrestricted" {
+  parent_id = local.ou_modernisation_platform_unrestricted_id
+}

--- a/organisation-security/terraform/firewall-manager.tf
+++ b/organisation-security/terraform/firewall-manager.tf
@@ -2,9 +2,11 @@
 # Firewall Manager in eu-west-2 #
 #################################
 
-# Shield Advanced policy
-resource "aws_fms_policy" "eu_west_2_modernisation_platform_shield_advanced" {
-  name                               = "modernisation-platform"
+# Shield Advanced policy (auto-remediate)
+resource "aws_fms_policy" "eu_west_2_shield_advanced_auto_remediate" {
+  provider = aws.eu-west-2
+
+  name                               = "shield_advanced_auto_remediate"
   delete_all_policy_resources        = true
   delete_unused_fm_managed_resources = false
   exclude_resource_tags              = false
@@ -16,10 +18,40 @@ resource "aws_fms_policy" "eu_west_2_modernisation_platform_shield_advanced" {
   ]
 
   include_map {
-    account = toset([
-      for name, id in local.accounts.modernisation_platform_shield_advanced :
-      id
-    ])
+    account = try(toset(local.shield_advanced_auto_remediate.accounts), null)
+    orgunit = try(toset(local.shield_advanced_auto_remediate.organizational_units), null)
+  }
+
+  resource_tags = {
+    is-production = "false"
+  }
+
+  security_service_policy_data {
+    type = "SHIELD_ADVANCED"
+    managed_service_data = jsonencode({
+      type = "SHIELD_ADVANCED"
+    })
+  }
+}
+
+# Shield Advanced policy (don't auto remediate)
+resource "aws_fms_policy" "eu_west_2_shield_advanced_no_auto_remediate" {
+  provider = aws.eu-west-2
+
+  name                               = "shield_advanced_no_auto_remediate"
+  delete_all_policy_resources        = true
+  delete_unused_fm_managed_resources = false
+  exclude_resource_tags              = false
+  remediation_enabled                = false
+  resource_type_list = [
+    "AWS::EC2::EIP",
+    "AWS::ElasticLoadBalancing::LoadBalancer",
+    "AWS::ElasticLoadBalancingV2::LoadBalancer",
+  ]
+
+  include_map {
+    account = try(toset(local.shield_advanced_no_auto_remediate.accounts), null)
+    orgunit = try(toset(local.shield_advanced_no_auto_remediate.organizational_units), null)
   }
 
   resource_tags = {

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -38,7 +38,7 @@ locals {
 
   # Shield Advanced
   shield_advanced_auto_remediate = {
-    accounts = null,
+    accounts             = null,
     organizational_units = null
   }
   shield_advanced_no_auto_remediate = {
@@ -46,9 +46,9 @@ locals {
     organizational_units = flatten([
       data.aws_organizations_organizational_units.modernisation_platform_core.id,
       [
-        for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children:
+        for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children :
         ou.id
-        if (
+        if(
           ou.name != "modernisation-platform-xhibit-portal"
         )
       ]

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -5,21 +5,62 @@ locals {
     if account.name == "organisation-security"
   ]...)
 
+  # AWS Organizational Units
+  ou_platforms_and_architecture_id = coalesce([
+    for ou in data.aws_organizations_organizational_units.organizational_units.children :
+    ou.id
+    if ou.name == "Platforms & Architecture"
+  ]...)
+
+  ou_modernisation_platform_id = coalesce([
+    for ou in data.aws_organizations_organizational_units.platforms_and_architecture.children :
+    ou.id
+    if ou.name == "Modernisation Platform"
+  ]...)
+
+  ou_modernisation_platform_core_id = coalesce([
+    for ou in data.aws_organizations_organizational_units.modernisation_platform.children :
+    ou.id
+    if ou.name == "Modernisation Platform Core"
+  ]...)
+
+  ou_modernisation_platform_member_id = coalesce([
+    for ou in data.aws_organizations_organizational_units.modernisation_platform.children :
+    ou.id
+    if ou.name == "Modernisation Platform Member"
+  ]...)
+
+  ou_modernisation_platform_unrestricted_id = coalesce([
+    for ou in data.aws_organizations_organizational_units.modernisation_platform.children :
+    ou.id
+    if ou.name == "Modernisation Platform Member Unrestricted"
+  ]...)
+
+  # Shield Advanced
+  shield_advanced_auto_remediate = {
+    accounts = null,
+    organizational_units = null
+  }
+  shield_advanced_no_auto_remediate = {
+    accounts = null,
+    organizational_units = flatten([
+      data.aws_organizations_organizational_units.modernisation_platform_core.id,
+      [
+        for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children:
+        ou.id
+        if (
+          ou.name != "modernisation-platform-xhibit-portal"
+        )
+      ]
+    ])
+  }
+
   # Accounts map
   accounts = {
     active_only_not_self : {
       for account in data.aws_organizations_organization.default.accounts :
       account.name => account.id
       if account.status == "ACTIVE" && account.name != "organisation-security"
-    },
-    modernisation_platform_shield_advanced : {
-      for account in data.aws_organizations_organization.default.accounts :
-      account.name => account.id
-      if account.status == "ACTIVE" && (
-        account.name == "cooker-development" ||
-        account.name == "sprinkler-development" ||
-        account.name == "shared-services-dev"
-      )
     }
   }
 }


### PR DESCRIPTION
This PR creates two Firewall Manager Shield Advanced policies: one with auto-remediate enabled, and one without auto-remediate enabled.

Accounts and organizational units can be added to the policy without auto-remediation to test and assess any changes Firewall Manager will make, such as attaching a managed WAF policy to a resource.

Once compliant, AWS accounts and organizational units can "graduate" to the auto-remediation policy. 

Shield Advanced policies created as part of Firewall Manager are included in the [AWS Shield Advanced yearly commitment cost](https://aws.amazon.com/firewall-manager/pricing/).