### PR TITLE
Remove SCP direct attachment to Security Operations pre-production

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -213,7 +213,6 @@ locals {
     aws_organizations_organizational_unit.security_engineering.id,
     aws_organizations_organizational_unit.technology_services.id,
     # organization-account
-    aws_organizations_account.security_operations_pre_production.id,
   ]
 }
 


### PR DESCRIPTION
This PR removes the direct attachment of the restricted regions service control policy from the Security Operations pre-production account, as it is already attached through inheritance in the Security Engineering organizational unit.