### PR TITLE
Enable trusted access for GuardDuty Malware Protection

### DIFF
--- a/management-account/terraform/organizations.tf
+++ b/management-account/terraform/organizations.tf
@@ -15,6 +15,7 @@ resource "aws_organizations_organization" "default" {
     "license-manager.amazonaws.com",
     "license-manager.member-account.amazonaws.com",
     "macie.amazonaws.com",
+    "malware-protection.guardduty.amazonaws.com",
     "ram.amazonaws.com",
     "reporting.trustedadvisor.amazonaws.com",
     "securityhub.amazonaws.com",


### PR DESCRIPTION
This PR enables organizational trusted access for [GuardDuty Malware Protection](https://docs.aws.amazon.com/guardduty/latest/ug/malware-protection.html).