### PR TITLE
Enable config and security hub for eu-west-3

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -11,6 +11,12 @@ data "aws_caller_identity" "current" {}
 # Enable Security Hub
 resource "aws_securityhub_account" "default" {
   control_finding_generator = "STANDARD_CONTROL"
+  lifecycle {
+    ignore_changes = [
+      # When importing this can't be changed without destroying the resource
+      enable_default_standards,
+    ]
+  }
 }
 
 # Subscribe to AWS Foundational Security Best Practices v1.0.0

--- a/organisation-security/terraform/.terraform.lock.hcl
+++ b/organisation-security/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.43.0"
   constraints = ">= 3.27.0, >= 4.0.0, >= 4.7.0, ~> 5.0"
   hashes = [
+    "h1:3w6NCYy+mbc9odXmM7K5Xag2ggtapraacZqJR3WpJKc=",
     "h1:5eJLZDBExIxV4lZRnnD6Tl2HtHtveoKXpqysLDxdVOQ=",
     "zh:07fb2abb9cf4d2042b41b2b2c642d4c4bd2feccbd856cd7040a7d15158fed478",
     "zh:1373339e796d8d8473c267c0ecddb701559fce454c2cdd192cf8b0eadf759b48",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = "3.6.0"
   hashes = [
+    "h1:I8MBeauYA8J8yheLJ8oSMWqB0kovn16dF/wKZ1QTdkk=",
     "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",
     "zh:1c67ac51254ba2a2bb53a25e8ae7e4d076103483f55f39b426ec55e47d1fe211",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.0.4"
   constraints = "~> 4.0"
   hashes = [
+    "h1:GZcFizg5ZT2VrpwvxGBHQ/hO9r6g0vYdQqx3bFD3anY=",
     "h1:Wd3RqmQW60k2QWPN4sK5CtjGuO1d+CRNXgC+D4rKtXc=",
     "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
     "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",


### PR DESCRIPTION
Turn on the required config settings to enable the default standards in security hub to work.

Security hub for eu-west-3 was already enabled and imported to this TF.

Changes were made to the security hub module introducting an ignore for enable_default_standards, as once security hub has been enabled there is no way to amend this value, when trying to import security hub which was already enabled it was set to false.  This required the resource to be destroyed which isn't possible unless you remove the delegation to this account which affects all accounts.

This TF has been applied locally as the pipeline does not have the required permissions.