### PR TITLE
Adding iam:GetRole permission to ModernisationPlatformGithubActionsRole

### DIFF
--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -112,7 +112,7 @@ module "modernisation_platform_github_actions_role" {
   github_repositories = ["ministryofjustice/modernisation-platform:*"]
   role_name           = "ModernisationPlatformGithubActionsRole"
   policy_arns         = [aws_iam_policy.terraform_organisation_management_policy.arn]
-  policy_jsons        = [aws_iam_policy_document.modernisation_platform_github_actions_additional_policy.json]
+  policy_jsons        = [data.aws_iam_policy_document.modernisation_platform_github_actions_additional_policy.json]
   tags                = {}
 
 }

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -112,7 +112,7 @@ module "modernisation_platform_github_actions_role" {
   github_repositories = ["ministryofjustice/modernisation-platform:*"]
   role_name           = "ModernisationPlatformGithubActionsRole"
   policy_arns         = [aws_iam_policy.terraform_organisation_management_policy.arn]
-  policy_jsons        = [aws_iam_policy.modernisation_platform_github_actions_additional_policy.json]
+  policy_jsons        = [aws_iam_policy_document.modernisation_platform_github_actions_additional_policy.json]
   tags                = {}
 
 }

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -112,6 +112,20 @@ module "modernisation_platform_github_actions_role" {
   github_repositories = ["ministryofjustice/modernisation-platform:*"]
   role_name           = "ModernisationPlatformGithubActionsRole"
   policy_arns         = [aws_iam_policy.terraform_organisation_management_policy.arn]
+  policy_jsons        = [aws_iam_policy.modernisation_platform_github_actions_additional_policy.json]
   tags                = {}
 
+}
+
+data "aws_iam_policy_document" "modernisation_platform_github_actions_additional_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:GetRole"
+    ]
+
+    resources = [module.modernisation_platform_github_actions_role.role]
+  }
 }


### PR DESCRIPTION
Related Issue: https://github.com/ministryofjustice/modernisation-platform/issues/2568

Modernisation platform delegate-access terraform implements a [workaround](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/bootstrap/delegate-access/providers.tf#L11) that allows it to be run using multiple roles without having to modify the providers.tf file. However, requires that all the calling roles need 
`iam:GetRole` 
permissions to run the code so they can [query](https://github.com/ministryofjustice/modernisation-platform/blob/main/terraform/environments/bootstrap/delegate-access/locals.tf#L5) information about themselves. The iam user group currently used to run the workflow has the `iam:GetUser` equivalent permission.

This PR adds the `iam:GetRole` permission to the `ModernisationPlatformGithubActionsRole` role.
