### PR TITLE
Remove organisation-management from restricted regions due to GuardDuty usage

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -211,7 +211,6 @@ locals {
     aws_organizations_organizational_unit.hmpps_electronic_monitoring_case_management.id,
     aws_organizations_organizational_unit.laa.id,
     aws_organizations_organizational_unit.opg.id,
-    aws_organizations_organizational_unit.organisation_management.id,
     aws_organizations_organizational_unit.platforms_and_architecture_cloud_platform.id,
     aws_organizations_organizational_unit.platforms_and_architecture_digital_studio_operations.id,
     aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id,


### PR DESCRIPTION
The `organisation-management` accounts are the delegated administrators for services such as GuardDuty, which is enabled in all regions. This PR removes the regional restrictions inherited through the SCP to allow the account to access GuardDuty in otherwise restricted regions (e.g. ap-* regions).