### PR TITLE
Enrol CICA accounts into restricted regions

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -204,6 +204,7 @@ locals {
     # orgnaizational-unit
     aws_organizations_organizational_unit.analytical_platform.id,
     aws_organizations_organizational_unit.central_digital.id,
+    aws_organizations_organizational_unit.cica.id,
     aws_organizations_organizational_unit.hmcts.id,
     aws_organizations_organizational_unit.hmpps_community_rehabilitation.id,
     aws_organizations_organizational_unit.hmpps_electronic_monitoring_acquisitive_crime.id,


### PR DESCRIPTION
This PR enrols the CICA accounts into the `restricted regions` service control policy, to deny actions outside of `eu-west-1`, `eu-west-2`, `eu-central-1`, and `us-east-1`.

- [x] Billing reviewed
- [x] Billable items in restricted regions have been deleted
- [x] Team aware
