### PR TITLE
Move SSO and SCIM modules to management-account

### DIFF
--- a/management-account/terraform/.terraform.lock.hcl
+++ b/management-account/terraform/.terraform.lock.hcl
@@ -1,9 +1,50 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/auth0/auth0" {
+  version     = "0.31.0"
+  constraints = "0.31.0"
+  hashes = [
+    "h1:Xh2Q7dnADxBDSoM5BsraPfsg3hCbbi9uh2M115oPNrg=",
+    "zh:0172fb27efae43d3d60b8190b467643f5e0ed926f12ea0271465ec4839714530",
+    "zh:13c91ed523b6d41a3ed0ee8d1194ef67a33d10faabd138e148039a84e394b9ca",
+    "zh:1d124b8681450c46c7b29a7569a71aa302015e540ed764ac1d8d522516ec75ca",
+    "zh:3220b318518b2d80caefdbfdd7378dd8e0cf1f1122d4adfd549601a8a299419b",
+    "zh:3322048311b649f0ff7b8596acb50a83db55056d85e293ad3b2cb545805df919",
+    "zh:343f001a5fc8ac85991de2074c162c194a698739ad47ea80dd086757fc97b56e",
+    "zh:400f792935b3d91cf34275c2c1f72ca2176846d761dafae1823d4c453bd8c499",
+    "zh:441b45a8765ae431ee43334a3e0c291aba5fab8b18c14349edbf6a2f3d7dd08d",
+    "zh:60568105d60e78bbe5acd63546538f236b23354166ad0eaa037dcbabd0bc1cd5",
+    "zh:7b7a8981921923062b2ba15758c059b6d27ab6dac7c794299dfc00a557b01b65",
+    "zh:91fb6ad78f889e06bc4cf100f49693c90bca2a1b393b21c78c4f71edf28f4144",
+    "zh:9ab798718d56f09ded19085a7a196e3d730c5ad5b015a619e815cdb687183b82",
+    "zh:abc872d52a3bd267c5689f0453e6fe49dad8c4205176e7382706ddfcd1d613cd",
+    "zh:d5a79f4c318bcf9e976854dbce2a7155471e8c2046e91899e25bb37af8e00997",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.2.0"
+  constraints = ">= 2.2.0"
+  hashes = [
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.8.0"
-  constraints = ">= 4.0.0, >= 4.7.0, 4.8.0"
+  constraints = ">= 3.6.0, >= 3.60.0, >= 4.0.0, >= 4.7.0, 4.8.0"
   hashes = [
     "h1:W2cPGKmqkPbTc91lu42QeC3RFBqB5TnRnS3IxNME2FM=",
     "zh:16cbdbc03ad13358d12433e645e2ab5a615e3a3662a74e3c317267c9377713d8",
@@ -18,6 +59,26 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:d27f9a8b5b30883a3e45f77506391524df0c66a76c3bc71f7236c3fc81d0597d",
     "zh:e2985563dc652cf9b10420bc62f0a710308ef5c31e46b94c8ea10b8f27fa1ef3",
     "zh:f11bb34ee0dad4bc865db51e7e299a4f030c5e9f6b6080d611797cc99deeb40a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.2.2"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:VUkgcWvCliS0HO4kt7oEQhFD2gcx/59XpwMqxfCU1kE=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
   ]
 }
 
@@ -42,7 +103,8 @@ provider "registry.terraform.io/hashicorp/random" {
 }
 
 provider "registry.terraform.io/hashicorp/tls" {
-  version = "3.4.0"
+  version     = "3.4.0"
+  constraints = "3.4.0"
   hashes = [
     "h1:fSRc/OyRitbAST9vE+mEcmgJiDp+Jx8pGPbUUeYEQRc=",
     "zh:2442a0df0cfb550b8eba9b2af39ac06f54b62447eb369ecc6b1c29f739b33bbb",

--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -52,4 +52,15 @@ locals {
       if account_name == "core-shared-services"
     ]
   }
+
+  # SSO
+  sso = {
+    email_suffix        = "@digital.justice.gov.uk"
+    region              = "eu-west-2"
+    github_organisation = "ministryofjustice"
+    auth0_tenant_domain = "ministryofjustice.eu.auth0.com"
+    auth0_saml          = sensitive(jsondecode(data.aws_secretsmanager_secret_version.auth0_saml.secret_string))
+    github_saml         = sensitive(jsondecode(data.aws_secretsmanager_secret_version.github_saml.secret_string))
+    aws_saml            = sensitive(jsondecode(data.aws_secretsmanager_secret_version.aws_saml.secret_string))
+  }
 }

--- a/management-account/terraform/secrets-manager.tf
+++ b/management-account/terraform/secrets-manager.tf
@@ -10,3 +10,33 @@ locals {
   aws_account_email_addresses          = jsondecode(data.aws_secretsmanager_secret_version.aws_account_email_addresses.secret_string)
   aws_account_email_addresses_template = local.aws_account_email_addresses["template"]
 }
+
+# SAML: Auth0 credentials
+resource "aws_secretsmanager_secret" "auth0_saml" {
+  name        = "auth0_saml"
+  description = "Auth0 Machine to Machine credentials for Terraform to setup Auth0 for AWS SSO"
+}
+
+data "aws_secretsmanager_secret_version" "auth0_saml" {
+  secret_id = aws_secretsmanager_secret.auth0_saml.id
+}
+
+# SAML: GitHub client ID and secrets
+resource "aws_secretsmanager_secret" "github_saml" {
+  name        = "github_saml"
+  description = "GitHub client ID and secret for the Ministry of Justice owned OAuth app for AWS SSO"
+}
+
+data "aws_secretsmanager_secret_version" "github_saml" {
+  secret_id = aws_secretsmanager_secret.github_saml.id
+}
+
+# SAML: AWS SSO
+resource "aws_secretsmanager_secret" "aws_saml" {
+  name        = "aws_saml"
+  description = "AWS SSO ACS and Issuer URLs"
+}
+
+data "aws_secretsmanager_secret_version" "aws_saml" {
+  secret_id = aws_secretsmanager_secret.aws_saml.id
+}

--- a/management-account/terraform/sso-scim.tf
+++ b/management-account/terraform/sso-scim.tf
@@ -1,0 +1,9 @@
+module "scim" {
+  source              = "github.com/ministryofjustice/moj-terraform-scim-github"
+  github_organisation = local.sso.github_organisation
+  github_token        = sensitive(local.sso.aws_saml.github_token)
+  sso_aws_region      = local.sso.region
+  sso_email_suffix    = local.sso.email_suffix
+  sso_scim_token      = sensitive(local.sso.aws_saml.sso_scim_token)
+  sso_tenant_id       = sensitive(local.sso.aws_saml.sso_tenant_id)
+}

--- a/management-account/terraform/sso.tf
+++ b/management-account/terraform/sso.tf
@@ -1,0 +1,15 @@
+module "sso" {
+  source                     = "github.com/ministryofjustice/moj-terraform-aws-sso"
+  auth0_allowed_domains      = local.sso.email_suffix
+  auth0_aws_sso_acs_url      = sensitive(local.sso.aws_saml.acs_url)
+  auth0_aws_sso_issuer_url   = sensitive(local.sso.aws_saml.issuer_url)
+  auth0_client_id            = sensitive(local.sso.auth0_saml.client_id)
+  auth0_client_secret        = sensitive(local.sso.auth0_saml.client_secret)
+  auth0_github_allowed_orgs  = [local.sso.github_organisation]
+  auth0_github_client_id     = sensitive(local.sso.github_saml.client_id)
+  auth0_github_client_secret = sensitive(local.sso.github_saml.client_secret)
+  auth0_tenant_domain        = sensitive(local.sso.auth0_tenant_domain)
+  sso_aws_region             = local.sso.region
+  sso_scim_token             = sensitive(local.sso.aws_saml.sso_scim_token)
+  sso_tenant_id              = sensitive(local.sso.aws_saml.sso_tenant_id)
+}


### PR DESCRIPTION
This PR moves the [SSO and SCIM modules](https://github.com/ministryofjustice/aws-root-account/blob/main/terraform/sso.tf) into `management-account`.