### PR TITLE
Add `iam:PassRole` to us-west-2 exception list

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -177,6 +177,7 @@ data "aws_iam_policy_document" "deny_non_eu_non_us_east_1_operations" {
       "cloudwatch:List*",     # To view the Network Manager log group
       "cloudwatch:Get*",      # To view the Network Manager log group
       "cloudwatch:Describe*", # To view the Network Manager log group
+      "iam:PassRole",
       "s3:CreateMultiRegionAccessPoint",
       "s3:DeleteMultiRegionAccessPoint",
       "s3:DescribeMultiRegionAccessPointOperation",


### PR DESCRIPTION
## Issue
I'm trying to create a aws chatbot configuration in the core-network-services account as part of this issue ministryofjustice/modernisation-platform#7833

Having added `chatbot:*` I now get an error about `iam:PassRole` ..

```
AccessDeniedException: User: arn:aws:sts::505974653433:assumed-role/ModernisationPlatformAccess/aws-go-sdk-1725633851672523000 is not authorized to perform: iam:PassRole on resource:
│ arn:aws:iam::505974653433:role/chatBot-channel-role-ecl7w with an explicit deny
```

## Fix

Adding `iam:PassRole` to the `us-west-2` exceptions list in the SCP policy.