### PR TITLE
Remove `MOJ Official (Network Operations Centre)` from code

### DIFF
--- a/.github/workflows/management-account-apply.yml
+++ b/.github/workflows/management-account-apply.yml
@@ -28,7 +28,7 @@ jobs:
           aws-region: eu-west-2
       - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
-          terraform_version: 1.5.2
+          terraform_version: 1.7.5
       - run: terraform fmt -check
         continue-on-error: true
       - run: terraform init

--- a/.github/workflows/management-account-plan.yml
+++ b/.github/workflows/management-account-plan.yml
@@ -27,7 +27,7 @@ jobs:
           aws-region: eu-west-2
       - uses: hashicorp/setup-terraform@a1502cd9e758c50496cc9ac5308c4843bcd56d36 # v3.0.0
         with:
-          terraform_version: 1.5.2
+          terraform_version: 1.7.5
       - run: terraform fmt -check
         continue-on-error: true
       - run: terraform init

--- a/management-account/terraform/organizations-accounts-technology-services.tf
+++ b/management-account/terraform/organizations-accounts-technology-services.tf
@@ -26,27 +26,6 @@ resource "aws_organizations_account" "moj_official_development" {
   }
 }
 
-resource "aws_organizations_account" "moj_official_network_operations_centre" {
-  name                       = "MOJ Official (Network Operations Centre)"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "mojofficial-networkopscentre")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.technology_services.id
-
-  tags = merge(local.tags_technology_services, {
-    is-production = true
-    application   = "Network Operations Centre"
-  })
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "moj_official_preproduction" {
   name                       = "MOJ Official (Pre-Production)"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "mojofficial-preprod")

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -212,7 +212,6 @@ locals {
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [
         aws_organizations_account.moj_official_development.id,
-        aws_organizations_account.moj_official_network_operations_centre.id,
         aws_organizations_account.moj_official_preproduction.id,
         aws_organizations_account.moj_official_production.id,
         aws_organizations_account.moj_official_public_key_infrastructure_dev.id,
@@ -227,7 +226,6 @@ locals {
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [
         aws_organizations_account.moj_official_development.id,
-        aws_organizations_account.moj_official_network_operations_centre.id,
         aws_organizations_account.workplace_tech_proof_of_concept_development.id,
         aws_organizations_account.wptpoc.id,
         aws_organizations_account.network_architecture.id,
@@ -238,7 +236,6 @@ locals {
       permission_set_arn = aws_ssoadmin_permission_set.techops_operator.arn,
       account_ids = [
         aws_organizations_account.moj_official_development.id,
-        aws_organizations_account.moj_official_network_operations_centre.id,
         aws_organizations_account.moj_official_preproduction.id,
         aws_organizations_account.moj_official_production.id,
         aws_organizations_account.moj_official_public_key_infrastructure_dev.id,
@@ -254,13 +251,6 @@ locals {
       permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
       account_ids = flatten([
         local.modernisation_platform_accounts.core_network_services_id
-      ])
-    },
-    {
-      github_team        = "moj-official-techops-readonly",
-      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
-      account_ids = flatten([
-        aws_organizations_account.moj_official_network_operations_centre.id,
       ])
     },
     {


### PR DESCRIPTION
The `MOJ Official (Network Operations Centre)` account is being moved into the Modernisation Platform for management. This PR will remove the code that manages the account in this repository to prevent it from being controlled in two separate places.

Before this PR is merged in the following resource will need to be removed from state:

```
aws_organizations_account.moj_official_network_operations_centre
```

This PR forms part of [this Modernisation Platform issue](https://github.com/ministryofjustice/modernisation-platform/issues/6416).