### PR TITLE
Enable RAM sharing for organizations

### DIFF
--- a/management-account/terraform/organizations.tf
+++ b/management-account/terraform/organizations.tf
@@ -40,3 +40,6 @@ resource "aws_organizations_delegated_administrator" "stacksets_organisation_sec
   account_id        = aws_organizations_account.organisation_security.id
   service_principal = "member.org.stacksets.cloudformation.amazonaws.com"
 }
+
+# Enable RAM sharing with the organization without requiring acceptors
+resource "aws_ram_sharing_with_organization" "default" {}


### PR DESCRIPTION
This will enable us to RAM share across the organization without requiring an acceptor.

https://docs.aws.amazon.com/ram/latest/userguide/getting-started-sharing.html#getting-started-sharing-orgs

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ram_principal_association

This is already enabled, adding to code.