### PR TITLE
Replace filter {} with alternate_identifier {}

### DIFF
--- a/management-account/terraform/sso-identity-store.tf
+++ b/management-account/terraform/sso-identity-store.tf
@@ -3,8 +3,10 @@ data "aws_identitystore_group" "default" {
 
   identity_store_id = local.sso_admin_identity_store_id
 
-  filter {
-    attribute_path  = "DisplayName"
-    attribute_value = each.value
+  alternate_identifier {
+    unique_attribute {
+      attribute_path  = "DisplayName"
+      attribute_value = each.value
+    }
   }
 }


### PR DESCRIPTION
`aws_identitystore_group`'s `filter` attribute was deprecated in [terraform-provider-aws v4.40.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#4400-november-17-2022) in favour of `alternate_identifier`, so this replaces it.