### PR TITLE
Add identitystore:List permissions for GitHub OIDC

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -64,7 +64,8 @@ data "aws_iam_policy_document" "extra_permissions" {
     actions = [
       "account:GetAlternateContact",
       "cur:DescribeReportDefinitions",
-      "secretsmanager:GetSecretValue"
+      "identitystore:ListGroups",
+      "secretsmanager:GetSecretValue",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
This PR adds a missing `identitystore:List` permission to GitHub OIDC.