### PR TITLE
Adding entra-id-scim function

### DIFF
--- a/management-account/terraform/sso-scim.tf
+++ b/management-account/terraform/sso-scim.tf
@@ -8,3 +8,11 @@ module "scim" {
   sso_identity_store_id = local.sso_admin_identity_store_id
   not_dry_run           = true
 }
+
+module "entraid-scim" {
+  source = "github.com/ministryofjustice/moj-terraform-scim-entra-id"
+  # Required variables for the module
+  azure_tenant_id     = "your-tenant-id"
+  azure_client_id     = "your-client-id"
+  azure_client_secret = "your-client-secret"
+}

--- a/management-account/terraform/sso-scim.tf
+++ b/management-account/terraform/sso-scim.tf
@@ -10,6 +10,7 @@ module "scim" {
 }
 
 module "entraid_scim" {
+  # tflint-ignore: terraform_module_pinned_source
   source              = "github.com/ministryofjustice/moj-terraform-scim-entra-id"
   azure_tenant_id     = "your-tenant-id"
   azure_client_id     = "your-client-id"

--- a/management-account/terraform/sso-scim.tf
+++ b/management-account/terraform/sso-scim.tf
@@ -10,8 +10,7 @@ module "scim" {
 }
 
 module "entraid-scim" {
-  source = "github.com/ministryofjustice/moj-terraform-scim-entra-id"
-  # Required variables for the module
+  source              = "github.com/ministryofjustice/moj-terraform-scim-entra-id"
   azure_tenant_id     = "your-tenant-id"
   azure_client_id     = "your-client-id"
   azure_client_secret = "your-client-secret"

--- a/management-account/terraform/sso-scim.tf
+++ b/management-account/terraform/sso-scim.tf
@@ -9,7 +9,7 @@ module "scim" {
   not_dry_run           = true
 }
 
-module "entraid-scim" {
+module "entraid_scim" {
   source              = "github.com/ministryofjustice/moj-terraform-scim-entra-id"
   azure_tenant_id     = "your-tenant-id"
   azure_client_id     = "your-client-id"


### PR DESCRIPTION
Related ticket:
https://github.com/ministryofjustice/analytical-platform/issues/4271

This PR adds the deployment of a new terraform module which itself configures and deploys a lambda function which will sync Identity Center with EntraID groups prefixed with `azure-aws-sso-`

Terraform and function code here: 
https://github.com/ministryofjustice/moj-terraform-scim-entra-id 

Details on executing the function tests are here: 
https://github.com/ministryofjustice/moj-terraform-scim-entra-id/pull/6