### PR TITLE
Move guardduty publishing destination to org sec

### DIFF
--- a/organisation-security/terraform/data.tf
+++ b/organisation-security/terraform/data.tf
@@ -1,5 +1,9 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_caller_identity" "root" {
+  provider = aws.root
+}
+
 data "aws_organizations_organization" "default" {
   provider = aws.root
 }


### PR DESCRIPTION
Moving to organisation security terraform folder, state has been imported.

Leaving in orginal location until remaining guardduty resources have been migrated.