### PR TITLE
Assign permisson set to SSO admin team

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -389,6 +389,13 @@ locals {
         aws_organizations_account.moj_official_development.id
       ]
     },
+    {
+      github_team        = "aws-sso-admin",
+      permission_set_arn = aws_ssoadmin_permission_set.aws_sso_admin.arn,
+      account_ids = [
+        aws_organizations_organization.default.master_account_id
+      ]
+    },
   ]
   sso_admin_account_assignments_expanded = flatten([
     for assignment in local.sso_admin_account_assignments : [


### PR DESCRIPTION
Add the newly created SSO admin permission set to the aws-sso-admin github team for the root account.