### PR TITLE
Enable S3 account public access block for management-account

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -1,3 +1,14 @@
+########################################
+# S3 account-level public access block #
+########################################
+
+resource "aws_s3_account_public_access_block" "default" {
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 ##############
 # S3 buckets #
 ##############


### PR DESCRIPTION
This PR enables the S3 account-wide public access block for `management-account`. This account should not host publicly accessible buckets.