### PR TITLE
Move NOMS API and HMPPS Delius PO Test to Closed accounts

### DIFF
--- a/management-account/terraform/organizations-accounts-closed-accounts.tf
+++ b/management-account/terraform/organizations-accounts-closed-accounts.tf
@@ -88,3 +88,43 @@ resource "aws_organizations_account" "hmpps_check_my_diary_development" {
     ]
   }
 }
+
+resource "aws_organizations_account" "hmpps_delius_po_test" {
+  name                       = "HMPPS Delius PO Test"
+  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-delius-po-test")
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
+
+  tags = merge(local.tags_delius, {
+
+  })
+
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name,
+    ]
+  }
+}
+
+resource "aws_organizations_account" "noms_api" {
+  name                       = "NOMS API"
+  email                      = replace(local.aws_account_email_addresses_template, "{email}", "noms-api")
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
+
+  tags = merge(local.tags_hmpps, {
+
+  })
+
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name,
+    ]
+  }
+}

--- a/management-account/terraform/organizations-accounts-hmpps-delius.tf
+++ b/management-account/terraform/organizations-accounts-hmpps-delius.tf
@@ -122,26 +122,6 @@ resource "aws_organizations_account" "hmpps_delius_performance" {
   }
 }
 
-resource "aws_organizations_account" "hmpps_delius_po_test" {
-  name                       = "HMPPS Delius PO Test"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-delius-po-test")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.hmpps_delius.id
-
-  tags = merge(local.tags_delius, {
-
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "hmpps_delius_po_test_1" {
   name                       = "HMPPS Delius PO Test 1"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-delius-po-test1")

--- a/management-account/terraform/organizations-accounts-hmpps.tf
+++ b/management-account/terraform/organizations-accounts-hmpps.tf
@@ -182,26 +182,6 @@ resource "aws_organizations_account" "hmpps_security_poc" {
   }
 }
 
-resource "aws_organizations_account" "noms_api" {
-  name                       = "NOMS API"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "noms-api")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.hmpps.id
-
-  tags = merge(local.tags_hmpps, {
-
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "probation" {
   name                       = "Probation"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "probation")

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -43,7 +43,6 @@ locals {
         aws_organizations_account.hmpps_delius_mis_non_prod.id,
         aws_organizations_account.hmpps_delius_mis_test.id,
         aws_organizations_account.hmpps_delius_performance.id,
-        aws_organizations_account.hmpps_delius_po_test.id,
         aws_organizations_account.hmpps_delius_po_test_1.id,
         aws_organizations_account.hmpps_delius_po_test_2.id,
         aws_organizations_account.hmpps_delius_pre_production.id,


### PR DESCRIPTION
This PR moves `NOMS API` and `HMPPS Delius PO Test` to the Closed accounts organizational unit, as these accounts are now suspended.