### PR TITLE
Add read-only access for moj_official_network_operations_centre account

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -253,6 +253,13 @@ locals {
       ]
     },
     {
+      github_team        = "moj-official-techops-readonly",
+      permission_set_arn = aws_ssoadmin_permission_set.techops_operator.arn,
+      account_ids = [
+        aws_organizations_account.moj_official_network_operations_centre.id,
+      ]
+    },
+    {
       github_team        = "moj-official-techops",
       permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
       account_ids = flatten([


### PR DESCRIPTION
## 👀 Purpose

- Request to provide users with read-only access to `moj_official_network_operations_centre` AWS Account. Due to the overlapping use of Github Team Associations, existing Teams could not be used for this purpose, as it added extra permissions over and above read-only. This change adds a new Team Association that limits permissions to read-only.

## ♻️ What's changed

- New association mapping added that allows new Github Team `moj-official-techops-readonly` access to the `moj_official_network_operations_centre` AWS account with `techops-operator` permissions (read-only).

## 📝 Notes

- [#ask-operations-engineering request](https://mojdt.slack.com/archives/C01BUKJSZD4/p1704809625543569)