### PR TITLE
✨ Add SSO ReadOnly Access to Organisation Security Account For Root Account Team

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -4,7 +4,8 @@ locals {
       github_team        = "aws-root-account-admin-team",
       permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
       account_ids = [
-        aws_organizations_organization.default.master_account_id
+        aws_organizations_organization.default.master_account_id,
+        aws_organizations_account.organisation_security.id,
       ]
     },
     {


### PR DESCRIPTION
## 👀 Purpose

- To ensure everyone on the Root Account team has the same level of access to the organisation security account

## ♻️ What's changed

- Added SSO access to the organisation security account for the aws-root-account-admin-team

## 📝 Notes

- NA