### PR TITLE
Add ownership controls to S3 buckets

### DIFF
--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket_acl" "default" {
 resource "aws_s3_bucket_ownership_controls" "default" {
   bucket = aws_s3_bucket.default.id
   rule {
-    object_ownership = "BucketOwnerPreferred"
+    object_ownership = "ObjectWriter"
   }
 }
 

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -13,8 +13,17 @@ resource "aws_s3_bucket" "default" {
 # Bucket ACL #
 ##############
 resource "aws_s3_bucket_acl" "default" {
+  depends_on = [aws_s3_bucket_ownership_controls.default]
+
   bucket = aws_s3_bucket.default.id
   acl    = var.bucket_acl
+}
+
+resource "aws_s3_bucket_ownership_controls" "default" {
+  bucket = aws_s3_bucket.default.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
 }
 
 #####################


### PR DESCRIPTION
Updates to to S3 buckets have ACLs disabled by default.  Terraform defaults the bucket ownership controls to BucketOwnerEnforced now which breaks when trying to create buckets with ACLS. Defining this to BucketOwnerEnforced or ObjectWriter fixes this.  

Changing to ObjectWriter to match existing buckets.

We should look at disabling the ACLs completely at some point, but changing this in the module would impact existing buckets and needs to be fully understood before changing.