### PR TITLE
Enrol Technology Services accounts into restricted regions

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -209,12 +209,11 @@ locals {
     aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id,
     aws_organizations_organizational_unit.platforms_and_architecture_operations_engineering.id,
     aws_organizations_organizational_unit.security_engineering.id,
+    aws_organizations_organizational_unit.technology_services.id,
     # organization-account
     aws_organizations_account.analytical_platform_data_engineering_sandbox.id,
     aws_organizations_account.analytical_platform_development.id,
     aws_organizations_account.analytical_platform_landing.id,
-    aws_organizations_account.moj_official_development.id,
-    aws_organizations_account.moj_official_network_operations_centre.id,
     aws_organizations_account.security_operations_pre_production.id,
   ]
 }


### PR DESCRIPTION
This PR enrols the Technology Services accounts into the `restricted regions` service control policy, to deny actions outside of `eu-west-1`, `eu-west-2`, `eu-central-1`, and `us-east-1`.

- [x] Billing reviewed
- [x] Billable items in restricted regions have been deleted
- [x] Team aware

Note that MOJ Official (Development) and MOJ Official (Network Operations Centre) are both part of this OU, so have been removed in favour of the OU-wide enrolment.