### PR TITLE
Giving Data Enineering administrator access in the DE sandbox account.

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -371,7 +371,14 @@ locals {
         aws_organizations_account.analytical_platform_data_engineering.id,
         aws_organizations_account.moj_analytics_platform.id,
       ]
-    }
+    },
+    {
+      github_team        = "data-engineering",
+      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
+      account_ids = [
+        aws_organizations_account.analytical_platform_data_engineering_sandbox.id,
+      ]
+    },
   ]
   sso_admin_account_assignments_expanded = flatten([
     for assignment in local.sso_admin_account_assignments : [


### PR DESCRIPTION
Currently, admin access to the DE sandbox account is managed by individual user iam in the Analytical Platform Landing account.

This is start of the effort to mirate AP/DE accounts to SSO to improve security, and this gives members of the Data Engineering team admin access to the sandbox account which doesn't contain any restricted data/information/infrastructure
