### PR TITLE
🛂 Amend cost and usage report permissions for `github-actions-apply` role

### DIFF
--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "oidc_assume_role_apply" {
       "ce:*",
       "cloudtrail:*",
       "config:*",
-      "cur:DescribeReportDefinitions",
+      "cur:*",
       "events:*",
       "fms:*",
       "guardduty:*",


### PR DESCRIPTION
This pull request:

- Sets cost and usage permissions to wildcard to address [broken workflow](https://github.com/ministryofjustice/aws-root-account/actions/runs/11126589509/job/30916861826#step:9:1464)
  - Aligns with all other wildcarded services

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 