### PR TITLE
Add MP eng permissions to MP team for root and org sec

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -242,7 +242,9 @@ locals {
       github_team        = "modernisation-platform-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.modernisation_platform_engineer.arn,
       account_ids = [
-        aws_organizations_account.modernisation_platform.id
+        aws_organizations_account.modernisation_platform.id,
+        aws_organizations_organization.default.master_account_id,
+        aws_organizations_account.organisation_security.id
       ]
     },
     {


### PR DESCRIPTION
This will enable the MP engineers to view and raise support requests for the root and organisational security accounts.

This will be require for starting to move responsibility of the root account to MP