### PR TITLE
🛂 Add PowerBI Author permission set

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -180,7 +180,7 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "modernisation_platfo
 # Modernisation Platform data engineer
 resource "aws_ssoadmin_permission_set" "modernisation_platform_data_mwaa_user" {
   name             = "modernisation-platform-mwaa-user"
-  description      = "Modernisation Platform: data engineering mwaa user"
+  description      = "Modernisation Platform: Data Engineering MWAA User"
   instance_arn     = local.sso_admin_instance_arn
   session_duration = "PT8H"
   tags             = {}
@@ -199,6 +199,37 @@ resource "aws_ssoadmin_permission_set_inline_policy" "modernisation_platform_dat
 }
 
 data "aws_iam_policy_document" "modernisation_platform_data_mwaa_user" {
+  statement {
+    actions = [
+      "airflow:CreateWebLoginToken"
+    ]
+    resources = ["arn:aws:airflow:*:*:role/*/User"]
+  }
+}
+
+
+# PowerBI Author
+resource "aws_ssoadmin_permission_set" "modernisation_platform_data_powerbi_author" {
+  name             = "modernisation-platform-powerbi-author"
+  description      = "Modernisation Platform: Data Engineering PowerBI Author"
+  instance_arn     = local.sso_admin_instance_arn
+  session_duration = "PT8H"
+  tags             = {}
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "modernisation_platform_data_powerbi_author" {
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_data_powerbi_author.arn
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "modernisation_platform_data_powerbi_author" {
+  instance_arn       = local.sso_admin_instance_arn
+  inline_policy      = data.aws_iam_policy_document.modernisation_platform_data_powerbi_author.json
+  permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_data_powerbi_author.arn
+}
+
+data "aws_iam_policy_document" "modernisation_platform_data_powerbi_author" {
   statement {
     actions = [
       "airflow:CreateWebLoginToken"

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -230,12 +230,101 @@ resource "aws_ssoadmin_permission_set_inline_policy" "modernisation_platform_dat
 }
 
 data "aws_iam_policy_document" "modernisation_platform_data_powerbi_author" {
-  statement {
-    actions = [
-      "airflow:CreateWebLoginToken"
-    ]
-    resources = ["arn:aws:airflow:*:*:role/*/User"]
-  }
+    statement {
+      actions = [
+        "s3:ListBucket",
+        "s3:ListAllMyBuckets",
+        "s3:GetBucketLocation"
+      ]
+      resources = [
+        "arn:aws:s3:::mojap-derived-tables/dev/run_artefacts/*",
+        "arn:aws:s3:::mojap-derived-tables/dev/models/domain_name=risk/*",
+        "arn:aws:s3:::mojap-derived-tables/seeds/*",
+        "arn:aws:s3:::alpha-everyone/*",
+        "arn:aws:s3:::dbt-query-dump/*",
+        "arn:aws:s3:::mojap-manage-offences/ho-offence-codes/dev/*",
+        "arn:aws:s3:::mojap-derived-tables/dev/models/domain_name=general/*",
+        "arn:aws:s3:::mojap-derived-tables/*__dbt_tmp/*",
+        "arn:aws:s3:::alpha-postcodes/database/postcodes/*",
+        "arn:aws:s3:::alpha-lookup-cjsq/lookup_offence_raw/*",
+        "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=general/*",
+        "arn:aws:s3:::moj-reg-dev-curated/hmpps-assess-risks-and-needs-dev/data/*",
+        "arn:aws:s3:::alpha-data-linking/v4/products/internal/*",
+        "arn:aws:s3:::moj-reg-dev-curated/data-eng-uploader-dev/data/*",
+        "arn:aws:s3:::alpha-cjsm-logs-data/api_test/production/processed/pass/*",
+        "arn:aws:s3:::alpha-postcodes/database/names/*",
+        "arn:aws:s3:::mojap-derived-tables/prod/run_artefacts/*",
+        "arn:aws:s3:::moj-reg-dev-curated/hmpps-interventions-dev/data/*",
+        "arn:aws:s3:::alpha-lookup-cjsq/lookup_offence/*",
+        "arn:aws:s3:::alpha-lookup-cjsq/lookup_court_disposals/*",
+        "arn:aws:s3:::alpha-data-linking-anonymised/v4/products/internal/*",
+        "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=risk/*",
+        "arn:aws:s3:::alpha-psr-discovery-work/*",
+        "arn:aws:s3:::alpha-interventions-discovery-ds/*",
+        "arn:aws:s3:::alpha-segmentation-adhoc/*",
+        "arn:aws:s3:::alpha-app-commuter-sandbox/*",
+        "arn:aws:s3:::alpha-app-interventions/*",
+        "arn:aws:s3:::alpha-segmentation/*",
+        "arn:aws:s3:::alpha-segmentation-2020alpha-segmentation-2020/restricted_share//*",
+        "arn:aws:s3:::alpha-segmentation-2020restricted_share//*",
+        "arn:aws:s3:::alpha-segmentation-2020restricted_share/*/*",
+        "arn:aws:s3:::alpha-segmentation-2020restricted_share/*",
+        "arn:aws:s3:::alpha-segmentation-2020/*",
+        "arn:aws:s3:::alpha-nextgenaccreditedevaluation/*",
+        "arn:aws:s3:::alpha-app-occupeye-automation/*",
+        "arn:aws:s3:::alpha-app-matrixbooking/*",
+        "arn:aws:s3:::alpha-dag-matrix/*",
+        "arn:aws:s3:::alpha-dag-occupeye/*",
+        "arn:aws:s3:::alpha-data-science-risk/*",
+        "arn:aws:s3:::alpha--people-survey/*",
+        "arn:aws:s3:::alpha-accredited-programmes-review-2021/*",
+        "arn:aws:s3:::alpha-probation-data-room/*",
+        "arn:aws:s3:::alpha-app-segmentation-tool-probation/*",
+        "arn:aws:s3:::alpha-hr-dataproject/Input Data/Pay Element Lists/*",
+        "arn:aws:s3:::alpha-hr-dataproject/Input Data/Remuneration Data/Remuneration Tool Data/*"
+      ]
+      sid = "read-only"
+    }
+    statement {
+      actions = [
+        "s3:ListBucket",
+        "s3:ListAllMyBuckets",
+        "s3:GetBucketLocation"
+      ]
+      resources = [
+        "arn:aws:s3:::alpha-cjsm-logs-data",
+        "arn:aws:s3:::alpha-data-linking",
+        "arn:aws:s3:::alpha-data-linking-anonymised",
+        "arn:aws:s3:::alpha-everyone",
+        "arn:aws:s3:::alpha-lookup-cjsq",
+        "arn:aws:s3:::alpha-postcodes",
+        "arn:aws:s3:::dbt-query-dump",
+        "arn:aws:s3:::moj-reg-dev-curated",
+        "arn:aws:s3:::mojap-derived-tables",
+        "arn:aws:s3:::mojap-manage-offences",
+        "arn:aws:s3:::alpha-probation-data-room",
+        "arn:aws:s3:::alpha-psr-discovery-work",
+        "arn:aws:s3:::alpha-interventions-discovery-ds",
+        "arn:aws:s3:::alpha-segmentation-adhoc",
+        "arn:aws:s3:::alpha-app-commuter-sandbox",
+        "arn:aws:s3:::alpha-app-segmentation-tool-probation",
+        "arn:aws:s3:::alpha-app-interventions",
+        "arn:aws:s3:::alpha-segmentation",
+        "arn:aws:s3:::alpha-segmentation-2020",
+        "arn:aws:s3:::alpha-nextgenaccreditedevaluation",
+        "arn:aws:s3:::alpha-app-occupeye-automation",
+        "arn:aws:s3:::alpha-app-matrixbooking",
+        "arn:aws:s3:::alpha-dag-matrix",
+        "arn:aws:s3:::alpha-dag-occupeye",
+        "arn:aws:s3:::alpha-data-science-risk",
+        "arn:aws:s3:::alpha--people-survey",
+        "arn:aws:s3:::alpha-hr-dataproject",
+        "arn:aws:s3:::alpha-accredited-programmes-review-2021",
+        "arn:aws:s3:::alpha-athena-query-dump",
+        "arn:aws:s3:::mojap-athena-query-dump"
+      ]
+      sid = "list"
+    }
 }
 
 # Modernisation Platform sandbox


### PR DESCRIPTION
The purpose of this PR is to create an SSO permission set for use in a specific _tactical_ business case - we are aware of the limitations here and this will not scale / is not expected to become an AP offering. 

This is in reference to [this issue](https://github.com/ministryofjustice/data-platform/issues/2451) specifically.

The user `modernisation-platform-powerbi-author` shall be assumed by three analytical platform users to configure a data source made up of data being held in analytical platform, in order to make it available in the PowerBI service. This permission set is only to be used in the `analytical-platform-data-production` account.

In a follow on PR, we will add the rego restrictions in `modernisation-platform` repository. 