### PR TITLE
Add managed policies for mp migration role

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -192,6 +192,18 @@ resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_migrat
   permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_migration.arn
 }
 
+resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_migration_mgn" {
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AWSApplicationMigrationFullAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_migration.arn
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_migration_datasync" {
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/AWSDataSyncFullAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_migration.arn
+}
+
 resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platform_migration" {
   instance_arn       = local.sso_admin_instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_migration.arn


### PR DESCRIPTION
Instead of manually giving permissions for the migration role, we are using managed policies so that we don't need to update them when they change.