### PR TITLE
LPAL-813 dev and preprod accounts to non autoremediate on Make an LPA OPG service

### DIFF
--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -67,7 +67,12 @@ locals {
       for account_name, account_value in local.accounts.active_only_not_self :
       account_value
       if
-      (account_name == "shared-services-dev" || account_name == "MoJ Digital Services")
+      (
+        account_name == "shared-services-dev" ||
+        account_name == "MoJ Digital Services" ||
+        account_name == "MOJ LPA Development" ||
+        account_name ==  "MOJ LPA Preproduction"
+      )
     ],
     organizational_units = null
   }


### PR DESCRIPTION
to enrol services LB's with WAF in Dev and Preprod accounts onto Shield Advanced on Make an LPA Service in OPG. 
initially with non auto remediate settings. 
this will be followed by Prod once we are certain there's no issues.