### PR TITLE
Add application migration service permissions MP

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -350,7 +350,10 @@ data "aws_iam_policy_document" "modernisation_platform_sandbox" {
       "redshift:*",
       "redshift-data:*",
       "redshift-serverless:*",
-      "sqlworkbench:*"
+      "sqlworkbench:*",
+      "mgn:*",
+      "drs:*",
+      "mgh:*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
Adding permissions to allow the modernisation platform sandbox role to use the AWS application migration service.