### PR TITLE
Enabling bedrock service in Frankfurt.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .terraform
 *.tfstate*
 .DS_Store
+
+# IDE
+**.vscode

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -338,6 +338,28 @@ data "aws_iam_policy_document" "modernisation_platform_member_ou_scp" {
     }
   }
 
+  # Deny everything aside from Bedrock in Germany unless requested by priveleged MP roles
+  statement {
+    effect = "Deny"
+    not_actions = [
+      "bedrock:*"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:RequestedRegion"
+      values = [
+        "eu-central-1"
+      ]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "aws:PrincipalARN"
+      values   = ["arn:aws:iam::*:role/OrganizationAccountAccessRole", "arn:aws:iam::*:role/ModernisationPlatformAccess", "arn:aws:iam::${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:role/superadmin"]
+    }
+  }
+
   # block changes to github-actions policy
   statement {
     effect = "Deny"


### PR DESCRIPTION
https://github.com/ministryofjustice/modernisation-platform/issues/5677

Updating Modernisation Platform top-level SCP to allow access to Bedrock in `eu-central-1`.

Note: This is not added to the regional SCP because it would block bootstrapping activities in non-MP accounts in Germany.