### PR TITLE
Adding permissions to OIDC apply role in order to list tags of cost usage report

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -143,6 +143,7 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
       "cloudtrail:*",
       "config:*",
       "cur:DescribeReportDefinitions",
+      "cur:ListTagsForResource",
       "events:*",
       "fms:*",
       "guardduty:*",


### PR DESCRIPTION
This is a follow up from the [previous PR](https://github.com/ministryofjustice/aws-root-account/pull/956), where the permission was added to the oidc plan role (`github-actions-plan`).
This PR is to apply the same to the `github-actions-apply` role.