### PR TITLE
Disable ACLs as default

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -23,9 +23,9 @@ module "cloudtrail_replication_s3_bucket" {
   providers = {
     aws = aws.eu-west-1
   }
-  source = "../../modules/s3"
-
-  bucket_name = "cloudtrail--replication20210315101340520100000002"
+  source           = "../../modules/s3"
+  object_ownership = "ObjectWriter"
+  bucket_name      = "cloudtrail--replication20210315101340520100000002"
 
   attach_policy        = true
   require_ssl_requests = true
@@ -44,8 +44,9 @@ module "cloudtrail_replication_s3_bucket" {
 module "cloudtrail_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_name = "cloudtrail-20210315101356188000000003"
-  bucket_acl  = "log-delivery-write"
+  bucket_name      = "cloudtrail-20210315101356188000000003"
+  bucket_acl       = "log-delivery-write"
+  object_ownership = "ObjectWriter"
 
   attach_policy        = true
   policy               = data.aws_iam_policy_document.cloudtrail_s3_bucket.json
@@ -120,6 +121,7 @@ module "log_bucket_s3_bucket" {
 
   attach_policy        = true
   require_ssl_requests = true
+  object_ownership     = "ObjectWriter"
 
   server_side_encryption_configuration = {
     rule = {

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket_acl" "default" {
 resource "aws_s3_bucket_ownership_controls" "default" {
   bucket = aws_s3_bucket.default.id
   rule {
-    object_ownership = "ObjectWriter"
+    object_ownership = var.object_ownership
   }
 }
 

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -61,3 +61,8 @@ variable "require_ssl_requests" {
   type    = bool
   default = false
 }
+
+variable "object_ownership" {
+  type    = string
+  default = "BucketOwnerEnforced"
+}


### PR DESCRIPTION
ACLs are now disabled as default by AWS, this turns off ACLs where easily possible (other need further policy changes).

This fixes the issue of the org sec account writing to the state bucket then the ACL preventing the root account from accessing it.