### PR TITLE
:busts_in_silhouette: Add cloud-ops-writers 

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -285,6 +285,18 @@ locals {
         aws_organizations_account.moj_official_shared_services.id,
       ]
     },
+        {
+      github_team        = "cloud-ops-writers",
+      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
+      account_ids = [
+        aws_organizations_account.moj_official_development.id,
+        aws_organizations_account.moj_official_preproduction.id,
+        aws_organizations_account.moj_official_production.id,
+        aws_organizations_account.moj_official_public_key_infrastructure_dev.id,
+        aws_organizations_account.moj_official_public_key_infrastructure.id,
+        aws_organizations_account.moj_official_shared_services.id,
+      ]
+    },
     {
       github_team        = "modernisation-platform-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.aws_sso_read_only.arn,

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -285,7 +285,7 @@ locals {
         aws_organizations_account.moj_official_shared_services.id,
       ]
     },
-        {
+    {
       github_team        = "cloud-ops-writers",
       permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
       account_ids = [


### PR DESCRIPTION
- This PR will give the `cloud-ops-writers` group `read-only` access to the MoJ Official accounts so they can view billing information on our accounts