### PR TITLE
Create PoC Azure EntraID connection

### DIFF
--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -82,5 +82,6 @@ locals {
     auth0_saml          = sensitive(jsondecode(data.aws_secretsmanager_secret_version.auth0_saml.secret_string))
     github_saml         = sensitive(jsondecode(data.aws_secretsmanager_secret_version.github_saml.secret_string))
     aws_saml            = sensitive(jsondecode(data.aws_secretsmanager_secret_version.aws_saml.secret_string))
+    azure_entraid_oidc  = sensitive(jsondecode(data.aws_secretsmanager_secret_version.azure_entraid_oidc.secret_string))
   }
 }

--- a/management-account/terraform/secrets-manager.tf
+++ b/management-account/terraform/secrets-manager.tf
@@ -75,3 +75,7 @@ resource "aws_secretsmanager_secret" "azure_entraid_oidc" {
   name        = "azure_entraid_oidc"
   description = "Azure client ID and secret for the Ministry of Justice owned OAuth app for AWS SSO"
 }
+
+data "aws_secretsmanager_secret_version" "azure_entraid_oidc" {
+  secret_id = aws_secretsmanager_secret.azure_entraid_oidc.id
+}

--- a/management-account/terraform/sso.tf
+++ b/management-account/terraform/sso.tf
@@ -1,13 +1,16 @@
 module "sso" {
   # tflint-ignore: terraform_module_pinned_source
-  source                     = "github.com/ministryofjustice/moj-terraform-aws-sso?ref=03d03c19b860229206aa7c01680d6f849cbb16da" # v3.2.2
-  auth0_allowed_domains      = local.sso.email_suffix
-  auth0_aws_sso_acs_url      = sensitive(local.sso.aws_saml.acs_url)
-  auth0_aws_sso_issuer_url   = sensitive(local.sso.aws_saml.issuer_url)
-  auth0_client_id            = sensitive(local.sso.auth0_saml.client_id)
-  auth0_client_secret        = sensitive(local.sso.auth0_saml.client_secret)
-  auth0_github_allowed_orgs  = [local.sso.github_organisation]
-  auth0_github_client_id     = sensitive(local.sso.github_saml.client_id)
-  auth0_github_client_secret = sensitive(local.sso.github_saml.client_secret)
-  auth0_tenant_domain        = sensitive(local.sso.auth0_tenant_domain)
+  source                            = "github.com/ministryofjustice/moj-terraform-aws-sso?ref=c6cb4112d079bc7471735fc81d6128ad3d38eedb" # v3.3.1
+  auth0_allowed_domains             = local.sso.email_suffix
+  auth0_aws_sso_acs_url             = sensitive(local.sso.aws_saml.acs_url)
+  auth0_aws_sso_issuer_url          = sensitive(local.sso.aws_saml.issuer_url)
+  auth0_client_id                   = sensitive(local.sso.auth0_saml.client_id)
+  auth0_client_secret               = sensitive(local.sso.auth0_saml.client_secret)
+  auth0_github_allowed_orgs         = [local.sso.github_organisation]
+  auth0_github_client_id            = sensitive(local.sso.github_saml.client_id)
+  auth0_github_client_secret        = sensitive(local.sso.github_saml.client_secret)
+  auth0_tenant_domain               = sensitive(local.sso.auth0_tenant_domain)
+  auth0_azure_entraid_client_id     = sensitive(local.sso.azure_entraid_oidc.client_id)
+  auth0_azure_entraid_client_secret = sensitive(local.sso.azure_entraid_oidc.client_secret)
+  auth0_azure_entraid_domain        = sensitive(local.sso.azure_entraid_oidc.domain)
 }


### PR DESCRIPTION
This will add an Azure EntraID connection to AWS SSO, allowing users to log in to AWS using their justice accounts.

This is a temporary connection, as the current Azure application is user based rather than machine to machine so SCIM can not yet be done.  Users are however populated into Auth0, so for the PoC we will add a set list of users to AWS SSO via the SCIM job until we can use the new Azure application (to be provided by Tech Services) to get the data automatically.