### PR TITLE
Revert "Add SSO for directory management role"

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -360,30 +360,6 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
   }
 }
 
-# Modernisation Platform Active Directory Administrator
-resource "aws_ssoadmin_permission_set" "modernisation_platform_active_directory_management" {
-  name             = "mp-active-directory-management"
-  description      = "Modernisation Platform: active-directory-management"
-  instance_arn     = local.sso_admin_instance_arn
-  session_duration = "PT8H"
-  tags             = {}
-}
-
-resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_active_directory_management_readonly" {
-  instance_arn       = local.sso_admin_instance_arn
-  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
-  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_active_directory_management.arn
-}
-
-resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platform_directory_management_mmad" {
-  instance_arn       = local.sso_admin_instance_arn
-  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_active_directory_management.arn
-  customer_managed_policy_reference {
-    name = "directory_management_policy"
-    path = "/"
-  }
-}
-
 ################################
 # OPG specific permission sets #
 ################################


### PR DESCRIPTION
Reverts ministryofjustice/aws-root-account#843

After some investigation in the team, we've chosen not to proceed with this solution, and as such this SSO role is no longer required.