### PR TITLE
Add OIDC provider and pipelines

### DIFF
--- a/.github/workflows/organisation-security-apply.yml
+++ b/.github/workflows/organisation-security-apply.yml
@@ -1,0 +1,38 @@
+name: terraform apply (organisation-security)
+
+on:
+  push:
+    paths:
+      - 'organisation-security/terraform/**'
+      - 'modules/**'
+      - '.github/workflows/organisation-security-plan.yml'
+      - '.github/workflows/organisation-security-apply.yml'
+    branches:
+      - main
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: ./organisation-security/terraform
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::${{secrets.AWS_SECURITY_ACCOUNT_ID}}:role/github-actions-apply
+          role-session-name: GitHubActions
+          aws-region: eu-west-2
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: 1.5.2
+      - run: terraform fmt -check
+        continue-on-error: true
+      - run: terraform init
+      - run: terraform validate -no-color
+      - run: terraform plan -no-color
+      - run: terraform apply -auto-approve
+        if: github.event.ref == 'refs/heads/main'

--- a/.github/workflows/organisation-security-plan.yml
+++ b/.github/workflows/organisation-security-plan.yml
@@ -1,0 +1,36 @@
+name: terraform plan (organisation-security)
+
+on:
+  pull_request:
+    paths:
+      - 'organisation-security/terraform/**'
+      - 'modules/**'
+      - '.github/workflows/organisation-security-plan.yml'
+      - '.github/workflows/organisation-security-apply.yml'
+  workflow_dispatch:
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        working-directory: ./organisation-security/terraform
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::${{secrets.AWS_SECURITY_ACCOUNT_ID}}:role/github-actions-plan
+          role-session-name: GitHubActions
+          aws-region: eu-west-2
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2.0.3
+        with:
+          terraform_version: 1.5.2
+      - run: terraform fmt -check
+        continue-on-error: true
+      - run: terraform init
+      - run: terraform validate -no-color
+      - run: terraform plan -no-color
+   

--- a/management-account/terraform/kms.tf
+++ b/management-account/terraform/kms.tf
@@ -1,0 +1,39 @@
+# State bucket key
+
+resource "aws_kms_key" "terraform_state_s3_bucket" {
+  policy              = data.aws_iam_policy_document.terraform_state_s3_bucket_kms.json
+  is_enabled          = true
+  enable_key_rotation = true
+}
+
+resource "aws_kms_alias" "terraform_state_s3_bucket" {
+  name          = "alias/terraform-state-s3-bucket"
+  target_key_id = aws_kms_key.terraform_state_s3_bucket.id
+}
+
+data "aws_iam_policy_document" "terraform_state_s3_bucket_kms" {
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${resource.aws_organizations_account.organisation_security.id}:root"]
+    }
+  }
+}

--- a/management-account/terraform/outputs.tf
+++ b/management-account/terraform/outputs.tf
@@ -22,5 +22,6 @@ output "guardduty_administrator_detector_ids" {
 }
 
 output "organizations_organization" {
-  value = aws_organizations_organization.default
+  value       = aws_organizations_organization.default
+  description = "Organization details"
 }

--- a/management-account/terraform/outputs.tf
+++ b/management-account/terraform/outputs.tf
@@ -20,3 +20,7 @@ output "guardduty_administrator_detector_ids" {
     "sa_east_1"      = module.guardduty_sa_east_1.administrator_detector_id
   }
 }
+
+output "organizations_organization" {
+  value = aws_organizations_organization.default
+}

--- a/modules/s3/outputs.tf
+++ b/modules/s3/outputs.tf
@@ -1,3 +1,7 @@
 output "bucket_name" {
   value = aws_s3_bucket.default.id
 }
+
+output "bucket" {
+  value = aws_s3_bucket.default
+}

--- a/organisation-security/terraform/.terraform.lock.hcl
+++ b/organisation-security/terraform/.terraform.lock.hcl
@@ -42,3 +42,23 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.4"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:Wd3RqmQW60k2QWPN4sK5CtjGuO1d+CRNXgC+D4rKtXc=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/organisation-security/terraform/config-aggregation.tf
+++ b/organisation-security/terraform/config-aggregation.tf
@@ -4,7 +4,7 @@
 # in that you can do MRMAA without delivering configuration changes to a central S3 bucket.
 locals {
   enrolled_into_config = [
-    { id = data.aws_caller_identity.root.id, name = "MoJ root account" }
+    { id = local.root_account_id, name = "MoJ root account" }
   ]
 }
 

--- a/organisation-security/terraform/data.tf
+++ b/organisation-security/terraform/data.tf
@@ -1,15 +1,7 @@
 data "aws_caller_identity" "current" {}
 
