### PR TITLE
Create MWAA user permission set

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -192,12 +192,18 @@ resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_data_m
   permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_data_mwaa_user.arn
 }
 
-resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platform_data_mwaa_user" {
+resource "aws_ssoadmin_permission_set_inline_policy" "modernisation_platform_data_mwaa_user" {
   instance_arn       = local.sso_admin_instance_arn
+  inline_policy      = data.aws_iam_policy_document.modernisation_platform_data_mwaa_user.json
   permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_data_mwaa_user.arn
-  customer_managed_policy_reference {
-    name = "data_engineering_mwaa_user_policy"
-    path = "/"
+}
+
+data "aws_iam_policy_document" "modernisation_platform_data_mwaa_user" {
+  statement {
+    actions = [
+      "airflow:CreateWebLoginToken"
+    ]
+    resources = ["*"]
   }
 }
 

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -177,6 +177,30 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
   }
 }
 
+# Modernisation Platform data engineer
+resource "aws_ssoadmin_permission_set" "modernisation_platform_data_mwaa_user" {
+  name             = "modernisation-platform-mwaa-user"
+  description      = "Modernisation Platform: data engineering mwaa user"
+  instance_arn     = local.sso_admin_instance_arn
+  session_duration = "PT8H"
+  tags             = {}
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_data_mwaa_user" {
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_data_mwaa_user.arn
+}
+
+resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platform_data_mwaa_user" {
+  instance_arn       = local.sso_admin_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_data_mwaa_user.arn
+  customer_managed_policy_reference {
+    name = "data_engineering_mwaa_user_policy"
+    path = "/"
+  }
+}
+
 # Modernisation Platform sandbox
 resource "aws_ssoadmin_permission_set" "modernisation_platform_sandbox" {
   name             = "modernisation-platform-sandbox"


### PR DESCRIPTION
As part of an issue on the Modernisation Platform backlog this PR creates an SSO permission set that can be assigned to Data Engineering MWAA (Managed Workflows for Apache Airflow) users. This will allow these users to sign in with a very limited permission set and make use of Airflow resources.