### PR TITLE
Add moj-eucs-identity Team to SSO

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -292,6 +292,17 @@ locals {
       ]
     },
     {
+      github_team        = "moj-eucs-identity",
+      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
+      account_ids = [
+        aws_organizations_account.moj_official_development.id,
+        aws_organizations_account.moj_official_preproduction.id,
+        aws_organizations_account.moj_official_production.id,
+        aws_organizations_account.moj_official_public_key_infrastructure_dev.id,
+        aws_organizations_account.moj_official_public_key_infrastructure.id
+      ]
+    },
+    {
       github_team        = "modernisation-platform-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.aws_sso_read_only.arn,
       account_ids = [


### PR DESCRIPTION
## 👀 Purpose

- PR to add new GitHub Team `moj-eucs-identity` read-only access to a number of accounts

## ♻️ What's changed

- Added block for `moj-eucs-identity`

## 📝 Notes

- [Slack request](https://mojdt.slack.com/archives/C01BUKJSZD4/p1709639018175069)