### PR TITLE
Additional permissions for chatbot

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -202,7 +202,8 @@ data "aws_iam_policy_document" "deny_non_eu_non_us_east_1_operations" {
   statement {
     effect = "Deny"
     not_actions = [
-      "chatbot:*"
+      "chatbot:*",
+      "iam:PassRole"
     ]
     resources = ["*"]
 


### PR DESCRIPTION
In order for chatbot to work the iam:PassRole permission is needed in us-east-2.

Excluding this permission from the deny all SCP.