### PR TITLE
Edtied permissions for developers based on requirements, now can copy…

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -185,6 +185,10 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
       "s3:PutObject",
       "s3:DeleteObject",
       "aws-marketplace:ViewSubscriptions",
+      "rds:CopyDBSnapshot",
+      "rds:CopyDBClusterSnapshot",
+      "rds:CreateDBSnapshot",
+      "rds:CreateDBClusterSnapshot",
       "support:*",
       "ssm-guiconnect:*",
       "rhelkb:GetRhelURL"


### PR DESCRIPTION
They now can copy db snapshots, clustered or not, as well as create them, similar to the permissions we give on ec2.