### PR TITLE
Add missing object ownership and shield config

### DIFF
--- a/organisation-security/terraform/firewall-manager.tf
+++ b/organisation-security/terraform/firewall-manager.tf
@@ -30,7 +30,7 @@ resource "aws_fms_policy" "eu_west_2_shield_advanced_auto_remediate" {
         automaticResponseAction = null
         automaticResponseStatus = "IGNORED"
       }
-      overrideCustomerWebaclClassic  = false
+      overrideCustomerWebaclClassic = false
     })
   }
 }
@@ -95,7 +95,7 @@ resource "aws_fms_policy" "eu_west_1_shield_advanced_auto_remediate" {
         automaticResponseAction = null
         automaticResponseStatus = "IGNORED"
       }
-      overrideCustomerWebaclClassic  = false
+      overrideCustomerWebaclClassic = false
     })
   }
 }

--- a/organisation-security/terraform/firewall-manager.tf
+++ b/organisation-security/terraform/firewall-manager.tf
@@ -26,6 +26,11 @@ resource "aws_fms_policy" "eu_west_2_shield_advanced_auto_remediate" {
     type = "SHIELD_ADVANCED"
     managed_service_data = jsonencode({
       type = "SHIELD_ADVANCED"
+      automaticResponseConfiguration = {
+        automaticResponseAction = null
+        automaticResponseStatus = "IGNORED"
+      }
+      overrideCustomerWebaclClassic  = false
     })
   }
 }
@@ -86,6 +91,11 @@ resource "aws_fms_policy" "eu_west_1_shield_advanced_auto_remediate" {
     type = "SHIELD_ADVANCED"
     managed_service_data = jsonencode({
       type = "SHIELD_ADVANCED"
+      automaticResponseConfiguration = {
+        automaticResponseAction = null
+        automaticResponseStatus = "IGNORED"
+      }
+      overrideCustomerWebaclClassic  = false
     })
   }
 }

--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -44,8 +44,8 @@ module "cloudtrail_replication_s3_bucket" {
 module "cloudtrail_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_name = "cloudtrail-${random_integer.suffix.result}"
-  bucket_acl  = "log-delivery-write"
+  bucket_name      = "cloudtrail-${random_integer.suffix.result}"
+  bucket_acl       = "log-delivery-write"
   object_ownership = "ObjectWriter"
 
   attach_policy        = true

--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -46,6 +46,7 @@ module "cloudtrail_s3_bucket" {
 
   bucket_name = "cloudtrail-${random_integer.suffix.result}"
   bucket_acl  = "log-delivery-write"
+  object_ownership = "ObjectWriter"
 
   attach_policy        = true
   policy               = data.aws_iam_policy_document.cloudtrail_s3_bucket.json


### PR DESCRIPTION
Adding a missed object ownership to match current config.

Also adding additional shield config that TF keeps removing and then gets auto re-added by AWS.

Plan now runs clean apart from one deprecation warning.