### PR TITLE
Add Mod Platform developer lambda permissions for easier debugging

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -155,6 +155,8 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
     actions = [
       "acm:ImportCertificate",
       "autoscaling:UpdateAutoScalingGroup",
+      "lambda:InvokeFunction",
+      "lambda:UpdateFunctionCode",
       "secretsmanager:GetResourcePolicy",
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",


### PR DESCRIPTION
This is a temporary measure and should be reverted as soon as XP team is 
rolled off.