### PR TITLE
Add BCM Data Export permissions to billing

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -53,6 +53,21 @@ resource "aws_ssoadmin_permission_set" "billing" {
   tags             = {}
 }
 
+resource "aws_ssoadmin_permission_set_inline_policy" "billing" {
+  instance_arn       = local.sso_admin_instance_arn
+  inline_policy      = data.aws_iam_policy_document.billing.json
+  permission_set_arn = aws_ssoadmin_permission_set.billing.arn
+}
+
+data "aws_iam_policy_document" "billing" {
+  statement {
+    sid       = "BCMDataExports"
+    effect    = "Allow"
+    actions   = ["bcm-data-exports:*"]
+    resources = ["*"]
+  }
+}
+
 resource "aws_ssoadmin_managed_policy_attachment" "billing" {
   instance_arn       = local.sso_admin_instance_arn
   managed_policy_arn = "arn:aws:iam::aws:policy/job-function/Billing"


### PR DESCRIPTION
The billing managed policy does not include permissions to allow exporting of data from cost and usage reports which makes it hard for this role to be useful as it is. This adds the required permissions for data export.

https://docs.aws.amazon.com/cur/latest/userguide/bcm-data-exports-access.html