### PR TITLE
added extra policy to readonly role so assumers can get group details

### DIFF
--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -133,6 +133,11 @@ resource "aws_iam_role_policy_attachment" "modernisation_platform_sso_readonly" 
   policy_arn = "arn:aws:iam::aws:policy/AWSSSOReadOnly"
 }
 
+resource "aws_iam_role_policy_attachment" "modernisation_platform_ssodirectory_readonly" {
+  role       = aws_iam_role.modernisation_platform_sso_readonly.name
+  policy_arn = "arn:aws:iam::aws:policy/AAWSSSODirectoryReadOnly"
+}
+
 ##########################################
 # ModernisationPlatformGithubActionsRole #
 ##########################################


### PR DESCRIPTION
In order to use terraform to retrieve a group ID, the `AWSSSODirectoryReadOnly` is required alongside `AWSSSOReadOnly`.

- `AWSSSOReadOnly` allows retrieval of the identitystore ID.
- `AWSSSODirectoryReadOnly` allows retrieval of a group ID.