### PR TITLE
Adding permissions for quicksight

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -321,6 +321,7 @@ data "aws_iam_policy_document" "modernisation_platform_sandbox" {
       "logs:*",
       "organizations:Describe*",
       "organizations:List*",
+      "quicksight:*",
       "rds-db:*",
       "rds:*",
       "route53:*",


### PR DESCRIPTION
Adding permissions for quicksight, as they are required by refer-monitor. A corresponding change will need to be made in the mod platform repo.

This has been requested by the team, so hopefully will work.