### PR TITLE
Remove "Electronic Monitoring" account from SSO, as it has been unused for over 6 months

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -84,7 +84,6 @@ locals {
         aws_organizations_account.electronic_monitoring_monitoring_and_mapping_dev.id,
         aws_organizations_account.electronic_monitoring_case_management_networking_prod.id,
         aws_organizations_account.electronic_monitoring_case_management_management_prod.id,
-        aws_organizations_account.electronic_monitoring.id,
         aws_organizations_account.electronic_monitoring_protective_monitoring.id,
         aws_organizations_account.electronic_monitoring_shared_logging.id,
         aws_organizations_account.electronic_monitoring_shared_networking.id,


### PR DESCRIPTION
This account has been sat in [Closed accounts](https://github.com/ministryofjustice/aws-root-account/blob/main/management-account/terraform/organizations-accounts-closed-accounts.tf#L2-L20) for since December 2022, and is not used by Electronic Monitoring. This removes the SSO assignment in preparation for deletion.