### PR TITLE
Enable MP developers to amend autoscaling groups

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -139,6 +139,7 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
   statement {
     actions = [
       "acm:ImportCertificate",
+      "autoscaling:UpdateAutoScalingGroup",
       "secretsmanager:GetResourcePolicy",
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",


### PR DESCRIPTION
This will allow developers to turn the bastion on after 9pm or make
emergency changes to scale out the number of instances.

Note any manual changes will be short lived as the next Terraform run will
overwrite any changes with the coded ones.