### PR TITLE
Adding CreateGrant permission to mod-platform-developer policy

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -191,6 +191,17 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
 
     resources = ["*"]
   }
+  statement {
+    actions = [
+      "kms:CreateGrant"
+    ]
+    resources = ["arn:aws:kms:*:${coalesce(local.modernisation_platform_accounts.core_shared_services_id...)}:key/*"]
+    condition {
+      test     = "Bool"
+      variable = "kms:GrantIsForAWSResource"
+      values   = ["true"]
+    }
+  }
 
   statement {
     actions = [


### PR DESCRIPTION
In order to start instances with EBS volumes encrypted with shared KMS keys, developers need to be able to create a grant to the instance.
Adding this permission to the dev role along with a restriction on the types of resources that can get the grant.

For reference: https://aws.amazon.com/premiumsupport/knowledge-center/kms-iam-ec2-permission/
