### PR TITLE
Add an extra permission to the MP SSO read-only role

### DIFF
--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -109,6 +109,11 @@ resource "aws_iam_role" "modernisation_platform_sso_readonly" {
   assume_role_policy = data.aws_iam_policy_document.modernisation_platform_sso_readonly.json
 }
 
+resource "aws_iam_policy" "modernisation_platform_sso_readonly_additional" {
+  name   = "ModernisationPlatformSSOReadOnlyAdditional"
+  policy = data.aws_iam_policy_document.modernisation_platform_sso_readonly_additional.json
+}
+
 data "aws_iam_policy_document" "modernisation_platform_sso_readonly" {
   statement {
     effect  = "Allow"
@@ -127,6 +132,15 @@ data "aws_iam_policy_document" "modernisation_platform_sso_readonly" {
   }
 }
 
+data "aws_iam_policy_document" "modernisation_platform_sso_readonly_additional" {
+  statement {
+    effect  = "Allow"
+    actions = ["identitystore:Get*"]
+
+    resources = ["arn:aws:identitystore::${data.aws_caller_identity.current.account_id}:identitystore/*"]
+  }
+}
+
 # Role policy attachments
 resource "aws_iam_role_policy_attachment" "modernisation_platform_sso_readonly" {
   role       = aws_iam_role.modernisation_platform_sso_readonly.name
@@ -136,6 +150,11 @@ resource "aws_iam_role_policy_attachment" "modernisation_platform_sso_readonly" 
 resource "aws_iam_role_policy_attachment" "modernisation_platform_ssodirectory_readonly" {
   role       = aws_iam_role.modernisation_platform_sso_readonly.name
   policy_arn = "arn:aws:iam::aws:policy/AWSSSODirectoryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "modernisation_platform_ssodirectory_readonly" {
+  role       = aws_iam_role.modernisation_platform_sso_readonly.name
+  policy_arn = aws_iam_policy.modernisation_platform_sso_readonly_additional.arn
 }
 
 ##########################################

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -152,7 +152,7 @@ resource "aws_iam_role_policy_attachment" "modernisation_platform_ssodirectory_r
   policy_arn = "arn:aws:iam::aws:policy/AWSSSODirectoryReadOnly"
 }
 
-resource "aws_iam_role_policy_attachment" "modernisation_platform_ssodirectory_readonly" {
+resource "aws_iam_role_policy_attachment" "modernisation_platform_ssodirectory_readonly_additional" {
   role       = aws_iam_role.modernisation_platform_sso_readonly.name
   policy_arn = aws_iam_policy.modernisation_platform_sso_readonly_additional.arn
 }


### PR DESCRIPTION
On further investigation it appears that the terraform `aws_identitystore_group` data call also requires the `identitystore:GetGroupID` action.

```
│ Error: reading AWS SSO Identity Store Group Data Source (d-*): operation error 
identitystore: GetGroupId, https response error StatusCode: 400, RequestID: (, 
AccessDeniedException: User: arn:aws:sts::*:assumed-role/ModernisationPlatformSSOReadOnly/* 
is not authorized to perform: identitystore:GetGroupId on resource: 
arn:aws:identitystore::*:identitystore/d-* because no identity-based policy allows the 
identitystore:GetGroupId action
```

This action doesn't appear in any of the AWS managed policies documented [here](https://docs.aws.amazon.com/singlesignon/latest/userguide/security-iam-awsmanpol.html), so we have to supply it additionally to the ModernisationPlatformSSOReadOnly role.