### PR TITLE
Enrol Analytical Platform accounts into restricted regions

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -197,6 +197,7 @@ data "aws_iam_policy_document" "deny_non_eu_non_us_east_1_operations" {
 locals {
   deny_non_eu_non_us_east_1_operations_targets = [
     # orgnaizational-unit
+    aws_organizations_organizational_unit.analytical_platform.id,
     aws_organizations_organizational_unit.central_digital.id,
     aws_organizations_organizational_unit.hmcts.id,
     aws_organizations_organizational_unit.hmpps_community_rehabilitation.id,
@@ -211,9 +212,6 @@ locals {
     aws_organizations_organizational_unit.security_engineering.id,
     aws_organizations_organizational_unit.technology_services.id,
     # organization-account
-    aws_organizations_account.analytical_platform_data_engineering_sandbox.id,
-    aws_organizations_account.analytical_platform_development.id,
-    aws_organizations_account.analytical_platform_landing.id,
     aws_organizations_account.security_operations_pre_production.id,
   ]
 }


### PR DESCRIPTION
This PR enrols the Analytical Platform accounts into the `restricted regions` service control policy, to deny actions outside of `eu-west-1`, `eu-west-2`, `eu-central-1`, and `us-east-1`.

- [x] Billing reviewed
- [x] Billable items in restricted regions have been deleted
- [x] Team aware

Note that Analytical Platform Data Engineering Sandbox, Analytical Platform Development, Analytical Platform Landing are all part of this OU, so have been removed in favour of the OU-wide enrolment.