### PR TITLE
✨ Add SSO ReadOnly Access to Organisation Logging Account For Root Account Team

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -6,6 +6,7 @@ locals {
       account_ids = [
         aws_organizations_organization.default.master_account_id,
         aws_organizations_account.organisation_security.id,
+        aws_organizations_account.organisation_logging.id,
       ]
     },
     {


### PR DESCRIPTION
## 👀 Purpose

- To ensure everyone in the AWS Root Account Admin Team has the same level of access to the Organisation Logging account

## ♻️ What's changed

- Added SSO Read Only Access to the Organisation logging Account for the `aws-root-account-admin-team`

## 📝 Notes

- NA