### PR TITLE
🔥 Remove Cloud Platforms Admin Access to MoJ DSD

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -4,7 +4,6 @@ locals {
       github_team        = "webops",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [
-        aws_organizations_account.moj_digital_services.id,
         aws_organizations_account.cloud_platform.id,
         aws_organizations_account.cloud_platform_ephemeral_test.id,
         aws_organizations_account.cloud_platform_transit_gateways.id


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4188 
- To reduce risk of DNS changes being made outside of Operations Engineering team by removing Cloud Platforms access to the account

## ♻️ What's changed

- Removed the "webops" teams (Cloud Platform teams) SSO admin access to the MoJ DSD AWS account

## 📝 Notes

- This change has been discussed with the Cloud Platform team
- Admin access was the only access the Cloud Platform team had to the account (i.e. no Read Only etc.)
- Link to [terraform plan](https://github.com/ministryofjustice/aws-root-account/actions/runs/7964154314/job/21741141618?pr=870#step:8:1242)