### PR TITLE
Add Cortex XSOAR Integration User

### DIFF
--- a/management-account/terraform/iam-groups.tf
+++ b/management-account/terraform/iam-groups.tf
@@ -31,6 +31,20 @@ resource "aws_iam_group_policy_attachment" "aws_organisations_admin_custom" {
   policy_arn = aws_iam_policy.aws_organisations_admin.arn
 }
 
+################################
+# AWSOrganisationsListReadOnly #
+################################
+resource "aws_iam_group" "aws_organisations_listreadonly" {
+  name = "AWSOrganisationsListReadOnly"
+  path = "/"
+}
+
+# Group policy attachments
+resource "aws_iam_group_policy_attachment" "aws_organisations_listreadonly" {
+  group      = aws_iam_group.aws_organisations_listreadonly.name
+  policy_arn = aws_iam_policy.aws_organizations_list_read_only.arn
+}
+
 #####################
 # BillingFullAccess #
 #####################

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -11,8 +11,9 @@ data "aws_iam_policy_document" "aws_organizations_list_read_only_role" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${aws_organizations_account.moj_digital_services.id}:root"]
+      type = "AWS"
+      identifiers = ["arn:aws:iam::${aws_organizations_account.moj_digital_services.id}:root",
+      "arn:aws:iam::${aws_organizations_account.moj_digital_services.id}:user/XsoarIntegration"]
     }
   }
 }

--- a/management-account/terraform/iam-users.tf
+++ b/management-account/terraform/iam-users.tf
@@ -182,3 +182,23 @@ resource "aws_iam_user_group_membership" "finance_team" {
     aws_iam_group.iam_user_change_password.name,
   ]
 }
+
+#####################
+# Cortex XSOAR user #
+#####################
+
+resource "aws_iam_user" "xsoar_integration" {
+  name          = "XsoarIntegration"
+  path          = "/"
+  force_destroy = true
+  tags          = {}
+}
+
+# User membership
+resource "aws_iam_user_group_membership" "xsoar_integration" {
+  user = aws_iam_user.xsoar_integration.name
+
+  groups = [
+    aws_iam_group.aws_organisations_listreadonly.name,
+  ]
+}


### PR DESCRIPTION
## What/Why?

Related issue: https://github.com/ministryofjustice/modernisation-platform/issues/7897

The SOC are after a way of enriching the alerts they get from AWS in the Cortex XSOAR tool. Specifically they would like to use the [Organizations](https://xsoar.pan.dev/docs/reference/integrations/aws---organizations) integration which will allow them to use the API to translate account numbers etc. into application details/business areas/contact details.

## What's Changed?

As the XSOAR tool is hosted outside the AWS environment in a remote network then the recommended integration method is access key and secret key authentication.

I'm adding a new user `XsoarIntegration` which I'm granting access to an existing Organizations List/ReadOnly role so that it can run queries to get the relevant information but not do any destructive activity.

I've added a new group which was missing for the `aws_organizations_list_read_only_role` so that future users could be added more easily if required.
