### PR TITLE
Adding Secrets Manager read/write managed policy to the sso-admin permission set

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -72,6 +72,12 @@ resource "aws_ssoadmin_managed_policy_attachment" "aws_sso_admin_read_only_acces
   permission_set_arn = aws_ssoadmin_permission_set.aws_sso_admin.arn
 }
 
+resource "aws_ssoadmin_managed_policy_attachment" "aws_sso_admin_secrets_manager_read_write" {
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/SecretsManagerReadWrite"
+  permission_set_arn = aws_ssoadmin_permission_set.aws_sso_admin.arn
+}
+
 # Billing Access
 resource "aws_ssoadmin_permission_set" "billing" {
   name             = "Billing"


### PR DESCRIPTION
Tracking story: https://github.com/ministryofjustice/analytical-platform/issues/4271

This PR adds the AWS SecretsManagerReadWrite managed policy to the aws-sso-admin role so that we can retrieve, read and write secrets. 