### PR TITLE
Add new LM config for Oracle on EC2

### DIFF
--- a/organisation-security/terraform/license-manager.tf
+++ b/organisation-security/terraform/license-manager.tf
@@ -69,3 +69,17 @@ resource "aws_licensemanager_license_configuration" "oracle_ee" {
   license_count_hard_limit = false
   license_counting_type    = "vCPU"
 }
+
+resource "aws_licensemanager_license_configuration" "oracle_ec2_licensemanager_configurations" {
+  for_each = {
+    "OracleDbEELicenseConfiguration"   = { description = "Oracle EC2 DB Enterprise Edition"},
+    "OracleDbSE2LicenseConfiguration"  = { description = "Oracle EC2 DB Standard Edition 2"},
+    "OracleDbPELicenseConfiguration"   = { description = "Oracle EC2 DB Personal Edition"},
+    "OracleDbXELicenseConfiguration"   = { description = "Oracle EC2 DB Express Edition"}
+  }
+  name                     = each.key
+  description              = each.value.description
+  license_count            = 0
+  license_count_hard_limit = false
+  license_counting_type    = "vCPU"
+}

--- a/organisation-security/terraform/license-manager.tf
+++ b/organisation-security/terraform/license-manager.tf
@@ -72,10 +72,10 @@ resource "aws_licensemanager_license_configuration" "oracle_ee" {
 
 resource "aws_licensemanager_license_configuration" "oracle_ec2_licensemanager_configurations" {
   for_each = {
-    "OracleDbEELicenseConfiguration"   = { description = "Oracle EC2 DB Enterprise Edition"},
-    "OracleDbSE2LicenseConfiguration"  = { description = "Oracle EC2 DB Standard Edition 2"},
-    "OracleDbPELicenseConfiguration"   = { description = "Oracle EC2 DB Personal Edition"},
-    "OracleDbXELicenseConfiguration"   = { description = "Oracle EC2 DB Express Edition"}
+    "OracleDbEELicenseConfiguration"  = { description = "Oracle EC2 DB Enterprise Edition" },
+    "OracleDbSE2LicenseConfiguration" = { description = "Oracle EC2 DB Standard Edition 2" },
+    "OracleDbPELicenseConfiguration"  = { description = "Oracle EC2 DB Personal Edition" },
+    "OracleDbXELicenseConfiguration"  = { description = "Oracle EC2 DB Express Edition" }
   }
   name                     = each.key
   description              = each.value.description


### PR DESCRIPTION
Following this documentation - https://aws.amazon.com/blogs/mt/centrally-track-oracle-database-licenses-in-aws-organizations-using-aws-license-manager-and-aws-systems-manager/

Note the names must be this to match scripts which run later in the blog post.

```
Terraform will perform the following actions:

  # aws_licensemanager_license_configuration.oracle_ec2_licensemanager_configurations["OracleDbEELicenseConfiguration"] will be created
  + resource "aws_licensemanager_license_configuration" "oracle_ec2_licensemanager_configurations" {
      + arn                      = (known after apply)
      + description              = "Oracle EC2 DB Enterprise Edition"
      + id                       = (known after apply)
      + license_count            = 0
      + license_count_hard_limit = false
      + license_counting_type    = "vCPU"
      + name                     = "OracleDbEELicenseConfiguration"
      + owner_account_id         = (known after apply)
      + tags_all                 = (known after apply)
    }

  # aws_licensemanager_license_configuration.oracle_ec2_licensemanager_configurations["OracleDbPELicenseConfiguration"] will be created
  + resource "aws_licensemanager_license_configuration" "oracle_ec2_licensemanager_configurations" {
      + arn                      = (known after apply)
      + description              = "Oracle EC2 DB Personal Edition"
      + id                       = (known after apply)
      + license_count            = 0
      + license_count_hard_limit = false
      + license_counting_type    = "vCPU"
      + name                     = "OracleDbPELicenseConfiguration"
      + owner_account_id         = (known after apply)
      + tags_all                 = (known after apply)
    }

  # aws_licensemanager_license_configuration.oracle_ec2_licensemanager_configurations["OracleDbSE2LicenseConfiguration"] will be created
  + resource "aws_licensemanager_license_configuration" "oracle_ec2_licensemanager_configurations" {
      + arn                      = (known after apply)
      + description              = "Oracle EC2 DB Standard Edition 2"
      + id                       = (known after apply)
      + license_count            = 0
      + license_count_hard_limit = false
      + license_counting_type    = "vCPU"
      + name                     = "OracleDbSE2LicenseConfiguration"
      + owner_account_id         = (known after apply)
      + tags_all                 = (known after apply)
    }

  # aws_licensemanager_license_configuration.oracle_ec2_licensemanager_configurations["OracleDbXELicenseConfiguration"] will be created
  + resource "aws_licensemanager_license_configuration" "oracle_ec2_licensemanager_configurations" {
      + arn                      = (known after apply)
      + description              = "Oracle EC2 DB Express Edition"
      + id                       = (known after apply)
      + license_count            = 0
      + license_count_hard_limit = false
      + license_counting_type    = "vCPU"
      + name                     = "OracleDbXELicenseConfiguration"
      + owner_account_id         = (known after apply)
      + tags_all                 = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.
```