### PR TITLE
✨ Add Slack Notification on Terraform Apply Failure

### DIFF
--- a/.github/workflows/management-account-apply.yml
+++ b/.github/workflows/management-account-apply.yml
@@ -3,10 +3,10 @@ name: terraform apply (management-account)
 on:
   push:
     paths:
-      - 'management-account/terraform/**'
-      - 'modules/**'
-      - '.github/workflows/management-account-plan.yml'
-      - '.github/workflows/management-account-apply.yml'
+      - "management-account/terraform/**"
+      - "modules/**"
+      - ".github/workflows/management-account-plan.yml"
+      - ".github/workflows/management-account-apply.yml"
     branches:
       - main
 
@@ -36,3 +36,13 @@ jobs:
       - run: terraform plan -no-color
       - run: terraform apply -auto-approve
         if: github.event.ref == 'refs/heads/main'
+
+      - name: Slack failure notification
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/management-account-apply.yml
+++ b/.github/workflows/management-account-apply.yml
@@ -42,7 +42,7 @@ jobs:
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           payload: |
-            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+            {"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.head_ref }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"View Workflow"},"url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","style":"primary"},{"type":"button","text":{"type":"plain_text","text":"View Commit"},"url":"https://github.com/${{ github.repository }}/commit/${{ github.sha }}"}]}]}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/organisation-security-apply.yml
+++ b/.github/workflows/organisation-security-apply.yml
@@ -42,7 +42,7 @@ jobs:
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           payload: |
-            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+            {"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.head_ref }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"View Workflow"},"url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","style":"primary"},{"type":"button","text":{"type":"plain_text","text":"View Commit"},"url":"https://github.com/${{ github.repository }}/commit/${{ github.sha }}"}]}]}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/organisation-security-apply.yml
+++ b/.github/workflows/organisation-security-apply.yml
@@ -3,10 +3,10 @@ name: terraform apply (organisation-security)
 on:
   push:
     paths:
-      - 'organisation-security/terraform/**'
-      - 'modules/**'
-      - '.github/workflows/organisation-security-plan.yml'
-      - '.github/workflows/organisation-security-apply.yml'
+      - "organisation-security/terraform/**"
+      - "modules/**"
+      - ".github/workflows/organisation-security-plan.yml"
+      - ".github/workflows/organisation-security-apply.yml"
     branches:
       - main
 
@@ -36,3 +36,13 @@ jobs:
       - run: terraform plan -no-color
       - run: terraform apply -auto-approve
         if: github.event.ref == 'refs/heads/main'
+
+      - name: Slack failure notification
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -1,9 +1,8 @@
 name: 🧪 Test Slack Notification
 
 on:
-  pull_request_target:
-    branches:
-      - main
+  pull_request:
+    branches: [main]
 
 permissions: {}
 
@@ -22,17 +21,8 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"
+                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"
                   }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": "*Job ID:* `${{ github.run_id }}`\n*Timestamp:* `${{ github.event.timestamp }} UTC`"
-                    }
-                  ]
                 },
                 {
                   "type": "actions",

--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -1,3 +1,4 @@
+# TODO: Delete once tested on push to main
 name: 🧪 Test Slack Notification
 
 on:
@@ -19,5 +20,5 @@ jobs:
           payload: |
             {"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.head_ref }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"View Workflow"},"url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","style":"primary"},{"type":"button","text":{"type":"plain_text","text":"View Commit"},"url":"https://github.com/${{ github.repository }}/commit/${{ github.sha }}"}]}]}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_TESTING }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -1,8 +1,9 @@
 name: 🧪 Test Slack Notification
 
 on:
-  pull_request:
-    branches: [main]
+  pull_request_target:
+    branches:
+      - main
 
 permissions: {}
 
@@ -15,7 +16,48 @@ jobs:
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           payload: |
-            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Job ID:* `${{ github.run_id }}`\n*Timestamp:* `${{ github.event.timestamp }} UTC`"
+                    }
+                  ]
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow"
+                      },
+                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "style": "primary"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Commit"
+                      },
+                      "url": "https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+                    }
+                  ]
+                }
+              ]
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -21,7 +21,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"
+                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.head_ref }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"
                   }
                 },
                 {

--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -3,6 +3,8 @@ name: 🧪 Test Slack Notification
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
 
 permissions: {}
 

--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -1,0 +1,21 @@
+name: 🧪 Test Slack Notification
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Slack failure notification
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          payload: |
+            {"blocks":[{"type": "section","text": {"type": "mrkdwn","text": ":no_entry: Failed GitHub Action:"}},{"type": "section","fields":[{"type": "mrkdwn","text": "*Workflow:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"},{"type": "mrkdwn","text": "*Job:*\n${{ github.job }}"},{"type": "mrkdwn","text": "*Repo:*\n${{ github.repository }}"}]}]}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-slack-notification.yml
+++ b/.github/workflows/test-slack-notification.yml
@@ -17,39 +17,7 @@ jobs:
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.head_ref }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"
-                  }
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "View Workflow"
-                      },
-                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-                      "style": "primary"
-                    },
-                    {
-                      "type": "button",
-                      "text": {
-                        "type": "plain_text",
-                        "text": "View Commit"
-                      },
-                      "url": "https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
-                    }
-                  ]
-                }
-              ]
-            }
+            {"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.head_ref }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"View Workflow"},"url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","style":"primary"},{"type":"button","text":{"type":"plain_text","text":"View Commit"},"url":"https://github.com/${{ github.repository }}/commit/${{ github.sha }}"}]}]}
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## 👀 Purpose

- In relation to #975 
- To make apply failures when code is merged into main more visible

## ♻️ What's changed

- Added a Slack alert to both terraform apply workflows when the workflow fails on main
- Added a temporary test workflow on PR and Push to `main` - just so I can make sure everything looks okay before closing off the ticket 🙈 

## 📝 Notes

- A new Slack app has been added for this feature, which all the @ministryofjustice/aws-root-account-admin-team have been added to
- While I'm testing the syntax of the alert I've added a test workflow and webhook, which is going to [#connors-testing-channel](https://mojdt.slack.com/archives/C03ME0QENQ1/p1726004507491459)
- Some information isn't present on the Pull Request event that (supposably) is available of the push event 🙈 Which is why I've got the temporary test workflow - which will be deleted after I've confirmed all looks good on the push event 🔥 