### PR TITLE
Adding permissions to OIDC in order to list tags of cost usage report

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -61,6 +61,7 @@ data "aws_iam_policy_document" "extra_permissions_plan" {
       "account:GetAlternateContact",
       "budgets:ListTagsForResource",
       "cur:DescribeReportDefinitions",
+      "cur:ListTagsForResource",
       "identitystore:ListGroups",
       "identitystore:GetGroupId",
       "identitystore:DescribeGroup",


### PR DESCRIPTION
This PR is to fix this pipeline error:
https://github.com/ministryofjustice/aws-root-account/actions/runs/10265540011/job/28401948137#step:8:1294