### PR TITLE
Add readonly role for org sec plan

### DIFF
--- a/management-account/terraform/iam.tf
+++ b/management-account/terraform/iam.tf
@@ -24,7 +24,8 @@ resource "aws_iam_account_password_policy" "default" {
 # OIDC Provider for GitHub actions #
 ####################################
 module "github_oidc" {
-  source                = "../../modules/github-oidc-provider"
-  repository_with_owner = "ministryofjustice/aws-root-account"
-  repository_branch     = "main"
+  source                           = "../../modules/github-oidc-provider"
+  repository_with_owner            = "ministryofjustice/aws-root-account"
+  repository_branch                = "main"
+  organisation_security_account_id = aws_organizations_account.organisation_security.id
 }

--- a/management-account/terraform/providers-organisation-security.tf
+++ b/management-account/terraform/providers-organisation-security.tf
@@ -8,7 +8,7 @@ provider "aws" {
   alias  = "organisation-security-us-east-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -18,7 +18,7 @@ provider "aws" {
   alias  = "organisation-security-us-east-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -28,7 +28,7 @@ provider "aws" {
   alias  = "organisation-security-us-west-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -38,7 +38,7 @@ provider "aws" {
   alias  = "organisation-security-us-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -48,7 +48,7 @@ provider "aws" {
   alias  = "organisation-security-ap-south-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -58,7 +58,7 @@ provider "aws" {
   alias  = "organisation-security-ap-northeast-3"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -68,7 +68,7 @@ provider "aws" {
   alias  = "organisation-security-ap-northeast-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -78,7 +78,7 @@ provider "aws" {
   alias  = "organisation-security-ap-southeast-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -88,7 +88,7 @@ provider "aws" {
   alias  = "organisation-security-ap-southeast-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -98,7 +98,7 @@ provider "aws" {
   alias  = "organisation-security-ap-northeast-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -108,7 +108,7 @@ provider "aws" {
   alias  = "organisation-security-ca-central-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -118,7 +118,7 @@ provider "aws" {
   alias  = "organisation-security-eu-central-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -128,7 +128,7 @@ provider "aws" {
   alias  = "organisation-security-eu-west-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -138,7 +138,7 @@ provider "aws" {
   alias  = "organisation-security-eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -148,7 +148,7 @@ provider "aws" {
   alias  = "organisation-security-eu-west-3"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -158,7 +158,7 @@ provider "aws" {
   alias  = "organisation-security-eu-north-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -168,6 +168,6 @@ provider "aws" {
   alias  = "organisation-security-sa-east-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
   }
 }

--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -68,6 +68,14 @@ data "aws_iam_policy_document" "extra_permissions_plan" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    resources = ["arn:aws:iam::${var.organisation_security_account_id}:role/ReadOnly"]
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "extra_permissions_plan" {
@@ -175,5 +183,13 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
       "sso:*AccountAssignment*"
     ]
     resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+    ]
+    resources = ["arn:aws:iam::${var.organisation_security_account_id}:role/ReadOnly"]
   }
 }

--- a/modules/github-oidc-provider/variables.tf
+++ b/modules/github-oidc-provider/variables.tf
@@ -10,3 +10,8 @@ variable "repository_with_owner" {
 variable "repository_branch" {
   description = "GitHub repository branch name for access (e.g. main)"
 }
+
+variable "organisation_security_account_id" {
+  description = "Organisation Security account ID"
+  default     = ""
+}

--- a/organisation-security/terraform/iam-roles.tf
+++ b/organisation-security/terraform/iam-roles.tf
@@ -1,0 +1,24 @@
+############
+# ReadOnly #
+############
+resource "aws_iam_role" "read_only" {
+  name               = "ReadOnly"
+  assume_role_policy = data.aws_iam_policy_document.read_only_role.json
+}
+
+data "aws_iam_policy_document" "read_only_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.root.id}:root"]
+    }
+  }
+}
+
+# Role policy attachments
+resource "aws_iam_role_policy_attachment" "read_only_role" {
+  role       = aws_iam_role.read_only.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}


### PR DESCRIPTION
Adding a read only role to allow the management account pipeline to plan for org sec resources.

When run locally the TF uses the organisation access role, but when run on the pipeline it uses the readonly role.

This fixes the management account plan failing.

Apply is set to use the same readonly role, but once the org sec is also on a pipeline it will assume the same role used for the org sec account apply (which will be a reduced set of permissions from the org access role).