### PR TITLE
Move remaining guardduty to management and org sec

### DIFF
--- a/management-account/terraform/guardduty.tf
+++ b/management-account/terraform/guardduty.tf
@@ -1,0 +1,300 @@
+# Accounts to enrol from the AWS Organization
+#
+# The configuration for the publishing destination is in guardduty_publishing-destination.tf,
+# which has an eu-west-2 bucket that all regional GuardDuty configurations publish to.
+
+# Prior to 4th May 2021, no regions had auto-enable turned on. To speed up and
+# simplify this Terraform, auto-enable was turned on in the below regions. This
+# allows us to deprecate the enrolled_into_guardduty variable for those regions,
+# and we can rely on auto-enable to automatically enable GuardDuty for **new** AWS
+# accounts created after 4th May 2021. This resulted in 1,288 (184 accounts * 7 regions)
+# resources being removed from the state, nearly halving the time Terraform took
+# to run.
+#
+# The AWS API also doesn't return the status of a member account (whether GuardDuty
+# is enabled or not), so it didn't provide much value other than the initial association
+# as a member account.
+# See: https://docs.aws.amazon.com/guardduty/latest/APIReference/API_Member.html
+#
+# The following regions have auto-enable turned **on**:
+# See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration
+# eu-*
+# us-*
+# ap-*
+# ca-*
+# sa-*
+#
+# In the event of having to recreate this AWS Organization, we can assume that
+# auto-enable will automatically create the member associations for the accounts.
+# Therefore, the aws_guardduty_member resources have been removed from regions
+# where auto-enable is now turned on as of 4th May 2021.
+
+###########################
+# GuardDuty in US regions #
+###########################
+module "guardduty_us_east_1" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.us-east-1
+    aws.delegated_administrator = aws.organisation-security-us-east-1
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_us_east_2" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.us-east-2
+    aws.delegated_administrator = aws.organisation-security-us-east-2
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_us_west_1" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.us-west-1
+    aws.delegated_administrator = aws.organisation-security-us-west-1
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_us_west_2" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.us-west-2
+    aws.delegated_administrator = aws.organisation-security-us-west-2
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+###########################
+# GuardDuty in AP regions #
+###########################
+module "guardduty_ap_south_1" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.ap-south-1
+    aws.delegated_administrator = aws.organisation-security-ap-south-1
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_ap_northeast_3" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.ap-northeast-3
+    aws.delegated_administrator = aws.organisation-security-ap-northeast-3
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_ap_northeast_2" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.ap-northeast-2
+    aws.delegated_administrator = aws.organisation-security-ap-northeast-2
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_ap_southeast_1" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.ap-southeast-1
+    aws.delegated_administrator = aws.organisation-security-ap-southeast-1
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_ap_southeast_2" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.ap-southeast-2
+    aws.delegated_administrator = aws.organisation-security-ap-southeast-2
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_ap_northeast_1" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.ap-northeast-1
+    aws.delegated_administrator = aws.organisation-security-ap-northeast-1
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+###########################
+# GuardDuty in CA regions #
+###########################
+module "guardduty_ca_central_1" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.ca-central-1
+    aws.delegated_administrator = aws.organisation-security-ca-central-1
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+###########################
+# GuardDuty in EU regions #
+###########################
+module "guardduty_eu_central_1" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.eu-central-1
+    aws.delegated_administrator = aws.organisation-security-eu-central-1
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_eu_west_1" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.eu-west-1
+    aws.delegated_administrator = aws.organisation-security-eu-west-1
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_eu_west_2" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.eu-west-2
+    aws.delegated_administrator = aws.organisation-security-eu-west-2
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_eu_west_3" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.eu-west-3
+    aws.delegated_administrator = aws.organisation-security-eu-west-3
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+module "guardduty_eu_north_1" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.eu-north-1
+    aws.delegated_administrator = aws.organisation-security-eu-north-1
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+###########################
+# GuardDuty in SA regions #
+###########################
+module "guardduty_sa_east_1" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.sa-east-1
+    aws.delegated_administrator = aws.organisation-security-sa-east-1
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}

