### PR TITLE
Remove cloud platform transit gateways account

### DIFF
--- a/management-account/terraform/.terraform.lock.hcl
+++ b/management-account/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/auth0/auth0" {
   version     = "1.1.1"
   constraints = ">= 1.0.0"
   hashes = [
+    "h1:nhAzjMfDzrn2QpjbwmsAaf+Vj8hw/R+49CHhFTAUDYQ=",
     "h1:s7JTRB1SOjgRqR+Ge9Dzvd2pnQM2uEq1FMhysXXFvew=",
     "zh:2fecf328558331bb9faa31bfc49c7610c08dd718624733aacb687c982454008e",
     "zh:35ca00946e511d9a03844d768bc1b21a1c87fc3ff547aa3e120a73e27559ce1f",
@@ -25,9 +26,10 @@ provider "registry.terraform.io/auth0/auth0" {
 
 provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.4.1"
-  constraints = ">= 2.4.0"
+  constraints = ">= 2.2.0"
   hashes = [
     "h1:3mCpFxc6HwDIETCFHNENlxBUgKdsW2S1EmVHARn9Lgk=",
+    "h1:AABk7Bon/bM1LKziIsGG78d97c9IhEqh/EWJs1J0rLo=",
     "zh:00240c042740d18d6ba545b211ff7ed5a9e8490d30be3f865e71dba90d7a34cf",
     "zh:230c285beafaffd8d60da3446157b95f8fb43b359ba94b09214c1822bf310c3d",
     "zh:726672a0e61a1d39695ce5e330aa3e6caa97f2a9438cf8125360e80f4cb52fa5",
@@ -45,8 +47,9 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.31.0"
-  constraints = ">= 3.27.0, >= 4.0.0, >= 4.7.0, >= 5.0.0, ~> 5.0"
+  constraints = ">= 3.6.0, >= 3.27.0, >= 4.0.0, >= 4.7.0, >= 5.0.0, ~> 5.0"
   hashes = [
+    "h1:2eauBmfftzGMpzFQn9aHSXiyaO3Ve5cnihmXcKGGpgU=",
     "h1:ltxyuBWIy9cq0kIKDJH1jeWJy/y7XJLjS4QrsQK4plA=",
     "zh:0cdb9c2083bf0902442384f7309367791e4640581652dda456f2d6d7abf0de8d",
     "zh:2fe4884cb9642f48a5889f8dff8f5f511418a18537a9dfa77ada3bcdad391e4e",
@@ -68,9 +71,10 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.3.2"
-  constraints = ">= 2.3.0"
+  constraints = ">= 2.1.0"
   hashes = [
     "h1:cy50n4q+Ir4GYppAfuYhQbBJVxMZbJUlIvM6FVK2axs=",
+    "h1:o3YpEB5BjeHiVi/1W0QDYhMUFmNsUZ7/3UombYD75e0=",
     "zh:020bf652739ecd841d696e6c1b85ce7dd803e9177136df8fb03aa08b87365389",
     "zh:0c7ea5a1cbf2e01a8627b8a84df69c93683f39fe947b288e958e72b9d12a827f",
     "zh:25a68604c7d6aa736d6e99225051279eaac3a7cf4cab33b00ff7eae7096166f6",
@@ -91,6 +95,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "3.6.0"
   hashes = [
     "h1:I8MBeauYA8J8yheLJ8oSMWqB0kovn16dF/wKZ1QTdkk=",
+    "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
     "zh:24a17bba7f6d679538ff51b3a2f378cedadede97af8a1db7dad4fd8d6d50f829",
@@ -110,6 +115,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.0.5"
   constraints = "4.0.5"
   hashes = [
+    "h1:yLqz+skP3+EbU3yyvw8JqzflQTKDQGsC9QyZAg+S4dg=",
     "h1:zeG5RmggBZW/8JWIVrdaeSJa0OG62uFX5HY1eE8SjzY=",
     "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
     "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",

--- a/management-account/terraform/organizations-accounts-technology-services.tf
+++ b/management-account/terraform/organizations-accounts-technology-services.tf
@@ -216,25 +216,3 @@ resource "aws_organizations_account" "network_architecture" {
     ]
   }
 }
-
-resource "aws_organizations_account" "cloud_platform_transit_gateways" {
-  name                       = "Cloud Platform Transit Gateways"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "cloud-platform-transit-gateways")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.technology_services.id
-
-  tags = merge(local.tags_technology_services, {
-    is-production = true
-    application   = "Core Transit Gateway"
-    source-code   = "github.com/ministryofjustice/transit-gateways"
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -87,11 +87,6 @@ resource "aws_organizations_policy_attachment" "deny_aws_account_root_user_opg" 
   target_id = aws_organizations_organizational_unit.opg.id
 }
 
-resource "aws_organizations_policy_attachment" "deny_aws_account_root_user_cloud_platform_transit_gateways" {
-  policy_id = aws_organizations_policy.deny_aws_account_root_user.id
-  target_id = aws_organizations_account.cloud_platform_transit_gateways.id
-}
-
 #####################################
 # Deny all actions on all resources #
 #####################################

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -6,7 +6,6 @@ locals {
       account_ids = [
         aws_organizations_account.cloud_platform.id,
         aws_organizations_account.cloud_platform_ephemeral_test.id,
-        aws_organizations_account.cloud_platform_transit_gateways.id
       ]
     },
     {
@@ -176,7 +175,6 @@ locals {
       github_team        = "modernisation-platform-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
       account_ids = [
-        aws_organizations_account.cloud_platform_transit_gateways.id,
         aws_organizations_account.moj_official_production.id,
         aws_organizations_account.moj_official_shared_services.id,
       ]


### PR DESCRIPTION
The transit gateways in this account have been decomissioned in this issue here - https://github.com/ministryofjustice/cloud-platform/issues/5228

This AWS account can now be closed.