### PR TITLE
Pin actions versions to hash

### DIFF
--- a/.github/workflows/management-account-apply.yml
+++ b/.github/workflows/management-account-apply.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'management-account/terraform/**'
       - 'modules/**'
+      - '.github/workflows/management-account-plan.yml'
+      - '.github/workflows/management-account-apply.yml'
     branches:
       - main
 
@@ -18,13 +20,13 @@ jobs:
       run:
         working-directory: ./management-account/terraform
     steps:
-      - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: arn:aws:iam::${{secrets.AWS_ROOT_ACCOUNT_ID}}:role/github-actions-apply
           role-session-name: GitHubActions
           aws-region: eu-west-2
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: 1.3.4
       - run: terraform fmt -check

--- a/.github/workflows/management-account-plan.yml
+++ b/.github/workflows/management-account-plan.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'management-account/terraform/**'
       - 'modules/**'
+      - '.github/workflows/management-account-plan.yml'
+      - '.github/workflows/management-account-apply.yml'
   workflow_dispatch:
 
 jobs:
@@ -17,13 +19,13 @@ jobs:
       run:
         working-directory: ./management-account/terraform
     steps:
-      - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: arn:aws:iam::${{secrets.AWS_ROOT_ACCOUNT_ID}}:role/github-actions-plan
           role-session-name: GitHubActions
           aws-region: eu-west-2
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
         with:
           terraform_version: 1.3.4
       - run: terraform fmt -check


### PR DESCRIPTION
As per Githubs hardening recommendations here https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions