### PR TITLE
Remove accounts past their 90-day closure cool-off period

### DIFF
--- a/management-account/terraform/budgets.tf
+++ b/management-account/terraform/budgets.tf
@@ -54,7 +54,6 @@ resource "aws_budgets_budget" "hmpps_delius" {
       aws_organizations_account.hmpps_delius_mis_non_prod.id,
       aws_organizations_account.hmpps_delius_mis_test.id,
       aws_organizations_account.hmpps_delius_performance.id,
-      aws_organizations_account.hmpps_delius_po_test.id,
       aws_organizations_account.hmpps_delius_po_test_1.id,
       aws_organizations_account.hmpps_delius_po_test_2.id,
       aws_organizations_account.hmpps_delius_pre_production.id,
@@ -110,7 +109,6 @@ resource "aws_budgets_budget" "laa" {
   cost_filter {
     name = "LinkedAccount"
     values = [
-      aws_organizations_account.aws_laa.id,
       aws_organizations_account.laa_cloudtrail.id,
       aws_organizations_account.laa_development.id,
       aws_organizations_account.laa_production.id,

--- a/management-account/terraform/organizations-accounts-closed-accounts.tf
+++ b/management-account/terraform/organizations-accounts-closed-accounts.tf
@@ -1,83 +1,9 @@
-resource "aws_organizations_account" "aws_laa" {
-  name                       = "AWS LAA"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "laa")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
-  tags                       = {}
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "money_to_prisoners" {
   name                       = "Money To Prisoners"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "moneytoprisoners")
   iam_user_access_to_billing = "ALLOW"
   parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
   tags                       = {}
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
-resource "aws_organizations_account" "platforms_non_production" {
-  name                       = "platforms-non-production"
-  email                      = local.aws_account_email_addresses["platforms-non-production"][0]
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
-  tags                       = {}
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
-resource "aws_organizations_account" "hmpps_delius_po_test" {
-  name                       = "HMPPS Delius PO Test"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-delius-po-test")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
-
-  tags = merge(local.tags_delius, {
-
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
-resource "aws_organizations_account" "noms_api" {
-  name                       = "NOMS API"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "noms-api")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
-
-  tags = merge(local.tags_hmpps, {
-
-  })
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
This PR removes the following AWS accounts, which are now past their 90-day closure cool-off period:

- AWS LAA
- platforms-non-production
- HMPPS Delius PO Test
- NOMS API