### PR TITLE
Enrol Security Engineering accounts into restricted regions

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -202,6 +202,7 @@ locals {
     aws_organizations_organizational_unit.hmpps_electronic_monitoring_case_management.id,
     aws_organizations_organizational_unit.opg.id,
     aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id,
+    aws_organizations_organizational_unit.security_engineering.id,
     # organization-account
     aws_organizations_account.analytical_platform_data_engineering_sandbox.id,
     aws_organizations_account.analytical_platform_development.id,


### PR DESCRIPTION
This PR enrols the following accounts into the `restricted regions` service control policy, to deny actions outside of `eu-west-1`, `eu-west-2`, `eu-central-1`, and `us-east-1`.

- [x] Billing reviewed
- [x] Billable items in restricted regions have been deleted
- [x] Team aware