### PR TITLE
✨ Add ReadOnlyAccess to `organistion-security-auditor` team for Organisation Security Account

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -225,6 +225,13 @@ locals {
       ]
     },
     {
+      github_team        = "organisation-security-auditor",
+      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
+      account_ids = [
+        aws_organizations_account.organisation_security.id,
+      ]
+    },
+    {
       github_team        = "modernisation-platform-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
       account_ids = [


### PR DESCRIPTION
## 👀 Purpose

- To enable the security audit team to access IPAM

## ♻️ What's changed

- Added ReadOnlyAccess to the `organisation-security-auditor` for the Organisation Security Account

## 📝 Notes

- The team currently has ViewOnly access, though this level of access does not allow access to services where the service provides insight into resources from other accounts. ReadOnlyAccess should provide the necessary permissions to view IPAM and other similar resources for the security audit team