### PR TITLE
Move HMPPS Delius MIS Test to closed accounts

### DIFF
--- a/management-account/terraform/organizations-accounts-closed-accounts.tf
+++ b/management-account/terraform/organizations-accounts-closed-accounts.tf
@@ -232,3 +232,23 @@ resource "aws_organizations_account" "hmpps_victim_case_management_system_integr
     ]
   }
 }
+
+resource "aws_organizations_account" "hmpps_delius_mis_test" {
+  name                       = "HMPPS Delius MIS Test"
+  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-delius-mis-test")
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
+
+  tags = merge(local.tags_delius, {
+
+  })
+
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name,
+    ]
+  }
+}

--- a/management-account/terraform/organizations-accounts-hmpps-delius.tf
+++ b/management-account/terraform/organizations-accounts-hmpps-delius.tf
@@ -62,26 +62,6 @@ resource "aws_organizations_account" "hmpps_delius_mis_non_prod" {
   }
 }
 
-resource "aws_organizations_account" "hmpps_delius_mis_test" {
-  name                       = "HMPPS Delius MIS Test"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-delius-mis-test")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.hmpps_delius.id
-
-  tags = merge(local.tags_delius, {
-
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "hmpps_delius_pre_production" {
   name                       = "HMPPS Delius Pre Production"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-delius-pre-prod")


### PR DESCRIPTION
This PR moves HMPPS Delius MIS Test to closed accounts as it is no longer used.