### PR TITLE
Apply root user lockout SCP to AP OU.

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -87,6 +87,11 @@ resource "aws_organizations_policy_attachment" "deny_aws_account_root_user_cloud
   target_id = aws_organizations_account.cloud_platform_transit_gateways.id
 }
 
+resource "aws_organizations_policy_attachment" "deny_aws_account_root_user_analytical_platform_ou" {
+  policy_id = aws_organizations_policy.deny_aws_account_root_user.id
+  target_id = aws_organizations_organizational_unit.analytical_platform.id
+}
+
 #####################################
 # Deny all actions on all resources #
 #####################################


### PR DESCRIPTION
This action is to mitigate the risk around Security Hub finding that asks for a hardware MFA key to be assigned to root users.
