### PR TITLE
Expand SCP for restricted regions to allow reading CloudWatch logs from Network Manager

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -168,14 +168,14 @@ data "aws_iam_policy_document" "deny_non_eu_non_us_east_1_operations" {
 
   # Deny anything apart from Network Manager in us-west-2
   statement {
-    effect      = "Deny"
+    effect = "Deny"
     not_actions = [
       "networkmanager:*",
-      "cloudwatch:List*", # To view the Network Manager log group
-      "cloudwatch:Get*", # To view the Network Manager log group
+      "cloudwatch:List*",    # To view the Network Manager log group
+      "cloudwatch:Get*",     # To view the Network Manager log group
       "cloudwatch:Describe*" # To view the Network Manager log group
     ]
-    resources   = ["*"]
+    resources = ["*"]
 
     condition {
       test     = "StringEquals"

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -169,7 +169,12 @@ data "aws_iam_policy_document" "deny_non_eu_non_us_east_1_operations" {
   # Deny anything apart from Network Manager in us-west-2
   statement {
     effect      = "Deny"
-    not_actions = ["networkmanager:*"]
+    not_actions = [
+      "networkmanager:*",
+      "cloudwatch:List*", # To view the Network Manager log group
+      "cloudwatch:Get*", # To view the Network Manager log group
+      "cloudwatch:Describe*" # To view the Network Manager log group
+    ]
     resources   = ["*"]
 
     condition {


### PR DESCRIPTION
This PR expands the SCP for restricted regions to allow reading CloudWatch logs in `us-east-2` as per the [Network Manager](https://docs.aws.amazon.com/vpc/latest/tgwnm/nm-security-iam.html) IAM documentation. Network Manager configures a CloudWatch log group in us-east-2.