### PR TITLE
LPAL-827 correct naming to match account in prod Make an LPA

### DIFF
--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -99,7 +99,7 @@ locals {
       (
         account_name == "shared-services-dev" ||
         account_name == "MoJ Digital Services" ||
-        account_name == "MOJ LPA Production"
+        account_name == "MOJ OPG LPA Production"
       )
     ],
     organizational_units = [


### PR DESCRIPTION
prod should've been `MOJ OPG LPA Production` -  this rectifies that.