### PR TITLE
Add dynamoDB put item for state lock table for mp eng role

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -333,6 +333,12 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
     ]
     resources = ["*"]
   }
+  statement {
+    sid    = "AllowStateLock"
+    effect = "Allow"
+    actions = ["dynamodb:PutItem"]
+    resources = ["arn:aws:dynamodb:eu-west-2:${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:table/modernisation-platform-terraform-state-lock"]
+  }
 }
 
 # Modernisation Platform end user permission sets are now managed in the modernisation-platform repository


### PR DESCRIPTION
Allowing the mp engineer role to write to dynamodb to aquire a state lock.