### PR TITLE
Update sso-admin-permission-sets.tf

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -179,6 +179,7 @@ data "aws_iam_policy_document" "modernisation_platform_developer" {
       "secretsmanager:PutSecretValue",
       "secretsmanager:UpdateSecret",
       "secretsmanager:RestoreSecret",
+      "secretsmanager:RotateSecret",
       "ssm:*",
       "kms:Decrypt*",
       "kms:Encrypt",


### PR DESCRIPTION
Gareth Wood
 [Today at 8:40 AM](https://mojdt.slack.com/archives/C01A7QK5VM1/p1671525603135529)
Hey! I’d like to test that I am able to successfully rotate a Secrets Manager secret value using a Lambda function we’ve deployed, but am unable to do so because of permission:
Failed to rotate the secret "apex/app/system-root-password". User: arn:aws:sts::573115265413:assumed-role/AWSReservedSSO_modernisation-platform-developer_1d9bd12b9fbfac0b/gcw85@digital.justice.gov.uk is not authorized to perform: secretsmanager:RotateSecret on resource: arn:aws:secretsmanager:eu-west-2:573115265413:secret:apex/app/system-root-password-Dl5EU1 because no identity-based policy allows the secretsmanager:RotateSecret action