### PR TITLE
🚑 Fix existing cost and usage reports and address issues from new report

### DIFF
--- a/management-account/terraform/cost-and-usage-reports.tf
+++ b/management-account/terraform/cost-and-usage-reports.tf
@@ -5,7 +5,7 @@ resource "aws_cur_report_definition" "no_integrations" {
   time_unit                  = "DAILY"
   format                     = "textORcsv"
   compression                = "ZIP"
-  additional_schema_elements = ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"]
+  additional_schema_elements = ["RESOURCES"]
   additional_artifacts       = []
   refresh_closed_reports     = true
   report_versioning          = "CREATE_NEW_REPORT"
@@ -23,7 +23,7 @@ resource "aws_cur_report_definition" "quicksight_integration" {
   time_unit                  = "DAILY"
   format                     = "textORcsv"
   compression                = "ZIP"
-  additional_schema_elements = ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"]
+  additional_schema_elements = ["RESOURCES"]
   additional_artifacts       = ["REDSHIFT", "QUICKSIGHT"]
   refresh_closed_reports     = true
   report_versioning          = "CREATE_NEW_REPORT"
@@ -39,8 +39,8 @@ resource "aws_cur_report_definition" "athena_integration" {
 
   report_name                = "MOJ-CUR-ATHENA"
   time_unit                  = "DAILY"
-  format                     = "textORcsv"
-  compression                = "ZIP"
+  format                     = "Parquet"
+  compression                = "Parquet"
   additional_schema_elements = ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"]
   additional_artifacts       = ["ATHENA"]
   refresh_closed_reports     = true


### PR DESCRIPTION
This pull request:

- Removes `SPLIT_COST_ALLOCATION_DATA` as it forces a replacement 🙅 
- Update compression and format of Athena report as per the error message
    ```
    Error: When ATHENA exists within additional_artifacts, both format and compression must be Parquet
    ```

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 