-data "aws_caller_identity" "root" {
-  provider = aws.root
-}
-
-data "aws_organizations_organization" "default" {
-  provider = aws.root
-}
-
 data "aws_organizations_organizational_units" "organizational_units" {
-  parent_id = data.aws_organizations_organization.default.roots[0].id
+  parent_id = local.organizations_organization.roots[0].id
 }
 
 data "aws_organizations_organizational_units" "platforms_and_architecture" {

--- a/organisation-security/terraform/guardduty-publishing-destination.tf
+++ b/organisation-security/terraform/guardduty-publishing-destination.tf
@@ -190,7 +190,7 @@ data "aws_iam_policy_document" "guardduty_kms_key_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.root.id}:root",   # Allow the root account to manage this key
+        "arn:aws:iam::${local.root_account_id}:root",   # Allow the root account to manage this key
         "arn:aws:iam::${data.aws_caller_identity.current.id}:root" # Allow the organisation-security account to manage this key
       ]
     }

--- a/organisation-security/terraform/guardduty-publishing-destination.tf
+++ b/organisation-security/terraform/guardduty-publishing-destination.tf
@@ -190,7 +190,7 @@ data "aws_iam_policy_document" "guardduty_kms_key_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${local.root_account_id}:root",   # Allow the root account to manage this key
+        "arn:aws:iam::${local.root_account_id}:root",              # Allow the root account to manage this key
         "arn:aws:iam::${data.aws_caller_identity.current.id}:root" # Allow the organisation-security account to manage this key
       ]
     }

--- a/organisation-security/terraform/iam-roles.tf
+++ b/organisation-security/terraform/iam-roles.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "read_only_role" {
     actions = ["sts:AssumeRole"]
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.root.id}:root"]
+      identifiers = ["arn:aws:iam::${local.root_account_id}:root"]
     }
   }
 }

--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -3,8 +3,8 @@
 ####################################
 
 module "github_oidc" {
-  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
-  role_name = "github-actions-plan"
+  source                 = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
+  role_name              = "github-actions-plan"
   additional_permissions = data.aws_iam_policy_document.oidc_assume_role_plan.json
   github_repositories    = ["ministryofjustice/aws-root-account:pull_request"]
   tags_common            = { "Name" = "GitHub Actions Plan" }
@@ -32,12 +32,12 @@ module "github_actions_apply_role" {
 
   source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=9d9a2d23cf569348cbdb665c979fcbaed76bb2f4" # v3.1.0
 
-  github_repositories         = ["ministryofjustice/aws-root-account:ref:refs/heads/main"]
-  role_name                   = "github-actions-apply"
-  policy_arns                 = ["arn:aws:iam::aws:policy/AdministratorAccess"]
-  policy_jsons                = [data.aws_iam_policy_document.oidc_assume_role_apply.json]
-  subject_claim               = "pull_request"
-  tags                        = { "Name" = "GitHub Actions Apply" }
+  github_repositories = ["ministryofjustice/aws-root-account:ref:refs/heads/main"]
+  role_name           = "github-actions-apply"
+  policy_arns         = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  policy_jsons        = [data.aws_iam_policy_document.oidc_assume_role_apply.json]
+  subject_claim       = "pull_request"
+  tags                = { "Name" = "GitHub Actions Apply" }
 
 }
 

--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -1,0 +1,76 @@
+####################################
+# OIDC Provider for GitHub actions #
+####################################
+
+module "github_oidc" {
+  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-provider?ref=82f546bd5f002674138a2ccdade7d7618c6758b3" # v3.0.0
+  role_name = "github-actions-plan"
+  additional_permissions = data.aws_iam_policy_document.oidc_assume_role_plan.json
+  github_repositories    = ["ministryofjustice/aws-root-account:pull_request"]
+  tags_common            = { "Name" = "GitHub Actions Plan" }
+  tags_prefix            = ""
+}
+
+data "aws_iam_policy_document" "oidc_assume_role_plan" {
+  statement {
+    sid       = "AllowOIDCToDecryptKMS"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:Decrypt"]
+  }
+
+  statement {
+    sid       = "AllowOIDCReadState"
+    effect    = "Allow"
+    resources = ["arn:aws:s3:::moj-aws-root-account-terraform-state/*", "arn:aws:s3:::moj-aws-root-account-terraform-state/"]
+    actions = ["s3:Get*",
+    "s3:List*"]
+  }
+}
+
+module "github_actions_apply_role" {
+
+  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=9d9a2d23cf569348cbdb665c979fcbaed76bb2f4" # v3.1.0
+
+  github_repositories         = ["ministryofjustice/aws-root-account:ref:refs/heads/main"]
+  role_name                   = "github-actions-apply"
+  policy_arns                 = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  policy_jsons                = [data.aws_iam_policy_document.oidc_assume_role_apply.json]
+  subject_claim               = "pull_request"
+  tags                        = { "Name" = "GitHub Actions Apply" }
+
+}
+
+data "aws_iam_policy_document" "oidc_assume_role_apply" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "account:*AlternateContact",
+      "apigateway:*",
+      "budgets:*",
+      "ce:*",
+      "cloudtrail:*",
+      "config:*",
+      "cur:DescribeReportDefinitions",
+      "events:*",
+      "fms:*",
+      "guardduty:*",
+      "iam:*",
+      "identitystore:ListGroups",
+      "identitystore:GetGroupId",
+      "identitystore:DescribeGroup",
+      "kms:Decrypt",
+      "lambda:*",
+      "license-manager:*",
+      "logs:*",
+      "organizations:Describe*",
+      "organizations:List*",
+      "route53:*",
+      "s3:*",
+      "secretsmanager:*",
+      "securityhub:*",
+      "sns:*",
+    ]
+    resources = ["*"]
+  }
+}

