### PR TITLE
✨ Add ReadOnly and Admin SSO Roles to `aws-root-account-admin-team`

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -2,6 +2,20 @@ locals {
   sso_admin_account_assignments = [
     {
       github_team        = "aws-root-account-admin-team",
+      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
+      account_ids = [
+        aws_organizations_organization.default.master_account_id
+      ]
+    },
+    {
+      github_team        = "aws-root-account-admin-team",
+      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
+      account_ids = [
+        aws_organizations_organization.default.master_account_id
+      ]
+    },
+    {
+      github_team        = "aws-root-account-admin-team",
       permission_set_arn = aws_ssoadmin_permission_set.aws_sso_read_only.arn,
       account_ids = [
         aws_organizations_organization.default.master_account_id


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/aws-root-account/issues/920
- To simplify permissions for the AWS Root Account Admin Team
- To reduce dependency on IAM credentials to perform admin functions in the root account

## ♻️ What's changed

- Added ReadOnly role to admin team
- Added Admin role to admin team

## 📝 Notes

- The permissions sets were already created, so just needed to assign them to the admin team 🥳