### PR TITLE
🔍 Create Athena enabled CUR and turn on split cost allocation data

### DIFF
--- a/management-account/terraform/cost-and-usage-reports.tf
+++ b/management-account/terraform/cost-and-usage-reports.tf
@@ -33,3 +33,21 @@ resource "aws_cur_report_definition" "quicksight_integration" {
   s3_region = "eu-west-2"
   s3_prefix = "CUR"
 }
+
+resource "aws_cur_report_definition" "athena_integration" {
+  provider = aws.us-east-1
+
+  report_name                = "MOJ-CUR-ATHENA"
+  time_unit                  = "DAILY"
+  format                     = "textORcsv"
+  compression                = "ZIP"
+  additional_schema_elements = ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"]
+  additional_artifacts       = ["ATHENA"]
+  refresh_closed_reports     = true
+  report_versioning          = "OVERWRITE_REPORT"
+
+  # S3 configuration
+  s3_bucket = module.cur_reports_s3_bucket.bucket_name
+  s3_region = "eu-west-2"
+  s3_prefix = "CUR-ATHENA"
+}

--- a/management-account/terraform/cost-and-usage-reports.tf
+++ b/management-account/terraform/cost-and-usage-reports.tf
@@ -5,7 +5,7 @@ resource "aws_cur_report_definition" "no_integrations" {
   time_unit                  = "DAILY"
   format                     = "textORcsv"
   compression                = "ZIP"
-  additional_schema_elements = ["RESOURCES"]
+  additional_schema_elements = ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"]
   additional_artifacts       = []
   refresh_closed_reports     = true
   report_versioning          = "CREATE_NEW_REPORT"


### PR DESCRIPTION
This pull request:

- Creates a new CUR that enables AWS Athena as an additional artefact, this was done because "When ATHENA exists within additional_artifacts, no other artifact type can be declared and report_versioning must be `OVERWRITE_REPORT`" ([source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cur_report_definition#:~:text=When%20ATHENA%20exists%20within%20additional_artifacts%2C%20no%20other%20artifact%20type%20can%20be%20declared%20and%20report_versioning%20must%20be%20OVERWRITE_REPORT))
- Enables [split cost allocation data](https://docs.aws.amazon.com/cur/latest/userguide/split-cost-allocation-data.html) on the non-QuickSight reports 

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 