### PR TITLE
Add SSO for directory management role

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -360,6 +360,30 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
   }
 }
 
+# Modernisation Platform Active Directory Administrator
+resource "aws_ssoadmin_permission_set" "modernisation_platform_active_directory_management" {
+  name             = "mp-active-directory-management"
+  description      = "Modernisation Platform: active-directory-management"
+  instance_arn     = local.sso_admin_instance_arn
+  session_duration = "PT8H"
+  tags             = {}
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_active_directory_management_readonly" {
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_active_directory_management.arn
+}
+
+resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platform_directory_management_mmad" {
+  instance_arn       = local.sso_admin_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_active_directory_management.arn
+  customer_managed_policy_reference {
+    name = "directory_management_policy"
+    path = "/"
+  }
+}
+
 ################################
 # OPG specific permission sets #
 ################################


### PR DESCRIPTION
As part of [this story](https://github.com/ministryofjustice/modernisation-platform/issues/5810), I'd like to create an SSO role that can be used purely for the administration of AWS Managed Microsoft Active Directory.

Because the AWS-managed IAM policy is quite broad, we'll hold the policy document in the `modernisation-platform` repository and reference it here.

This role will be applied to GitHub Teams who want to host AD on the Modernisation Platform in our `core-shared-services` account.