### PR TITLE
add pre / dev accounts to auto remediate list, prod to non auto remediate for Make an LPA service

### DIFF
--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -98,7 +98,8 @@ locals {
       if
       (
         account_name == "shared-services-dev" ||
-        account_name == "MoJ Digital Services"
+        account_name == "MoJ Digital Services" ||
+        account_name == "MOJ LPA Production"
       )
     ],
     organizational_units = [

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -74,7 +74,9 @@ locals {
         account_name == "Youth Justice Framework Dev" ||
         account_name == "Youth Justice Framework Eng Tools" ||
         account_name == "Youth Justice Framework Management" ||
-        account_name == "Youth Justice Framework Sandpit"
+        account_name == "Youth Justice Framework Sandpit" ||
+        account_name == "MOJ LPA Development" ||
+        account_name == "MOJ LPA Preproduction"
       )
     ],
     organizational_units = flatten([
@@ -96,9 +98,7 @@ locals {
       if
       (
         account_name == "shared-services-dev" ||
-        account_name == "MoJ Digital Services" ||
-        account_name == "MOJ LPA Development" ||
-        account_name == "MOJ LPA Preproduction"
+        account_name == "MoJ Digital Services"
       )
     ],
     organizational_units = [


### PR DESCRIPTION
- Add dev and preproduction accounts to the auto remediate list. 
- Add production to go on to non auto remediate list.
we will follow up with a check to see if there are any issues, and check logs, then create a further PR.