### PR TITLE
🔥 Remove `tfsec` Since `trivy` is Already Running

### DIFF
--- a/.github/workflows/terraform-tools.yml
+++ b/.github/workflows/terraform-tools.yml
@@ -2,25 +2,11 @@ name: terraform-tools
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
 jobs:
-  tfsec:
-    runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-    steps:
-      - uses: actions/checkout@v4
-      - run: rm -r modules/ # remove modules from being security checked
-      - uses: aquasecurity/tfsec-sarif-action@v0.1.4
-        with:
-          tfsec_args: --force-all-dirs --soft-fail -m CRITICAL
-          sarif_file: tfsec.sarif
-      - uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: tfsec.sarif
   tflint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## 👀 Purpose

- In relation to #973 
- To remove deprecated tool `tfsec` (trivy is already setup and running)

## ♻️ What's changed

- Removed `tfsec` from the terraform tools workflow

## 📝 Notes

- Vendor has stated they recommend using trivy over tfsec. Trivy is already running in this repository so we're duplicating effort by having both. Also tfsec is currently broken, so removing this will aid in not seeing a failing pipeline for every PR and merge 🥳 