### PR TITLE
Add finance team

### DIFF
--- a/management-account/terraform/iam-users.tf
+++ b/management-account/terraform/iam-users.tf
@@ -81,26 +81,6 @@ resource "aws_iam_user_group_membership" "jason_birchall" {
   ]
 }
 
-##################
-# Julie Robertson #
-##################
-resource "aws_iam_user" "julie_robertson" {
-  name          = "JulieRobertson"
-  path          = "/"
-  force_destroy = true
-  tags          = {}
-}
-
-# User membership
-resource "aws_iam_user_group_membership" "julie_robertson" {
-  user = aws_iam_user.julie_robertson.name
-
-  groups = [
-    aws_iam_group.billing_full_access.name,
-    aws_iam_group.iam_user_change_password.name,
-  ]
-}
-
 ###############################################
 # ModernisationPlatformOrganisationManagement #
 ###############################################

--- a/management-account/terraform/iam-users.tf
+++ b/management-account/terraform/iam-users.tf
@@ -193,7 +193,7 @@ resource "aws_iam_user_group_membership" "steve_marshall" {
 variable "finance_team" {
   description = "Finance team members"
   type        = list(string)
-  default     = [
+  default = [
     # Finance business partners
     "NickiStowe",
     "TraceyBartonWilliams",
@@ -209,17 +209,17 @@ variable "finance_team" {
 }
 
 resource "aws_iam_user" "finance_team" {
-  for_each = toset(var.finance_team)
-  name = each.value
-  path = "/"
+  for_each      = toset(var.finance_team)
+  name          = each.value
+  path          = "/"
   force_destroy = true
-  tags = {}
+  tags          = {}
 }
 
 # User membership
 resource "aws_iam_user_group_membership" "finance_team" {
   for_each = toset(var.finance_team)
-  user = aws_iam_user.finance_team[each.key].name
+  user     = aws_iam_user.finance_team[each.key].name
 
   groups = [
     aws_iam_group.billing_full_access.name,

--- a/management-account/terraform/iam-users.tf
+++ b/management-account/terraform/iam-users.tf
@@ -185,3 +185,44 @@ resource "aws_iam_user_group_membership" "steve_marshall" {
     aws_iam_group.iam_user_change_password.name,
   ]
 }
+
+################
+# Finance team #
+################
+
+variable "finance_team" {
+  description = "Finance team members"
+  type        = list(string)
+  default     = [
+    # Finance business partners
+    "NickiStowe",
+    "TraceyBartonWilliams",
+
+    # Digital finance team
+    "TraceyCampbell",
+    "AdeoluAdelaja",
+    "DavidCooper",
+
+    # Accounting
+    "AnthonyTimms",
+  ]
+}
+
+resource "aws_iam_user" "finance_team" {
+  for_each = toset(var.finance_team)
+  name = each.value
+  path = "/"
+  force_destroy = true
+  tags = {}
+}
+
+# User membership
+resource "aws_iam_user_group_membership" "finance_team" {
+  for_each = toset(var.finance_team)
+  user = aws_iam_user.finance_team[each.key].name
+
+  groups = [
+    aws_iam_group.billing_full_access.name,
+    aws_iam_group.iam_user_change_password.name,
+  ]
+}


### PR DESCRIPTION
We want our finance team to be able to run reports for themselves, and check the state of our invoices in the AWS console.

This also removes our previous finance business partner's account.