### PR TITLE
Scope MWAA user policy to specific role

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -203,7 +203,7 @@ data "aws_iam_policy_document" "modernisation_platform_data_mwaa_user" {
     actions = [
       "airflow:CreateWebLoginToken"
     ]
-    resources = ["*"]
+    resources = ["arn:aws:airflow:*:*:role/*/User"]
   }
 }
 


### PR DESCRIPTION
After discussion with original requestor, it appears that the `airflow` managed service has a number of different roles which could be inadvertently assumed if the `resource` is not correctly scoped. This PR changes the policy resource in place, which should in turn enforce the use of a specific role.