### PR TITLE
Allow `modernisation-platform-engineers` ViewOnly access to organisational-security account

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -219,6 +219,7 @@ locals {
       account_ids = [
         aws_organizations_account.moj_official_production.id,
         aws_organizations_account.moj_official_shared_services.id,
+        aws_organizations_account.organisation_security.id
       ]
     },
     {


### PR DESCRIPTION
In order to make use of IPAM features such as relating elastic IP addresses to owning accounts, this PR give the `ViewOnly` role in the organisational security account to members of the `modernisation-platform-engineers` team.