### PR TITLE
Importing existing active cost allocation tags

### DIFF
--- a/management-account/terraform/cost-allocation-tags.tf
+++ b/management-account/terraform/cost-allocation-tags.tf
@@ -1,0 +1,17 @@
+# Define Cost Allocation Tags
+
+resource "aws_ce_cost_allocation_tag" "cost_allocation_tags" {
+  for_each = toset(local.active_tags)
+
+  tag_key = each.value
+  status  = "Active"
+}
+
+# Import Existing Active Cost Allocation Tags
+
+import {
+  for_each = toset(local.active_tags)
+  to       = aws_ce_cost_allocation_tag.cost_allocation_tags[each.value]
+  id       = each.value
+}
+

--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -84,4 +84,31 @@ locals {
     aws_saml            = sensitive(jsondecode(data.aws_secretsmanager_secret_version.aws_saml.secret_string))
     azure_entraid_oidc  = sensitive(jsondecode(data.aws_secretsmanager_secret_version.azure_entraid_oidc.secret_string))
   }
+
+  # Cost Allocation Tags
+  active_tags = [
+    "app.kubernetes.io/name",
+    "application",
+    "aws:createdBy",
+    "aws:eks:deployment",
+    "aws:eks:namespace",
+    "aws:eks:node",
+    "aws:eks:workload-name",
+    "aws:eks:workload-type",
+    "business-unit",
+    "component",
+    "eks:cluster-name",
+    "environment-name",
+    "infrastructure-support",
+    "is-production",
+    "kubernetes_cluster",
+    "kubernetes_namespace",
+    "kubernetes.io/namespace",
+    "namespace",
+    "owner",
+    "runbook",
+    "source-code",
+    "stack",
+    "Stack"
+  ]
 }

--- a/management-account/terraform/secrets-manager.tf
+++ b/management-account/terraform/secrets-manager.tf
@@ -82,11 +82,18 @@ data "aws_secretsmanager_secret_version" "azure_entraid_oidc" {
 
 # EntraID: Secrets for User Sync Lambda -- secrets values to be stored in a set of key-value pairs comprising tenant, application id and application secret
 
-resource "aws_secretsmanager_secret" "azure_entraid_group_sync" {
-  name        = "azure_entraid_oidc"
-  description = "Azure tenant ID, client ID and secret for the Ministry of Justice owned webapp for group membership syncing"
+removed {
+  from = aws_secretsmanager_secret.azure_entraid_group_sync
+
+  lifecycle {
+    destroy = false
+  }
 }
 
-data "aws_secretsmanager_secret_version" "azure_entraid_group_sync" {
-  secret_id = aws_secretsmanager_secret.azure_entraid_group_sync.id
+removed {
+  from = aws_secretsmanager_secret_version.azure_entraid_group_sync
+
+  lifecycle {
+    destroy = false
+  }
 }


### PR DESCRIPTION
Tracking story:
https://github.com/ministryofjustice/analytical-platform/issues/5135

This PR imports into terraform existing cost allocation tags currently in use in the MOJ AWS Organisation.

The list was retrieved from AWS Cost Explorer and filtered for status.