### PR TITLE
Move MoJ Info Services Dev (Courtfinder Development) to closed accounts in preparation for deletion

### DIFF
--- a/management-account/terraform/organizations-accounts-closed-accounts.tf
+++ b/management-account/terraform/organizations-accounts-closed-accounts.tf
@@ -37,3 +37,21 @@ resource "aws_organizations_account" "legal_aid_agency" {
     ]
   }
 }
+
+resource "aws_organizations_account" "moj_info_services_dev" {
+  name                       = "MoJ Info Services Dev"
+  email                      = replace(local.aws_account_email_addresses_template, "{email}", "courtfinder")
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.closed_accounts.id
+
+  tags = local.tags_hmcts
+
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name,
+    ]
+  }
+}

--- a/management-account/terraform/organizations-accounts-hmcts.tf
+++ b/management-account/terraform/organizations-accounts-hmcts.tf
@@ -61,24 +61,6 @@ resource "aws_organizations_account" "ministry_of_justice_courtfinder_prod" {
   }
 }
 
-resource "aws_organizations_account" "moj_info_services_dev" {
-  name                       = "MoJ Info Services Dev"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "courtfinder")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.hmcts.id
-
-  tags = local.tags_hmcts
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "tp_hmcts" {
   name                       = "TP-HMCTS"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "TP-HMCTS")


### PR DESCRIPTION
The service that this account was used for has been moved to HMCTS' Azure (Find a Court & Tribunal).

This moves the account to "Closed accounts", which denies all actions, for a grace period before deletion.