### PR TITLE
Simplify using pre-created accounts by removing the need to assume a role in Modernisation Platform

### DIFF
--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -38,4 +38,18 @@ locals {
       if account.status == "ACTIVE"
     }
   }
+
+  # Modernisation Platform account IDs
+  modernisation_platform_accounts = {
+    core_network_services_id = [
+      for account_name, account_id in local.accounts.active_only:
+      account_id
+      if account_name == "core-network-services"
+    ]
+    core_shared_services_id = [
+      for account_name, account_id in local.accounts.active_only:
+      account_id
+      if account_name == "core-shared-services"
+    ]
+  }
 }

--- a/management-account/terraform/providers-modernisation-platform.tf
+++ b/management-account/terraform/providers-modernisation-platform.tf
@@ -1,9 +1,0 @@
-# Provider for the Modernisation Platform, to get account IDs managed by the Modernisation Platform
-provider "aws" {
-  alias  = "modernisation-platform"
-  region = "eu-west-2"
-
-  assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.modernisation_platform.id}:role/OrganizationAccountAccessRole"
-  }
-}

--- a/management-account/terraform/secrets-manager.tf
+++ b/management-account/terraform/secrets-manager.tf
@@ -10,18 +10,3 @@ locals {
   aws_account_email_addresses          = jsondecode(data.aws_secretsmanager_secret_version.aws_account_email_addresses.secret_string)
   aws_account_email_addresses_template = local.aws_account_email_addresses["template"]
 }
-
-# Below is a data source to get all Modernisation Platform-managed AWS accounts
-data "aws_secretsmanager_secret" "modernisation_platform_environment_management" {
-  provider = aws.modernisation-platform
-  name     = "environment_management"
-}
-
-data "aws_secretsmanager_secret_version" "modernisation_platform_account_ids" {
-  provider  = aws.modernisation-platform
-  secret_id = data.aws_secretsmanager_secret.modernisation_platform_environment_management.id
-}
-
-locals {
-  modernisation_platform_environment_management = jsondecode(data.aws_secretsmanager_secret_version.modernisation_platform_account_ids.secret_string).account_ids
-}

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -275,9 +275,9 @@ locals {
     {
       github_team        = "moj-official-techops",
       permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
-      account_ids = [
-        local.modernisation_platform_environment_management["core-network-services-production"]
-      ]
+      account_ids = flatten([
+        local.modernisation_platform_accounts.core_network_services_id
+      ])
     },
     {
       github_team        = "cloud-ops-alz-admins",
@@ -347,7 +347,7 @@ locals {
 }
 
 resource "aws_ssoadmin_account_assignment" "github_team_access" {
-  for_each = tomap(nonsensitive(local.sso_admin_account_assignments_with_keys))
+  for_each = tomap(local.sso_admin_account_assignments_with_keys)
 
   instance_arn       = local.sso_admin_instance_arn
   permission_set_arn = each.value.permission_set_arn

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -213,7 +213,7 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
     resources = [
       "arn:aws:iam::*:role/read-dns-records",
       "arn:aws:iam::*:role/member-delegation-read-only",
-      "arn:aws:iam::${local.modernisation_platform_environment_management["core-shared-services-production"]}:role/member-shared-services"
+      "arn:aws:iam::${coalesce(local.modernisation_platform_accounts.core_shared_services_id...)}:role/member-shared-services"
     ]
   }
 }


### PR DESCRIPTION
This PR removes the need to use a separate provider to get an account ID, instead by relying on the name for an account that is already created. This also simplifies and improves the security for the github-actions workflow, as it won't need permissions to assume a role in another account.