### PR TITLE
Move AWS Config configuration to management-account

### DIFF
--- a/management-account/terraform/config.tf
+++ b/management-account/terraform/config.tf
@@ -1,0 +1,46 @@
+########################
+# Config in EU regions #
+########################
+module "config_eu_west_2" {
+  source = "../../modules/config"
+  providers = {
+    aws = aws.eu-west-2
+  }
+
+  create_iam_role = true
+  s3_bucket_name  = module.config_log_bucket.bucket_name
+}
+
+module "config_eu_west_1" {
+  source = "../../modules/config"
+  providers = {
+    aws = aws.eu-west-1
+  }
+
+  iam_role_arn   = module.config_eu_west_2.iam_role_arn
+  s3_bucket_name = module.config_log_bucket.bucket_name
+}
+
+module "config_eu_central_1" {
+  source = "../../modules/config"
+  providers = {
+    aws = aws.eu-central-1
+  }
+
+  iam_role_arn   = module.config_eu_west_2.iam_role_arn
+  s3_bucket_name = module.config_log_bucket.bucket_name
+}
+
+########################
+# Config in US regions #
+########################
+module "config_us_east_1" {
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  source = "../../modules/config"
+
+  iam_role_arn   = module.config_eu_west_2.iam_role_arn
+  s3_bucket_name = module.config_log_bucket.bucket_name
+}

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -13,6 +13,11 @@ resource "aws_s3_account_public_access_block" "default" {
 # S3 buckets #
 ##############
 
+# AWS Config log bucket
+module "config_log_bucket" {
+  source = "../../modules/config-bucket"
+}
+
 # cloudtrail--replication20210315101340520100000002
 module "cloudtrail_replication_s3_bucket" {
   providers = {

--- a/modules/config-bucket/data.tf
+++ b/modules/config-bucket/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/modules/config-bucket/main.tf
+++ b/modules/config-bucket/main.tf
@@ -1,0 +1,75 @@
+resource "random_uuid" "bucket_name" {}
+
+locals {
+  bucket_name = "config-${random_uuid.bucket_name.result}"
+}
+
+module "s3_bucket" {
+  source = "../s3"
+
+  attach_policy        = true
+  bucket_name          = local.bucket_name
+  policy               = data.aws_iam_policy_document.bucket.json
+  require_ssl_requests = true
+}
+
+data "aws_iam_policy_document" "bucket" {
+  version = "2012-10-17"
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetBucketAcl"]
+    resources = ["arn:aws:s3:::${local.bucket_name}"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::${local.bucket_name}"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::${local.bucket_name}/AWSLogs/${data.aws_caller_identity.current.account_id}/Config/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+}

--- a/modules/config-bucket/outputs.tf
+++ b/modules/config-bucket/outputs.tf
@@ -1,0 +1,4 @@
+output "bucket_name" {
+  description = "Bucket name"
+  value       = module.s3_bucket.bucket_name
+}

--- a/modules/config-bucket/versions.tf
+++ b/modules/config-bucket/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.1.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=4.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.2.0"
+    }
+  }
+}

--- a/modules/config/data.tf
+++ b/modules/config/data.tf
@@ -1,0 +1,2 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}

--- a/modules/config/iam.tf
+++ b/modules/config/iam.tf
@@ -1,0 +1,68 @@
+resource "aws_iam_role" "config" {
+  for_each = var.create_iam_role ? toset(["enabled"]) : toset([])
+
+  name               = "AWSConfigRole"
+  assume_role_policy = data.aws_iam_policy_document.config.json
+}
+
+data "aws_iam_policy_document" "config" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+  }
+}
+
+# Attach managed AWS_ConfigRole policy
+resource "aws_iam_role_policy_attachment" "aws_managed" {
+  for_each = var.create_iam_role ? toset(["enabled"]) : toset([])
+
+  role       = aws_iam_role.config["enabled"].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
+}
+
+# IAM policy for S3
+resource "aws_iam_policy" "s3" {
+  for_each = var.create_iam_role ? toset(["enabled"]) : toset([])
+
+  name   = "AWSConfigRoleS3Access"
+  policy = data.aws_iam_policy_document.s3.json
+}
+
+data "aws_iam_policy_document" "s3" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+    ]
+    resources = ["arn:aws:s3:::${var.s3_bucket_name}/AWSLogs/${data.aws_caller_identity.current.account_id}/*"]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetBucketAcl"]
+    resources = ["arn:aws:s3:::${var.s3_bucket_name}"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "s3" {
+  for_each = var.create_iam_role ? toset(["enabled"]) : toset([])
+
+  role       = aws_iam_role.config["enabled"].name
+  policy_arn = aws_iam_policy.s3["enabled"].arn
+}

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -1,0 +1,27 @@
+resource "aws_config_delivery_channel" "default" {
+  name = "AWSConfig"
+
+  s3_bucket_name = var.s3_bucket_name
+
+  snapshot_delivery_properties {
+    delivery_frequency = "One_Hour"
+  }
+
+  depends_on = [aws_config_configuration_recorder.default]
+}
+
+resource "aws_config_configuration_recorder" "default" {
+  name     = "AWSConfig"
+  role_arn = var.create_iam_role ? aws_iam_role.config["enabled"].arn : var.iam_role_arn
+
+  recording_group {
+    all_supported                 = true
+    include_global_resource_types = (data.aws_region.current.name == "us-east-1") ? true : false
+  }
+}
+
+resource "aws_config_configuration_recorder_status" "default" {
+  name       = aws_config_configuration_recorder.default.name
+  is_enabled = true
+  depends_on = [aws_config_delivery_channel.default]
+}

--- a/modules/config/outputs.tf
+++ b/modules/config/outputs.tf
@@ -1,0 +1,3 @@
+output "iam_role_arn" {
+  value = var.create_iam_role ? aws_iam_role.config["enabled"].arn : var.iam_role_arn
+}

--- a/modules/config/variables.tf
+++ b/modules/config/variables.tf
@@ -1,0 +1,16 @@
+variable "create_iam_role" {
+  type        = bool
+  description = "Whether to create the IAM role for AWS Config"
+  default     = false
+}
+
+variable "iam_role_arn" {
+  type        = string
+  description = "IAM role ARN for AWS Config, if create_iam_role is set to false"
+  default     = ""
+}
+
+variable "s3_bucket_name" {
+  type        = string
+  description = "S3 bucket name for AWS Config logs"
+}

--- a/modules/config/versions.tf
+++ b/modules/config/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.1.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">=4.7.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR moves the [older AWS Config configuration](https://github.com/ministryofjustice/aws-root-account/commit/7e118d6ce8411efbefdf785473bb20c14fd99982) to `management-account`.