### PR TITLE
Move HMPPS DSO accounts to P&A

### DIFF
--- a/management-account/terraform/organizations-accounts-hmpps.tf
+++ b/management-account/terraform/organizations-accounts-hmpps.tf
@@ -22,49 +22,9 @@ resource "aws_organizations_account" "hmpps_co_financing_organisation" {
   }
 }
 
-resource "aws_organizations_account" "hmpps_dev" {
-  name                       = "HMPPS Dev"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-dev")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.hmpps.id
-
-  tags = merge(local.tags_hmpps, {
-
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "hmpps_engineering_production" {
   name                       = "HMPPS Engineering Production"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-engineering-prod")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.hmpps.id
-
-  tags = merge(local.tags_hmpps, {
-
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
-resource "aws_organizations_account" "hmpps_management" {
-  name                       = "HMPPS Management"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-mgmt")
   iam_user_access_to_billing = "ALLOW"
   parent_id                  = aws_organizations_organizational_unit.hmpps.id
 
@@ -105,26 +65,6 @@ resource "aws_organizations_account" "hmpps_performance_hub" {
 resource "aws_organizations_account" "hmpps_probation_production" {
   name                       = "HMPPS Probation Production"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-probation-prod")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.hmpps.id
-
-  tags = merge(local.tags_hmpps, {
-
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
-resource "aws_organizations_account" "hmpps_prod" {
-  name                       = "HMPPS PROD"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-prod")
   iam_user_access_to_billing = "ALLOW"
   parent_id                  = aws_organizations_organizational_unit.hmpps.id
 

--- a/management-account/terraform/organizations-accounts-platforms-and-architecture-digital-studio-operations.tf
+++ b/management-account/terraform/organizations-accounts-platforms-and-architecture-digital-studio-operations.tf
@@ -1,0 +1,68 @@
+resource "aws_organizations_account" "hmpps_dev" {
+  name                       = "HMPPS Dev"
+  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-dev")
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.platforms_and_architecture_digital_studio_operations.id
+
+  tags = merge(local.tags_platforms, {
+    application            = "Digtial Studio Operations development"
+    environment-name       = "dso-hmpps-dev"
+    infrastructure-support = "Digital Studio Operations: digital-studio-operations-team@digital.justice.gov.uk"
+    owner                  = "Digital Studio Operations: digital-studio-operations-team@digital.justice.gov.uk"
+  })
+
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name,
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps_management" {
+  name                       = "HMPPS Management"
+  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-mgmt")
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.platforms_and_architecture_digital_studio_operations.id
+
+  tags = merge(local.tags_platforms, {
+    application            = "Digital Studio Operations management"
+    environment-name       = "dso-hmpps-management"
+    infrastructure-support = "Digital Studio Operations: digital-studio-operations-team@digital.justice.gov.uk"
+    owner                  = "Digital Studio Operations: digital-studio-operations-team@digital.justice.gov.uk"
+  })
+
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name,
+    ]
+  }
+}
+
+resource "aws_organizations_account" "hmpps_prod" {
+  name                       = "HMPPS PROD"
+  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-prod")
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.platforms_and_architecture_digital_studio_operations.id
+
+  tags = merge(local.tags_platforms, {
+    application            = "Digital Studio Operations production"
+    environment-name       = "dso-hmpps-prod"
+    infrastructure-support = "Digital Studio Operations: digital-studio-operations-team@digital.justice.gov.uk"
+    owner                  = "Digital Studio Operations: digital-studio-operations-team@digital.justice.gov.uk"
+  })
+
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name,
+    ]
+  }
+}

--- a/management-account/terraform/organizations-organizational-units.tf
+++ b/management-account/terraform/organizations-organizational-units.tf
@@ -205,6 +205,13 @@ resource "aws_organizations_organizational_unit" "platforms_and_architecture_ope
   tags      = {}
 }
 
+# Digital Studio Operations
+resource "aws_organizations_organizational_unit" "platforms_and_architecture_digital_studio_operations" {
+  name      = "Digital Studio Operations"
+  parent_id = aws_organizations_organizational_unit.platforms_and_architecture.id
+  tags      = {}
+}
+
 ########################
 # Security Engineering #
 ########################


### PR DESCRIPTION
This PR moves the AWS accounts managed by @ministryofjustice/studio-webops into the P&A organizational unit.