### PR TITLE
Add Oasys to Oracle licensing reporting

### DIFF
--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -85,10 +85,12 @@ locals {
   # ous for license manager
   ou_example  = coalesce([for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children : ou.id if ou.name == "modernisation-platform-example"]...)
   ou_ccms_ebs = coalesce([for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children : ou.id if ou.name == "modernisation-platform-ccms-ebs"]...)
+  ou_oasys = coalesce([for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children : ou.id if ou.name == "modernisation-platform-oasys"]...)
 
   license_mamager_ous = [
     local.ou_example,
-    local.ou_ccms_ebs
+    local.ou_ccms_ebs,
+    local.ou_oasys
   ]
 
   # modernisation_platform_member_ous = [

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -85,7 +85,7 @@ locals {
   # ous for license manager
   ou_example  = coalesce([for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children : ou.id if ou.name == "modernisation-platform-example"]...)
   ou_ccms_ebs = coalesce([for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children : ou.id if ou.name == "modernisation-platform-ccms-ebs"]...)
-  ou_oasys = coalesce([for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children : ou.id if ou.name == "modernisation-platform-oasys"]...)
+  ou_oasys    = coalesce([for ou in data.aws_organizations_organizational_units.modernisation_platform_member.children : ou.id if ou.name == "modernisation-platform-oasys"]...)
 
   license_mamager_ous = [
     local.ou_example,


### PR DESCRIPTION
Allow Oracle licensing reports to be generated for oasys accounts.