### PR TITLE
Move guardduty threat intel set to org sec

### DIFF
--- a/organisation-security/terraform/guardduty-threatintelset.tf
+++ b/organisation-security/terraform/guardduty-threatintelset.tf
@@ -1,0 +1,22 @@
+locals {
+  guardduty_threatintelset = join("\n", [
+    for file in fileset("./guardduty-threatintelset", "*.txt") :
+    file("./guardduty-threatintelset/${file}")
+  ])
+}
+
+resource "aws_s3_bucket" "guardduty_threatintelset" {}
+
+resource "aws_s3_bucket_acl" "guardduty_threatintelset" {
+  bucket = aws_s3_bucket.guardduty_threatintelset.id
+  acl    = "private"
+}
+
+resource "aws_s3_object" "guardduty_threatintelset" {
+  acl          = "public-read"
+  bucket       = aws_s3_bucket.guardduty_threatintelset.id
+  key          = "ThreatIntelSet"
+  content      = local.guardduty_threatintelset
+  content_type = "text/plain"
+  etag         = md5(local.guardduty_threatintelset)
+}

--- a/organisation-security/terraform/guardduty-threatintelset/README.md
+++ b/organisation-security/terraform/guardduty-threatintelset/README.md
@@ -3,5 +3,5 @@
 This repository holds text files of IP addresses to use as threat intel sets in AWS GuardDuty.
 
 | Filename | Reason | Source |
-|-|-|-|
-| | | |
+| -------- | ------ | ------ |
+|          |        |        |

--- a/organisation-security/terraform/guardduty-threatintelset/README.md
+++ b/organisation-security/terraform/guardduty-threatintelset/README.md
@@ -1,0 +1,7 @@
+# GuardDuty Threat Intel Sets
+
+This repository holds text files of IP addresses to use as threat intel sets in AWS GuardDuty.
+
+| Filename | Reason | Source |
+|-|-|-|
+| | | |

--- a/terraform/guardduty-threatintelset.tf
+++ b/terraform/guardduty-threatintelset.tf
@@ -1,3 +1,5 @@
+# Moved to organisation security, leaving here whilst other guardduty resources are still dependant on it
+
 locals {
   guardduty-threatintelset = join("\n", [
     for file in fileset("./guardduty-threatintelset", "*.txt") :


### PR DESCRIPTION
Moving guardduty to the org sec account starting with this. This will remain in the root terraform account until all guardduty resources have been migrated.