### PR TITLE
Expanding SSO Security Audit scope to include MoJ Master account

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -212,6 +212,7 @@ locals {
       github_team        = "organisation-security-auditor",
       permission_set_arn = aws_ssoadmin_permission_set.security_audit.arn,
       account_ids = [
+        aws_organizations_organization.default.master_account_id,
         aws_organizations_account.organisation_security.id,
         aws_organizations_account.cloud_platform.id
       ]


### PR DESCRIPTION
MP team had a call with the SOC team regarding security alerts and one of the issues they were facing was that they did not know what the account numbers translate to in terms of the account name and their organisational place.

This change is to expand the scope of the [organisation-security-auditor](https://github.com/orgs/ministryofjustice/teams/organisation-security-auditor) team to include  the SSO Security Audit role in the MoJ Master account.