### PR TITLE
Temporarily add permissions to the Mod Platform Developer role.

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -158,7 +158,9 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
       "ec2:CreateTags",
       "s3:PutObject",
       "s3:DeleteObject",
-      "aws-marketplace:ViewSubscriptions"
+      "aws-marketplace:ViewSubscriptions",
+      "lambda:InvokeFunction",
+      "lambda:UpdateFunctionCode"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
This is to simplify debugging of lambdas in the console.