### PR TITLE
Allow chatbot in us-west-2

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -168,11 +168,12 @@ data "aws_iam_policy_document" "deny_non_eu_non_us_east_1_operations" {
     }
   }
 
-  # Deny anything apart from Network Manager and S3 Global Endpoint Management Operations in us-west-2
+  # Deny anything apart from Network Manager, S3 Global Endpoint Management Operations and ChatBot in us-west-2
   statement {
     effect = "Deny"
     not_actions = [
       "networkmanager:*",
+      "chatbot:*",
       "cloudwatch:List*",     # To view the Network Manager log group
       "cloudwatch:Get*",      # To view the Network Manager log group
       "cloudwatch:Describe*", # To view the Network Manager log group


### PR DESCRIPTION
## Issue

I'm trying to create a aws chatbot configuration in the `core-network-services` account as part of this issue https://github.com/ministryofjustice/modernisation-platform/issues/7833

## Fix

The `Platforms` business unit is restricting building services in `us-west-2` , and this PR adds `chatbot:*` to the exclusion list to allow creation of slack channel configs in this OU.