### PR TITLE
Remove HMPPS Delius MIS Test from Closed accounts

### DIFF
--- a/management-account/terraform/organizations-accounts-closed-accounts.tf
+++ b/management-account/terraform/organizations-accounts-closed-accounts.tf
@@ -15,26 +15,6 @@ resource "aws_organizations_account" "money_to_prisoners" {
   }
 }
 
-resource "aws_organizations_account" "hmpps_delius_mis_test" {
-  name                       = "HMPPS Delius MIS Test"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "hmpps-delius-mis-test")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
-
-  tags = merge(local.tags_delius, {
-
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "security_logging_platform" {
   name                       = "Security Logging Platform"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "security-logging-platform")


### PR DESCRIPTION
This PR removes `HMPPS Delius MIS Test`, as it is past its 90-day suspension cool-off period.