--- a/organisation-security/terraform/license-manager.tf
+++ b/organisation-security/terraform/license-manager.tf
@@ -97,7 +97,7 @@ resource "aws_cloudformation_stack" "oracleblts" {
     IsDelegatedAdministrator = true
     ArtifactsS3Bucket        = "license-manager-artifact-bucket"
     AdministratorAccountId   = data.aws_caller_identity.current.id
-    OrganizationId           = data.aws_organizations_organization.default.id
+    OrganizationId           = local.organizations_organization.id
     TargetOUs                = local.ou_modernisation_platform_member_id
     TargetRegions            = "eu-west-2"
     TargetKey                = "tag:OracleDbLTS-ManagedInstance"

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -1,11 +1,19 @@
 locals {
+  organizations_organization = data.terraform_remote_state.management_account.outputs.organizations_organization
+
+  root_account_id = coalesce([
+    for account in local.organizations_organization.accounts :
+    account.id
+    if account.name == "MOJ Master"
+  ]...)
+
   organisation_security_account_id = coalesce([
-    for account in data.aws_organizations_organization.default.accounts :
+    for account in local.organizations_organization.accounts :
     account.id
     if account.name == "organisation-security"
   ]...)
 
-  organisation_account_numbers = [for account in data.aws_organizations_organization.default.accounts : account.id]
+  organisation_account_numbers = [for account in local.organizations_organization.accounts : account.id]
 
   # AWS Organizational Units
   ou_opg = coalesce([
@@ -137,7 +145,7 @@ locals {
   # Accounts map
   accounts = {
     active_only_not_self : {
-      for account in data.aws_organizations_organization.default.accounts :
+      for account in local.organizations_organization.accounts :
       account.name => account.id
       if account.status == "ACTIVE" && account.name != "organisation-security"
     }

--- a/organisation-security/terraform/providers.tf
+++ b/organisation-security/terraform/providers.tf
@@ -1,17 +1,19 @@
-# Root provider, for getting the organisation-security account ID
+# Default provider
 
 provider "aws" {
-  alias  = "root"
+  alias  = "original-session"
   region = "eu-west-2"
 }
 
-# Default provider
+data "aws_caller_identity" "original_session" {
+  provider = aws.original-session
+}
 
 provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -22,7 +24,7 @@ provider "aws" {
   region = "us-east-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -31,7 +33,7 @@ provider "aws" {
   region = "us-east-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -40,7 +42,7 @@ provider "aws" {
   region = "us-west-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -49,7 +51,7 @@ provider "aws" {
   region = "us-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -60,7 +62,7 @@ provider "aws" {
   region = "af-south-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -71,7 +73,7 @@ provider "aws" {
   region = "ap-east-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -80,7 +82,7 @@ provider "aws" {
   region = "ap-southeast-3"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -89,7 +91,7 @@ provider "aws" {
   region = "ap-south-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -98,7 +100,7 @@ provider "aws" {
   region = "ap-northeast-3"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -107,7 +109,7 @@ provider "aws" {
   region = "ap-northeast-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -116,7 +118,7 @@ provider "aws" {
   region = "ap-southeast-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -125,7 +127,7 @@ provider "aws" {
   region = "ap-southeast-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -134,7 +136,7 @@ provider "aws" {
   region = "ap-northeast-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -145,7 +147,7 @@ provider "aws" {
   region = "ca-central-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -156,7 +158,7 @@ provider "aws" {
   region = "eu-central-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -165,7 +167,7 @@ provider "aws" {
   region = "eu-west-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -174,7 +176,7 @@ provider "aws" {
   region = "eu-west-2"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -183,7 +185,7 @@ provider "aws" {
   region = "eu-south-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -192,7 +194,7 @@ provider "aws" {
   region = "eu-west-3"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -201,7 +203,7 @@ provider "aws" {
   region = "eu-north-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
   }
 }
 
@@ -212,7 +214,8 @@ provider "aws" {
   region = "me-south-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+
   }
 }
 
@@ -223,6 +226,7 @@ provider "aws" {
   region = "sa-east-1"
 
   assume_role {
-    role_arn = "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
+
   }
 }


### PR DESCRIPTION
- Add an OIDC provider with roles for plan and apply.
- Adds plan and apply workflows.
- Makes changes to data sources and providers to account for that the terraform will be run locally using root creds, and on the workflows using the new roles.
- Create KMS key to enable the state bucket access to be shared to the organisation security account.

This TF has been applied locally in advance to create the required resources so that the plan can work on this PR.