### PR TITLE
Adding DS tags and snapshot permissions to MP ClickOps roles.

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -213,7 +213,9 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
       "rhelkb:GetRhelURL",
       "cloudwatch:PutDashboard",
       "cloudwatch:ListMetrics",
-      "cloudwatch:DeleteDashboards"
+      "cloudwatch:DeleteDashboards",
+      "ds:*Tags*",
+      "ds:*Snapshot*"
     ]
 
     resources = ["*"]
@@ -368,7 +370,9 @@ data "aws_iam_policy_document" "modernisation_platform_sandbox" {
       "sqlworkbench:*",
       "mgn:*",
       "drs:*",
-      "mgh:*"
+      "mgh:*",
+      "ds:*Tags*",
+      "ds:*Snapshot*"
     ]
     resources = ["*"] #tfsec:ignore:AWS099 tfsec:ignore:AWS097
   }


### PR DESCRIPTION
Related thread: https://mojdt.slack.com/archives/C01A7QK5VM1/p1669997610033519

Permissions needed to add/remove tags and take/restore from/delete directory service snapshots via the aws console
