### PR TITLE
Move Security Logging Platform (MLAP) to Closed accounts

### DIFF
--- a/management-account/terraform/organizations-accounts-closed-accounts.tf
+++ b/management-account/terraform/organizations-accounts-closed-accounts.tf
@@ -54,3 +54,21 @@ resource "aws_organizations_account" "hmpps_delius_mis_test" {
     ]
   }
 }
+
+resource "aws_organizations_account" "security_logging_platform" {
+  name                       = "Security Logging Platform"
+  email                      = replace(local.aws_account_email_addresses_template, "{email}", "security-logging-platform")
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
+
+  tags = local.tags_security
+
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name,
+    ]
+  }
+}

--- a/management-account/terraform/organizations-accounts-security-engineering.tf
+++ b/management-account/terraform/organizations-accounts-security-engineering.tf
@@ -20,24 +20,6 @@ resource "aws_organizations_account" "moj_security" {
   }
 }
 
-resource "aws_organizations_account" "security_logging_platform" {
-  name                       = "Security Logging Platform"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "security-logging-platform")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.security_engineering.id
-
-  tags = local.tags_security
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "security_operations_development" {
   name                       = "Security Operations Development"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "secops-dev")


### PR DESCRIPTION
This account used to house MLAP, which has now been superseded by a different SIEM (Azure Sentinel).