### PR TITLE
Fix account number in orgs readonly role policy

### DIFF
--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "aws_organizations_list_read_only_role" {
     principals {
       type = "AWS"
       identifiers = ["arn:aws:iam::${aws_organizations_account.moj_digital_services.id}:root",
-      "arn:aws:iam::${aws_organizations_account.moj_digital_services.id}:user/XsoarIntegration"]
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/XsoarIntegration"]
     }
   }
 }


### PR DESCRIPTION
## What?

This PR merge faile ddue to a malformed policy: https://github.com/ministryofjustice/aws-root-account/actions/runs/10905784148/job/30265486170#step:9:1438

I got the account id reference wrong in the terraform.

## Fix

Reference the right account i.e. the calling account (root)