### PR TITLE
Refactor AWS Shield Advanced auto-enrolment: enrol MP member OU in its entirety, not MP member children

### DIFF
--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -93,10 +93,7 @@ locals {
       local.ou_sirius,
       local.ou_technology_services,
       data.aws_organizations_organizational_units.modernisation_platform_core.id,
-      [
-        for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children :
-        ou.id
-      ]
+      data.aws_organizations_organizational_units.modernisation_platform_member.id
     ])
   }
   shield_advanced_no_auto_remediate = {


### PR DESCRIPTION
Whilst we were testing Shield Advanced, we excluded some members of the Modernisation Platform from being enrolled. In #521, the last excluded member, `Xhibit Portal`, [was enrolled](https://github.com/ministryofjustice/aws-root-account/commit/a501b4132e6052d012ce89664ce3781d9de49c60).

This PR switches from enrolling each child organisational unit, to enrolling the parent OU (which will then enrol all of it's children).