### PR TITLE
Enable EKS monitoring for new accounts

### DIFF
--- a/modules/guardduty-org-sec/main.tf
+++ b/modules/guardduty-org-sec/main.tf
@@ -19,6 +19,21 @@ resource "aws_guardduty_organization_configuration" "delegated_administrator" {
   }
 }
 
+#######################################################################
+# Auto-enable EKS Monitoring for new accounts in the AWS Organization #
+#######################################################################
+# Note we are leaving installing the security agent add-on as a manual process
+resource "aws_guardduty_organization_configuration_feature" "eks_runtime_monitoring" {
+  detector_id = var.administrator_detector_id
+  name        = "EKS_RUNTIME_MONITORING"
+  auto_enable = "NEW"
+
+  additional_configuration {
+    name        = "EKS_ADDON_MANAGEMENT"
+    auto_enable = "NONE"
+  }
+}
+
 ####################################
 # GuardDuty publishing destination #
 ####################################


### PR DESCRIPTION
https://docs.aws.amazon.com/guardduty/latest/ug/how-does-runtime-monitoring-work.html

Note, this will only auto enable for new accounts meaning exising accounts will still need this to be manually enabled.  This will minimise any unwanted impact for existing accounts (although there shouldn't be any)

We are not auto enabling the installing the agent (which is required for monitoring) as this installs an EKS add on (daemon set) and we may not want this for all clusters (eg non production ones)