### PR TITLE
Add IP pool for NOC to IPAM

### DIFF
--- a/organisation-security/terraform/ipam.tf
+++ b/organisation-security/terraform/ipam.tf
@@ -37,12 +37,12 @@ resource "aws_vpc_ipam_scope" "private" {
 
 # Network Operations
 resource "aws_vpc_ipam_pool" "network_operations_centre" {
-  description = "Network Operations Centre"
+  description    = "Network Operations Centre"
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam_scope.public.id
   locale         = "eu-west-2"
-  aws_service = "ec2"
-  tags = { "owner" = "Networks"}
+  aws_service    = "ec2"
+  tags           = { "owner" = "Networks" }
 }
 
 resource "aws_vpc_ipam_pool_cidr" "network_operations_centre" {
@@ -54,7 +54,7 @@ resource "aws_ram_resource_share" "network_operations_centre_byoip" {
   name                      = "network_operations_centre_byoip"
   allow_external_principals = false
   permission_arns = [
-   "arn:aws:ram::aws:permission/AWSRAMDefaultPermissionsIpamPool"
+    "arn:aws:ram::aws:permission/AWSRAMDefaultPermissionsIpamPool"
   ]
 }
 

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -13,6 +13,12 @@ locals {
     if account.name == "organisation-security"
   ]...)
 
+  workplace_tech_poc_development_account_id = coalesce([
+    for account in local.organizations_organization.accounts :
+    account.id
+    if account.name == "Workplace Tech Proof Of Concept Development"
+  ]...)
+
   organisation_account_numbers = [for account in local.organizations_organization.accounts : account.id]
 
   # AWS Organizational Units


### PR DESCRIPTION
Creating a public network IP pool for Network Operations Center BYOIP range.

This range has alread been imported to a single AWS account, but we need to use those public IPs in different accounts now.

BYOIPs once imported into AWS can be moved to IPAM, see guidance here -

https://docs.aws.amazon.com/vpc/latest/ipam/tutorials-byoip-ipam-transfer-ipv4.html

This PR creates the IP pool and RAM share for the transfer.  RAM sharing to other accounts will be added in later PRs.