### PR TITLE
Added sso:GetRoleCredentials to modernisation_platform_developer

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -186,7 +186,8 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
       "s3:DeleteObject",
       "aws-marketplace:ViewSubscriptions",
       "support:*",
-      "ssm-guiconnect:*"
+      "ssm-guiconnect:*",
+      "sso:GetRoleCredentials"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
Added sso:GetRoleCredentials to modernisation_platform_developer policy. To try to fix the error:

```
aws sso login --profile sprinkler-development-sso
aws ec2 describe-instances --no-cli-pager --profile sprinkler-development-sso
An error occurred (ForbiddenException) when calling the GetRoleCredentials operation: No access
```

Further details can be found in this slack thread: https://mojdt.slack.com/archives/C013RM6MFFW/p1661330212364299