### PR TITLE
Add MP to MoJ official shared-services read only

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -195,6 +195,7 @@ locals {
       account_ids = [
         aws_organizations_account.cloud_platform_transit_gateways.id,
         aws_organizations_account.moj_official_production.id,
+        aws_organizations_account.moj_official_shared_services.id,
       ]
     },
     {


### PR DESCRIPTION
This will allow MP engineers to view the progress and any error messages on deployment pipelines when raising changes in the tgw deployment repo.