### PR TITLE
adding ec2 permissions to the apply role

### DIFF
--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -70,6 +70,7 @@ data "aws_iam_policy_document" "oidc_assume_role_apply" {
       "secretsmanager:*",
       "securityhub:*",
       "sns:*",
+      "ec2:*"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
This gives the apply role ec2 permissions to allow ipam management.