### PR TITLE
Rename Workplace Technology to Technology Services

### DIFF
--- a/management-account/terraform/organizations-accounts-technology-services.tf
+++ b/management-account/terraform/organizations-accounts-technology-services.tf
@@ -1,14 +1,14 @@
 locals {
-  tags_workplace_technology = local.tags_business_units.hq
+  tags_technology_services = local.tags_business_units.hq
 }
 
 resource "aws_organizations_account" "cloud_networks_psn" {
   name                       = "Cloud Networks PSN"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "cloud_networks_PSN")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [
@@ -24,9 +24,9 @@ resource "aws_organizations_account" "moj_official_development" {
   name                       = "MOJ Official (Development)"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "mojofficial-dev")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [
@@ -42,9 +42,9 @@ resource "aws_organizations_account" "moj_official_network_operations_centre" {
   name                       = "MOJ Official (Network Operations Centre)"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "mojofficial-networkopscentre")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [
@@ -60,9 +60,9 @@ resource "aws_organizations_account" "moj_official_preproduction" {
   name                       = "MOJ Official (Pre-Production)"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "mojofficial-preprod")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [
@@ -78,9 +78,9 @@ resource "aws_organizations_account" "moj_official_production" {
   name                       = "MOJ Official (Production)"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "mojofficial-prod")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [
@@ -96,9 +96,9 @@ resource "aws_organizations_account" "moj_official_public_key_infrastructure_dev
   name                       = "MOJ Official (Public Key Infrastructure Dev)"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "mojofficial-pki-dev")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [
@@ -114,9 +114,9 @@ resource "aws_organizations_account" "moj_official_public_key_infrastructure" {
   name                       = "MOJ Official (Public Key Infrastructure)"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "mojofficial-public-key-infra")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [
@@ -132,9 +132,9 @@ resource "aws_organizations_account" "moj_official_shared_services" {
   name                       = "MOJ Official (Shared Services)"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "mojofficial-shared")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [
@@ -150,9 +150,9 @@ resource "aws_organizations_account" "workplace_tech_proof_of_concept_developmen
   name                       = "Workplace Tech Proof Of Concept Development"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "wptpocdev")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [
@@ -168,9 +168,9 @@ resource "aws_organizations_account" "wptpoc" {
   name                       = "WPTPOC"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "WPTPOC")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [
@@ -186,9 +186,9 @@ resource "aws_organizations_account" "network_architecture" {
   name                       = "Network Architecture"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "network-architecture")
   iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.workplace_technology.id
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
 
-  tags = local.tags_workplace_technology
+  tags = local.tags_technology_services
 
   lifecycle {
     ignore_changes = [

--- a/management-account/terraform/organizations-organizational-units.tf
+++ b/management-account/terraform/organizations-organizational-units.tf
@@ -214,11 +214,11 @@ resource "aws_organizations_organizational_unit" "security_engineering" {
   tags      = {}
 }
 
-########################
-# Workplace Technology #
-########################
-resource "aws_organizations_organizational_unit" "workplace_technology" {
-  name      = "Workplace Technology"
+#######################
+# Technology Services #
+#######################
+resource "aws_organizations_organizational_unit" "technology_services" {
+  name      = "Technology Services"
   parent_id = aws_organizations_organization.default.roots[0].id
   tags      = {}
 }


### PR DESCRIPTION
"Workplace Technology" now sits with Technology Services within MOJ, so this PR renames the organizational unit and associated tags to the correct name for Technology Services AWS accounts.