### PR TITLE
Updated SCP for modernisation platform member OU

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -311,14 +311,27 @@ resource "aws_organizations_policy" "modernisation_platform_member_ou_scp" {
 }
 
 data "aws_iam_policy_document" "modernisation_platform_member_ou_scp" {
+  # Deny creation of peering connections anywhere
   statement {
     effect = "Deny"
     actions = [
       "ec2:CreateVpcPeeringConnection",
+    ]
+    resources = ["*"]
+  }
+  # Deny creation of VPCs or Subnets outside of eu-west-2
+  statement {
+    effect = "Deny"
+    actions = [
       "ec2:CreateVpc",
       "ec2:CreateSubnet"
     ]
     resources = ["*"]
+    condition {
+      test     = "StringNotEqualsIfExists"
+      variable = "aws:RequestedRegion"
+      values   = ["eu-west-2"]
+    }
   }
   # block changes to OIDC provider github role
   statement {


### PR DESCRIPTION
There are occasional instances where Modernisation Platform customers will require access to isolated networking resources. In order to contain our code for customers in the `modernisation-platform-environments` repository, the SCP that controls what resources can be built by customer accounts needs some adjustment.