### PR TITLE
Add rds Reboot permissions

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -192,6 +192,7 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
       "rds:CopyDBClusterSnapshot",
       "rds:CreateDBSnapshot",
       "rds:CreateDBClusterSnapshot",
+      "rds:RebootDB*",
       "support:*",
       "ssm-guiconnect:*",
       "rhelkb:GetRhelURL",


### PR DESCRIPTION
Allow the Modernisation Platform developer role to reboot databases.

This saves users having to push pipeline changes to trigger reboots/rebuilds.