### PR TITLE
Grant Read-only Access via SSO to MoJo Shared Services for moj-eucs-identity Team

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -299,7 +299,8 @@ locals {
         aws_organizations_account.moj_official_preproduction.id,
         aws_organizations_account.moj_official_production.id,
         aws_organizations_account.moj_official_public_key_infrastructure_dev.id,
-        aws_organizations_account.moj_official_public_key_infrastructure.id
+        aws_organizations_account.moj_official_public_key_infrastructure.id,
+        aws_organizations_account.moj_official_shared_services.id,
       ]
     },
     {


### PR DESCRIPTION
## 👀 Purpose

- PR to grant read-only access via SSO to MoJo Shared Services for `moj-eucs-identity` Team

## ♻️ What's changed

- AWS account added to SSO assignments

## 📝 Notes

- [User Request and authority](https://mojdt.slack.com/archives/C01BUKJSZD4/p1710864763568579?thread_ts=1709639018.175069&cid=C01BUKJSZD4)