### PR TITLE
Move Security Engineering to closed accounts

### DIFF
--- a/management-account/terraform/organizations-accounts-closed-accounts.tf
+++ b/management-account/terraform/organizations-accounts-closed-accounts.tf
@@ -206,3 +206,21 @@ resource "aws_organizations_account" "strategic_partner_gateway_non_production" 
     ]
   }
 }
+
+resource "aws_organizations_account" "security_engineering" {
+  name                       = "Security Engineering"
+  email                      = replace(local.aws_account_email_addresses_template, "{email}", "security_engineering")
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
+
+  tags = local.tags_security
+
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name,
+    ]
+  }
+}

--- a/management-account/terraform/organizations-accounts-security-engineering.tf
+++ b/management-account/terraform/organizations-accounts-security-engineering.tf
@@ -20,24 +20,6 @@ resource "aws_organizations_account" "moj_security" {
   }
 }
 
-resource "aws_organizations_account" "security_engineering" {
-  name                       = "Security Engineering"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "security_engineering")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.security_engineering.id
-
-  tags = local.tags_security
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "security_logging_platform" {
   name                       = "Security Logging Platform"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "security-logging-platform")


### PR DESCRIPTION
This PR moves the Security Engineering AWS account to "Closed accounts", as it is no longer used.