### PR TITLE
Enrol Cloud Platform accounts into restricted regions

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -206,6 +206,7 @@ locals {
     aws_organizations_organizational_unit.laa.id,
     aws_organizations_organizational_unit.opg.id,
     aws_organizations_organizational_unit.organisation_management.id,
+    aws_organizations_organizational_unit.platforms_and_architecture_cloud_platform.id,
     aws_organizations_organizational_unit.platforms_and_architecture_digital_studio_operations.id,
     aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id,
     aws_organizations_organizational_unit.platforms_and_architecture_operations_engineering.id,


### PR DESCRIPTION
This PR enrols the Cloud Platform accounts into the `restricted regions` service control policy, to deny actions outside of `eu-west-1`, `eu-west-2`, `eu-central-1`, and `us-east-1`.

- [x] Billing reviewed
- [x] Billable items in restricted regions have been deleted
- [x] Team aware
