### PR TITLE
Adding data-eng MP permissions set and fixing common-fate PS reference to allow plan.

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -153,6 +153,30 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
   }
 }
 
+# Modernisation Platform data engineer
+resource "aws_ssoadmin_permission_set" "modernisation_platform_data_engineer" {
+  name             = "modernisation-platform-data-eng"
+  description      = "Modernisation Platform: data engineer tenancy"
+  instance_arn     = local.sso_admin_instance_arn
+  session_duration = "PT8H"
+  tags             = {}
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_data_engineer" {
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_data_engineer.arn
+}
+
+resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platform_data_engineer" {
+  instance_arn       = local.sso_admin_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_data_engineer.arn
+  customer_managed_policy_reference {
+    name = "data_engineering_policy"
+    path = "/"
+  }
+}
+
 # Modernisation Platform sandbox
 resource "aws_ssoadmin_permission_set" "modernisation_platform_sandbox" {
   name             = "modernisation-platform-sandbox"

--- a/management-account/terraform/sso-common-fate.tf
+++ b/management-account/terraform/sso-common-fate.tf
@@ -10,7 +10,7 @@ data "aws_identitystore_group" "commonfate_administrators" {
   alternate_identifier {
     unique_attribute {
       attribute_path  = "DisplayName"
-      attribute_value = "common-fate-admins"
+      attribute_value = "common-fate-administrators"
     }
   }
 }


### PR DESCRIPTION
Adding a new permission set for Data Engineers in the Modernisation Platform. The role will take advantage of a `data_engineering_policy` which Modernisation Platform will be creating in accounts where these permissions are being assigned. 

Additionally, fixing the lookup for the `common-fate-administrators` permission set.