### PR TITLE
Remove securityhub enrollment in org security

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -86,6 +86,7 @@ resource "aws_securityhub_organization_configuration" "default" {
 }
 
 # Add members from the organisation
+# This is now down automatically when accounts are created
 resource "aws_securityhub_member" "default" {
   depends_on = [aws_securityhub_account.default]
   for_each   = var.is_delegated_administrator ? var.enrolled_accounts : {}

--- a/organisation-security/terraform/securityhub.tf
+++ b/organisation-security/terraform/securityhub.tf
@@ -10,7 +10,6 @@ module "securityhub_eu_west_2" {
   aggregation_region = true
 
   is_delegated_administrator = true
-  enrolled_accounts          = tomap(local.accounts.active_only_not_self)
 }
 
 module "securityhub_eu_west_1" {
@@ -20,7 +19,6 @@ module "securityhub_eu_west_1" {
   }
 
   is_delegated_administrator = true
-  enrolled_accounts          = tomap(local.accounts.active_only_not_self)
 }
 
 module "securityhub_eu_central_1" {
@@ -30,7 +28,6 @@ module "securityhub_eu_central_1" {
   }
 
   is_delegated_administrator = true
-  enrolled_accounts          = tomap(local.accounts.active_only_not_self)
 }
 
 ##############################
@@ -44,5 +41,4 @@ module "securityhub_us_east_1" {
   source = "../../modules/securityhub"
 
   is_delegated_administrator = true
-  enrolled_accounts          = tomap(local.accounts.active_only_not_self)
 }


### PR DESCRIPTION
This is now done at an org level and not required for member accounts as it happens on account creation.  Existing accounts have been removed from state.

Local apply:

```

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are
needed.

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```