### PR TITLE
Enabling AminAccessRole in MP Account

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -212,6 +212,13 @@ locals {
       ]
     },
     {
+      github_team        = "modernisation-platform-engineers",
+      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
+      account_ids = [
+        aws_organizations_account.modernisation_platform.id
+      ]
+    },
+    {
       github_team        = "secops",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [


### PR DESCRIPTION
This is in aid of retiring the use of superadmin static credentials to perform local plans and applies in Modernisation Platform accounts including the main one.
