### PR TITLE
Move Cloud Platform Transit Gateways to Technology Services

### DIFF
--- a/management-account/terraform/organizations-accounts-platforms-and-architecture-cloud-platform.tf
+++ b/management-account/terraform/organizations-accounts-platforms-and-architecture-cloud-platform.tf
@@ -37,23 +37,3 @@ resource "aws_organizations_account" "cloud_platform_ephemeral_test" {
     ]
   }
 }
-
-resource "aws_organizations_account" "cloud_platform_transit_gateways" {
-  name                       = "Cloud Platform Transit Gateways"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "cloud-platform-transit-gateways")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.platforms_and_architecture_cloud_platform.id
-
-  tags = merge(local.tags_platforms, {
-    is-production = true
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}

--- a/management-account/terraform/organizations-accounts-technology-services.tf
+++ b/management-account/terraform/organizations-accounts-technology-services.tf
@@ -199,3 +199,23 @@ resource "aws_organizations_account" "network_architecture" {
     ]
   }
 }
+
+resource "aws_organizations_account" "cloud_platform_transit_gateways" {
+  name                       = "Cloud Platform Transit Gateways"
+  email                      = replace(local.aws_account_email_addresses_template, "{email}", "cloud-platform-transit-gateways")
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.technology_services.id
+
+  tags = merge(local.tags_technology_services, {
+    is-production = true
+  })
+
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name,
+    ]
+  }
+}

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -82,6 +82,11 @@ resource "aws_organizations_policy_attachment" "deny_aws_account_root_user_hmpps
   target_id = aws_organizations_organizational_unit.hmpps_community_rehabilitation.id
 }
 
+resource "aws_organizations_policy_attachment" "deny_aws_account_root_user_cloud_platform_transit_gateways" {
+  policy_id = aws_organizations_policy.deny_aws_account_root_user.id
+  target_id = aws_organizations_account.cloud_platform_transit_gateways.id
+}
+
 #####################################
 # Deny all actions on all resources #
 #####################################


### PR DESCRIPTION
The Cloud Platform Transit Gateways AWS account is now managed by Technology Services, so this PR moves the account to the correct OU, and re-attaches the deny root user service control policy, which is lost as part of the move from the [Platforms and Architecture OU](https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/organizations-policy-service-control.tf#L75).