### PR TITLE
✨ Add Ignore For False Positive GitLeaks

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,1 +1,3 @@
 60e8f406be4219b01e7363d1de37662c3a020707:organisation-security/terraform/cloudformation/OracleDbLTS-Orchestrate.yaml:generic-api-key:279
+c8883ab61007bebe110b62740442731d314436c1:organisation-security/terraform/.terraform.lock.hcl:square-access-token:19
+a9c7860510294cbe869c57b673e85eaba530e328:management-account/terraform/.terraform.lock.hcl:square-access-token:19


### PR DESCRIPTION
## 👀 Purpose

- Reported when upgrading to v8.0.0 of Megalinter #965 
- To ignore false positives to ensure actual issues are visible

## ♻️ What's changed

- Added ignore lines for both reported leaks

## 📝 Notes

- Leaks are false positives as they are just hashes of the provider