### PR TITLE
Give transit-gateway-readonly access to Analytical Platform accounts

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -329,6 +329,14 @@ locals {
       account_ids = [
         aws_organizations_account.organisation_security.id
       ]
+    },
+    {
+      github_team        = "transit-gateway-readonly"
+      permission_set_arn = aws_ssoadmin_permission_set.ec2_readonly.arn,
+      account_ids = [
+        aws_organizations_account.moj_analytics_platform.id,
+        aws_organizations_account.analytical_platform_data_engineering.id
+      ]
     }
   ]
   sso_admin_account_assignments_expanded = flatten([

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -59,6 +59,21 @@ resource "aws_ssoadmin_managed_policy_attachment" "billing" {
   permission_set_arn = aws_ssoadmin_permission_set.billing.arn
 }
 
+# EC2 Read Only
+resource "aws_ssoadmin_permission_set" "ec2_readonly" {
+  name             = "EC2ReadOnly"
+  description      = "EC2 read-only access"
+  instance_arn     = local.sso_admin_instance_arn
+  session_duration = "PT8H"
+  tags             = {}
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "ec2_readonly" {
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.ec2_readonly.arn
+}
+
 # Read Only Access
 resource "aws_ssoadmin_permission_set" "read_only_access" {
   name             = "ReadOnlyAccess"


### PR DESCRIPTION
This PR gives the "transit-gateway-readonly" GitHub team readonly access to AWS accounts.