### PR TITLE
Adding a Github web identity assumable role

### DIFF
--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -107,7 +107,7 @@ resource "aws_iam_role_policy_attachment" "modernisation_platform_sso_administra
 
 module "modernisation_platform_github_actions_role" {
 
-  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=1.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=v1.0.0"
 
   github_repositories = ["ministryofjustice/modernisation-platform:*"]
   role_name           = "ModernisationPlatformGithubActionsRole"

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -100,3 +100,18 @@ resource "aws_iam_role_policy_attachment" "modernisation_platform_sso_administra
   role       = aws_iam_role.modernisation_platform_sso_administrator.name
   policy_arn = aws_iam_policy.sso_administrator_policy.arn
 }
+
+##########################################
+# ModernisationPlatformGithubActionsRole #
+##########################################
+
+module "modernisation_platform_github_actions_role" {
+
+  source = "https://github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=1.0.0"
+
+  github_repositories = ["ministryofjustice/modernisation-platform:*"]
+  role_name           = "ModernisationPlatformGithubActionsRole"
+  policy_arns         = [aws_iam_policy.terraform_organisation_management_policy.arn]
+  tags                = {}
+
+}

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -107,7 +107,7 @@ resource "aws_iam_role_policy_attachment" "modernisation_platform_sso_administra
 
 module "modernisation_platform_github_actions_role" {
 
-  source = "https://github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=1.0.0"
+  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=1.0.0"
 
   github_repositories = ["ministryofjustice/modernisation-platform:*"]
   role_name           = "ModernisationPlatformGithubActionsRole"


### PR DESCRIPTION
Relevant Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2593

Currently, workflows in https://github.com/ministryofjustice/modernisation-platform repository that are targeting the main organisation account are running with a static credentials of [this iam user](https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/iam-users.tf#L105). This PR creates a role assumable with a Github web identity with the same permissions which is restricted to the MP repo, in order to allow the conversion of those workflows to OIDC. 

This PR does not retire any iam users, groups or policies.