### PR TITLE
Add permissions needed for Common Fate to Plan

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -60,6 +60,7 @@ data "aws_iam_policy_document" "extra_permissions_plan" {
     actions = [
       "account:GetAlternateContact",
       "cur:DescribeReportDefinitions",
+      "execute-api:Invoke", # for CommonFate
       "identitystore:ListGroups",
       "identitystore:GetGroupId",
       "identitystore:DescribeGroup",
@@ -129,6 +130,7 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
     actions = [
       "account:GetAlternateContact",
       "cur:DescribeReportDefinitions",
+      "execute-api:Invoke", # for CommonFate
       "identitystore:ListGroups",
       "identitystore:GetGroupId",
       "identitystore:DescribeGroup",


### PR DESCRIPTION
This permission is needed for common fate to refresh resources, without it the plan errors as seen here -

https://github.com/ministryofjustice/aws-root-account/actions/runs/5900520825/job/16004923391?pr=762#step:8:1886