### PR TITLE
Add MP dev and sandbox access STS permissions

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -241,7 +241,8 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
     resources = [
       "arn:aws:iam::*:role/read-dns-records",
       "arn:aws:iam::*:role/member-delegation-read-only",
-      "arn:aws:iam::${coalesce(local.modernisation_platform_accounts.core_shared_services_id...)}:role/member-shared-services"
+      "arn:aws:iam::${coalesce(local.modernisation_platform_accounts.core_shared_services_id...)}:role/member-shared-services",
+      "arn:aws:iam::${aws_organizations_account.modernisation_platform.id}:role/githubReadOnly"
     ]
   }
 }
@@ -397,6 +398,19 @@ data "aws_iam_policy_document" "modernisation_platform_sandbox" {
       "iam:UpdateRoleDescription"
     ]
     resources = ["arn:aws:iam::*:user/cicd-member-user"]
+  }
+
+  statement {
+    actions = [
+      "sts:AssumeRole"
+    ]
+
+    resources = [
+      "arn:aws:iam::*:role/read-dns-records",
+      "arn:aws:iam::*:role/member-delegation-read-only",
+      "arn:aws:iam::${coalesce(local.modernisation_platform_accounts.core_shared_services_id...)}:role/member-shared-services",
+      "arn:aws:iam::${aws_organizations_account.modernisation_platform.id}:role/githubReadOnly"
+    ]
   }
 }
 


### PR DESCRIPTION
Adding the ability for the developer role to assume the githubreadonly role for the main account, this role is used by github actions, and adding the ability to assume it so that the terraform can be planned locally.

Mirroring the same sts:assume roles to the sandbox role.