### PR TITLE
Adding security audit role to MP team on the Moj Master account

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -370,6 +370,13 @@ locals {
       ]
     },
     {
+      github_team        = "modernisation-platform",
+      permission_set_arn = aws_ssoadmin_permission_set.security_audit.arn,
+      account_ids = [
+        aws_organizations_organization.default.master_account_id
+      ]
+    },
+    {
       github_team        = "modernisation-platform-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.view_only_access.arn,
       account_ids = [


### PR DESCRIPTION
This is so that non-engineering team members of MP, can read organisations.