--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -58,6 +58,21 @@ locals {
     ]
   }
 
+  root_account = merge(local.tags_business_units.platforms, {
+    application   = "AWS root account"
+    is-production = true
+    owner         = "Hosting Leads: hosting-leads@digital.justice.gov.uk"
+  })
+
+  tags_organisation_management = {
+    application            = "Organisation Management"
+    business-unit          = "Platforms"
+    infrastructure-support = "Hosting Leads: hosting-leads@digital.justice.gov.uk"
+    is-production          = true
+    owner                  = "Hosting Leads: hosting-leads@digital.justice.gov.uk"
+    source-code            = "github.com/ministryofjustice/aws-root-account"
+  }
+
   # SSO
   sso = {
     email_suffix        = "@digital.justice.gov.uk"

--- a/management-account/terraform/outputs.tf
+++ b/management-account/terraform/outputs.tf
@@ -1,6 +1,6 @@
 output "guardduty_administrator_detector_ids" {
+  description = "Guardduty detector IDs for the organisation security account"
   value = {
-    "us_east_1"      = module.guardduty_us_east_1.administrator_detector_id
     "us_east_1"      = module.guardduty_us_east_1.administrator_detector_id
     "us_east_2"      = module.guardduty_us_east_2.administrator_detector_id
     "us_west_1"      = module.guardduty_us_west_1.administrator_detector_id
@@ -20,71 +20,3 @@ output "guardduty_administrator_detector_ids" {
     "sa_east_1"      = module.guardduty_sa_east_1.administrator_detector_id
   }
 }
-
-# output "administrator_detector_id_us_east_1" {
-#   value = module.guardduty_us_east_1.administrator_detector_id
-# }
-
-# output "administrator_detector_id_us_east_2" {
-#   value = module.guardduty_us_east_2.administrator_detector_id
-# }
-
-# output "administrator_detector_id_us_west_1" {
-#   value = module.guardduty_us_us_west_1.administrator_detector_id
-# }
-
-# output "administrator_detector_id_us_west_2" {
-#   value = module.guardduty_us_west_2.administrator_detector_id
-# }
-
-# output "administrator_detector_id_ap_south_1" {
-#   value = module.guardduty_us_ap_south_1.administrator_detector_id
-# }
-
-# output "administrator_detector_id_ap_northeast_1" {
-#   value = module.guardduty_ap_northeast_1.administrator_detector_id
-# }
-
-# output "administrator_detector_id_ap_northeast_2" {
-#   value = module.guardduty_ap_northeast_2.administrator_detector_id
-# }
-
-# output "administrator_detector_id_ap_northeast_3" {
-#   value = module.guardduty_ap_northeast_3.administrator_detector_id
-# }
-
-# output "administrator_detector_id_ap_southeast_1" {
-#   value = module.guardduty_ap_southeast_1.administrator_detector_id
-# }
-
-# output "administrator_detector_id_ap_southeast_2" {
-#   value = module.guardduty_ap_southeast_2.administrator_detector_id
-# }
-
-# output "administrator_detector_id_ca_central_1" {
-#   value = module.guardduty_ca_central_1.administrator_detector_id
-# }
-
-# output "administrator_detector_id_eu_central_1" {
-#   value = module.guardduty_eu_central_1.administrator_detector_id
-# }
-
-# output "administrator_detector_id_eu_west_1" {
-#   value = module.guardduty_eu_west_1.administrator_detector_id
-# }
-
-# output "administrator_detector_id_eu_west_2" {
-#   value = module.guardduty_eu_west_2.administrator_detector_id
-# }
-
-# output "administrator_detector_id_eu_west_3" {
-#   value = module.guardduty_eu_west_3.administrator_detector_id
-# }
-
-# output "administrator_detector_id_eu_north_1" {
-#   value = module.guardduty_eu_north_1.administrator_detector_id
-# }
-
-# output "administrator_detector_id_sa_east_1" {
-#   value = module.guardduty_sa_east_1.administrator_detector_id
-# }

--- a/management-account/terraform/outputs.tf
+++ b/management-account/terraform/outputs.tf
@@ -1,0 +1,90 @@
+output "guardduty_administrator_detector_ids" {
+  value = {
+    "us_east_1"      = module.guardduty_us_east_1.administrator_detector_id
+    "us_east_1"      = module.guardduty_us_east_1.administrator_detector_id
+    "us_east_2"      = module.guardduty_us_east_2.administrator_detector_id
+    "us_west_1"      = module.guardduty_us_west_1.administrator_detector_id
+    "us_west_2"      = module.guardduty_us_west_2.administrator_detector_id
+    "ap_south_1"     = module.guardduty_ap_south_1.administrator_detector_id
+    "ap_northeast_1" = module.guardduty_ap_northeast_1.administrator_detector_id
+    "ap_northeast_2" = module.guardduty_ap_northeast_2.administrator_detector_id
+    "ap_northeast_3" = module.guardduty_ap_northeast_3.administrator_detector_id
+    "ap_southeast_1" = module.guardduty_ap_southeast_1.administrator_detector_id
+    "ap_southeast_2" = module.guardduty_ap_southeast_2.administrator_detector_id
+    "ca_central_1"   = module.guardduty_ca_central_1.administrator_detector_id
+    "eu_central_1"   = module.guardduty_eu_central_1.administrator_detector_id
+    "eu_west_1"      = module.guardduty_eu_west_1.administrator_detector_id
+    "eu_west_2"      = module.guardduty_eu_west_2.administrator_detector_id
+    "eu_west_3"      = module.guardduty_eu_west_3.administrator_detector_id
+    "eu_north_1"     = module.guardduty_eu_north_1.administrator_detector_id
+    "sa_east_1"      = module.guardduty_sa_east_1.administrator_detector_id
+  }
+}
+
+# output "administrator_detector_id_us_east_1" {
+#   value = module.guardduty_us_east_1.administrator_detector_id
+# }
+
+# output "administrator_detector_id_us_east_2" {
+#   value = module.guardduty_us_east_2.administrator_detector_id
+# }
+
+# output "administrator_detector_id_us_west_1" {
+#   value = module.guardduty_us_us_west_1.administrator_detector_id
+# }
+
+# output "administrator_detector_id_us_west_2" {
+#   value = module.guardduty_us_west_2.administrator_detector_id
+# }
+
+# output "administrator_detector_id_ap_south_1" {
+#   value = module.guardduty_us_ap_south_1.administrator_detector_id
+# }
+
+# output "administrator_detector_id_ap_northeast_1" {
+#   value = module.guardduty_ap_northeast_1.administrator_detector_id
+# }
+
+# output "administrator_detector_id_ap_northeast_2" {
+#   value = module.guardduty_ap_northeast_2.administrator_detector_id
+# }
+
+# output "administrator_detector_id_ap_northeast_3" {
+#   value = module.guardduty_ap_northeast_3.administrator_detector_id
+# }
+
+# output "administrator_detector_id_ap_southeast_1" {
+#   value = module.guardduty_ap_southeast_1.administrator_detector_id
+# }
+
+# output "administrator_detector_id_ap_southeast_2" {
+#   value = module.guardduty_ap_southeast_2.administrator_detector_id
+# }
+
+# output "administrator_detector_id_ca_central_1" {
+#   value = module.guardduty_ca_central_1.administrator_detector_id
+# }
+
+# output "administrator_detector_id_eu_central_1" {
+#   value = module.guardduty_eu_central_1.administrator_detector_id
+# }
+
+# output "administrator_detector_id_eu_west_1" {
+#   value = module.guardduty_eu_west_1.administrator_detector_id
+# }
+
+# output "administrator_detector_id_eu_west_2" {
+#   value = module.guardduty_eu_west_2.administrator_detector_id
+# }
+
+# output "administrator_detector_id_eu_west_3" {
+#   value = module.guardduty_eu_west_3.administrator_detector_id
+# }
+
+# output "administrator_detector_id_eu_north_1" {
+#   value = module.guardduty_eu_north_1.administrator_detector_id
+# }
+
+# output "administrator_detector_id_sa_east_1" {
+#   value = module.guardduty_sa_east_1.administrator_detector_id
+# }

--- a/management-account/terraform/providers-organisation-security.tf
+++ b/management-account/terraform/providers-organisation-security.tf
@@ -1,0 +1,173 @@
+###################################
+# organisation-security providers #
+###################################
+
+# us-east-1
+provider "aws" {
+  region = "us-east-1"
+  alias  = "organisation-security-us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# us-east-2
+provider "aws" {
+  region = "us-east-2"
+  alias  = "organisation-security-us-east-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# us-west-1
+provider "aws" {
+  region = "us-west-1"
+  alias  = "organisation-security-us-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# us-west-2
+provider "aws" {
+  region = "us-west-2"
+  alias  = "organisation-security-us-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# ap-south-1
+provider "aws" {
+  region = "ap-south-1"
+  alias  = "organisation-security-ap-south-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# ap-northeast-3
+provider "aws" {
+  region = "ap-northeast-3"
+  alias  = "organisation-security-ap-northeast-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# ap-northeast-2
+provider "aws" {
+  region = "ap-northeast-2"
+  alias  = "organisation-security-ap-northeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# ap-southeast-1
+provider "aws" {
+  region = "ap-southeast-1"
+  alias  = "organisation-security-ap-southeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# ap-southeast-2
+provider "aws" {
+  region = "ap-southeast-2"
+  alias  = "organisation-security-ap-southeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# ap-northeast-1
+provider "aws" {
+  region = "ap-northeast-1"
+  alias  = "organisation-security-ap-northeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# ca-central-1
+provider "aws" {
+  region = "ca-central-1"
+  alias  = "organisation-security-ca-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# eu-central-1
+provider "aws" {
+  region = "eu-central-1"
+  alias  = "organisation-security-eu-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# eu-west-1
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "organisation-security-eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# eu-west-2
+provider "aws" {
+  region = "eu-west-2"
+  alias  = "organisation-security-eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# eu-west-3
+provider "aws" {
+  region = "eu-west-3"
+  alias  = "organisation-security-eu-west-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# eu-north-1
+provider "aws" {
+  region = "eu-north-1"
+  alias  = "organisation-security-eu-north-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
+# sa-east-1
+provider "aws" {
+  region = "sa-east-1"
+  alias  = "organisation-security-sa-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}

--- a/modules/guardduty-org-sec/main.tf
+++ b/modules/guardduty-org-sec/main.tf
@@ -6,6 +6,8 @@
 # Auto-enable GuardDuty for new accounts in the AWS Organization #
 ##################################################################
 resource "aws_guardduty_organization_configuration" "delegated_administrator" {
+  provider = aws.delegated_administrator
+
   detector_id = var.administrator_detector_id
   auto_enable = var.auto_enable
 
@@ -21,6 +23,8 @@ resource "aws_guardduty_organization_configuration" "delegated_administrator" {
 # GuardDuty publishing destination #
 ####################################
 resource "aws_guardduty_publishing_destination" "delegated_administrator" {
+  provider = aws.delegated_administrator
+
   detector_id     = var.administrator_detector_id
   destination_arn = var.destination_arn
   kms_key_arn     = var.kms_key_arn
@@ -30,6 +34,8 @@ resource "aws_guardduty_publishing_destination" "delegated_administrator" {
 # GuardDuty ThreatIntelSet #
 ############################
 resource "aws_guardduty_threatintelset" "default" {
+  provider = aws.delegated_administrator
+
   activate    = var.enable_threatintelset
   detector_id = var.administrator_detector_id
   format      = "TXT"

--- a/modules/guardduty-org-sec/main.tf
+++ b/modules/guardduty-org-sec/main.tf
@@ -1,0 +1,38 @@
+#############
+# GuardDuty #
+#############
+
+##################################################################
+# Auto-enable GuardDuty for new accounts in the AWS Organization #
+##################################################################
+resource "aws_guardduty_organization_configuration" "delegated_administrator" {
+  detector_id = var.administrator_detector_id
+  auto_enable = var.auto_enable
+
+  # Auto-enable S3 logs to be analysed for new accounts in the AWS Organization
+  datasources {
+    s3_logs {
+      auto_enable = true
+    }
+  }
+}
+
+####################################
+# GuardDuty publishing destination #
+####################################
+resource "aws_guardduty_publishing_destination" "delegated_administrator" {
+  detector_id     = var.administrator_detector_id
+  destination_arn = var.destination_arn
+  kms_key_arn     = var.kms_key_arn
+}
+
+############################
+# GuardDuty ThreatIntelSet #
+############################
+resource "aws_guardduty_threatintelset" "default" {
+  activate    = var.enable_threatintelset
+  detector_id = var.administrator_detector_id
+  format      = "TXT"
+  location    = "https://s3.amazonaws.com/${var.threatintelset_bucket}/${var.threatintelset_key}"
+  name        = var.threatintelset_key
+}

--- a/modules/guardduty-org-sec/variables.tf
+++ b/modules/guardduty-org-sec/variables.tf
@@ -1,0 +1,48 @@
+variable "kms_key_arn" {
+  description = "KMS key ARN for encrypting GuardDuty findings in S3"
+  type        = string
+}
+
+variable "destination_arn" {
+  description = "S3 bucket ARN where findings get exported to"
+  type        = string
+}
+
+variable "administrator_tags" {
+  description = "Tags to apply to resources created in the delegated administrator account, if applicable"
+  type        = map(any)
+  default     = {}
+}
+
+variable "filterable_security_accounts" {
+  description = "Security account IDs to filter out (with NOOP)"
+  type        = list(string)
+  default     = []
+}
+
+variable "auto_enable" {
+  description = "Whether to auto-enable GuardDuty in new AWS accounts"
+  type        = bool
+  default     = false
+}
+
+variable "threatintelset_bucket" {
+  description = "GuardDuty ThreatIntelSet bucket"
+  type        = string
+}
+
+variable "threatintelset_key" {
+  description = "GuardDuty ThreatIntelSet key"
+  type        = string
+}
+
+variable "enable_threatintelset" {
+  description = "Whether to enable a ThreatIntelSet for GuardDuty"
+  type        = bool
+  default     = false
+}
+
+variable "administrator_detector_id" {
+  description = "Guardduty detector ID of the region administrator"
+  type        = string
+}

--- a/modules/guardduty-org-sec/versions.tf
+++ b/modules/guardduty-org-sec/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.27.0"
+      configuration_aliases = [
+        aws.delegated_administrator
+      ]
+    }
+  }
+  required_version = ">= 0.15.0"
+}

--- a/modules/guardduty-root/main.tf
+++ b/modules/guardduty-root/main.tf
@@ -1,0 +1,59 @@
+#############
+# GuardDuty #
+#############
+
+# Get the delegated administrator account ID
+data "aws_caller_identity" "delegated_administrator" {
+  provider = aws.delegated_administrator
+}
+
+#################################
+# GuardDuty in the root account #
+#################################
+resource "aws_guardduty_detector" "default" {
+  provider = aws.root_account
+
+  # Set enable to false if you want to suspend GuardDuty.
+  # This allows you to keep historical findings rather than removing the resource
+  # block, which will destroy all historical findings
+  enable = true
+
+  tags = var.root_tags
+}
+
+####################################################
+# GuardDuty in the delegated administrator account #
+####################################################
+resource "aws_guardduty_detector" "delegated_administrator" {
+  provider = aws.delegated_administrator
+
+  # Set enable to false if you want to suspend GuardDuty.
+  # This allows you to keep historical findings rather than removing the resource
+  # block, which will destroy all historical findings
+  enable = true
+
+  # For newly generated findings, AWS GuardDuty publishes the finding within 5 minutes, which cannot be changed.
+  # For subsequent findings, you can choose to be notified again within 6 hours, 1 hour, or 15 minutes.
+  # Note that member accounts inherit this setting, so it'll be set for all member accounts at the value here.
+  # See: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html#guardduty_findings_cloudwatch_notification_frequency
+  finding_publishing_frequency = "FIFTEEN_MINUTES"
+
+  # Enable S3 logs to be analysed in GuardDuty
+  datasources {
+    s3_logs {
+      enable = true
+    }
+  }
+
+  tags = var.administrator_tags
+}
+
+#####################################
+# GuardDuty delegated administrator #
+#####################################
+resource "aws_guardduty_organization_admin_account" "default" {
+  admin_account_id = data.aws_caller_identity.delegated_administrator.account_id
+
+  # GuardDuty is required to be turned on in the account before you set it as the delegated administrator
+  depends_on = [aws_guardduty_detector.delegated_administrator]
+}

--- a/modules/guardduty-root/outputs.tf
+++ b/modules/guardduty-root/outputs.tf
@@ -1,0 +1,3 @@
+output "administrator_detector_id" {
+  value = aws_guardduty_detector.delegated_administrator.id
+}

--- a/modules/guardduty-root/variables.tf
+++ b/modules/guardduty-root/variables.tf
@@ -1,0 +1,11 @@
+variable "root_tags" {
+  description = "Tags to apply to resources created in the root account, if applicable"
+  type        = map(any)
+  default     = {}
+}
+
+variable "administrator_tags" {
+  description = "Tags to apply to resources created in the delegated administrator account, if applicable"
+  type        = map(any)
+  default     = {}
+}

--- a/modules/guardduty-root/versions.tf
+++ b/modules/guardduty-root/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.27.0"
+      configuration_aliases = [
+        aws.root_account,
+        aws.delegated_administrator
+      ]
+    }
+  }
+  required_version = ">= 0.15.0"
+}

--- a/organisation-security/terraform/data.tf
+++ b/organisation-security/terraform/data.tf
@@ -31,3 +31,12 @@ data "aws_organizations_organizational_units" "modernisation_platform_member" {
 data "aws_organizations_organizational_units" "opg" {
   parent_id = local.ou_opg
 }
+
+data "terraform_remote_state" "management_account" {
+  backend = "s3"
+  config = {
+    bucket = "moj-aws-root-account-terraform-state"
+    key    = "management-account/terraform.tfstate"
+    region = "eu-west-2"
+  }
+}

--- a/organisation-security/terraform/guardduty.tf
+++ b/organisation-security/terraform/guardduty.tf
@@ -93,7 +93,7 @@ module "guardduty_us_west_1" {
 
   providers = { aws.delegated_administrator = aws.us-west-1 }
 
-  administrator_detector_id = local.guardduty_administrator_detector_ids.guardduty_us_west_1
+  administrator_detector_id = local.guardduty_administrator_detector_ids.us_west_1
 
   # Utilise ThreatIntelSet
   enable_threatintelset = false

--- a/organisation-security/terraform/guardduty.tf
+++ b/organisation-security/terraform/guardduty.tf
@@ -1,0 +1,535 @@
+# Accounts to enrol from the AWS Organization
+#
+# The configuration for the publishing destination is in guardduty-publishing-destination.tf,
+# which has an eu-west-2 bucket that all regional GuardDuty configurations publish to.
+
+# Prior to 4th May 2021, no regions had auto-enable turned on. To speed up and
+# simplify this Terraform, auto-enable was turned on in the below regions. This
+# allows us to deprecate the enrolled_into_guardduty variable for those regions,
+# and we can rely on auto-enable to automatically enable GuardDuty for **new** AWS
+# accounts created after 4th May 2021. This resulted in 1,288 (184 accounts * 7 regions)
+# resources being removed from the state, nearly halving the time Terraform took
+# to run.
+#
+# The AWS API also doesn't return the status of a member account (whether GuardDuty
+# is enabled or not), so it didn't provide much value other than the initial association
+# as a member account.
+# See: https://docs.aws.amazon.com/guardduty/latest/APIReference/API_Member.html
+#
+# The following regions have auto-enable turned **on**:
+# See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_organization_configuration
+# eu-*
+# us-*
+# ap-*
+# ca-*
+# sa-*
+#
+# In the event of having to recreate this AWS Organization, we can assume that
+# auto-enable will automatically create the member associations for the accounts.
+# Therefore, the aws_guardduty_member resources have been removed from regions
+# where auto-enable is now turned on as of 4th May 2021.
+
+###########################
+# GuardDuty in US regions #
+###########################
+module "guardduty_us_east_1" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.us-east-1 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.us_east_1
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for us-east-1
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_us_east_2" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.us-east-2 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.us_east_2
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for us-east-2
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_us_west_1" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.us-west-1 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.guardduty_us_west_1
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for us-west-1
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_us_west_2" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.us-west-2 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.us_west_2
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for us-west-2
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+###########################
+# GuardDuty in AP regions #
+###########################
+module "guardduty_ap_south_1" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.ap-south-1 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.ap_south_1
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for ap-south-1
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_ap_northeast_3" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.ap-northeast-3 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.ap_northeast_3
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for ap-northeast-3
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_ap_northeast_2" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.ap-northeast-2 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.ap_northeast_2
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for ap-northeast-2
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_ap_southeast_1" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.ap-southeast-1 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.ap_southeast_1
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for ap-southeast-1
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_ap_southeast_2" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.ap-southeast-2 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.ap_southeast_2
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for ap-southeast-2
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_ap_northeast_1" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.ap-northeast-1 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.ap_northeast_1
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for ap-northeast-1
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+###########################
+# GuardDuty in CA regions #
+###########################
+module "guardduty_ca_central_1" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.ca-central-1 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.ca_central_1
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for ca-central-1
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+###########################
+# GuardDuty in EU regions #
+###########################
+module "guardduty_eu_central_1" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.eu-central-1 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.eu_central_1
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for eu-central-1
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_eu_west_1" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.eu-west-1 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.eu_west_1
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for eu-west-1
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_eu_west_2" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.eu-west-2 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.eu_west_2
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for eu-west-2
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_eu_west_3" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.eu-west-3 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.eu_west_3
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for eu-west-3
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+module "guardduty_eu_north_1" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.eu-north-1 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.eu_north_1
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for eu-north-1
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}
+
+###########################
+# GuardDuty in SA regions #
+###########################
+module "guardduty_sa_east_1" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.sa-east-1 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.sa_east_1
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for sa-east-1
+  auto_enable = true
+
+  destination_arn = aws_s3_bucket.guardduty_bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    aws_s3_bucket_policy.guardduty_bucket_policy
+  ]
+}

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -143,5 +143,5 @@ locals {
     }
   }
 
-  guardduty_administrator_detector_ids = data.terraform_remote_state.management_account.guardduty_administrator_detector_ids
+  guardduty_administrator_detector_ids = data.terraform_remote_state.management_account.outputs.guardduty_administrator_detector_ids
 }

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -142,4 +142,6 @@ locals {
       if account.status == "ACTIVE" && account.name != "organisation-security"
     }
   }
+
+  guardduty_administrator_detector_ids = data.terraform_remote_state.management_account.guardduty_administrator_detector_ids
 }


### PR DESCRIPTION
This moves Guardduty to the management and org sec accounts.

 - Split Guardduty in to two modules, one for each account

Management (root) account:

 - Move Root and security account guardduty detectors, and delegate
administrator to the security account.
 - Move requried providers for the security account regions
 - Add an output for the Guardduty detector IDs in the security account

Organisation Security account:

 - Move organisation configuration for auto enrollment
 - Threat intel sets and aggregation bucket already moved here
 - Data source for management state to get detector IDs

Everything has been imported and both sets of Terraform run clean on apply - no changes.

The plan fails on the pipeline due to lack of permissions (I will resolve this in a separate PR).

Guardduty in the original terraform root folder will be removed in a separate PR.