### PR TITLE
Add missing dynamodb permissions

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -336,7 +336,10 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
   statement {
     sid    = "AllowStateLock"
     effect = "Allow"
-    actions = ["dynamodb:PutItem"]
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem" 
+    ]
     resources = ["arn:aws:dynamodb:eu-west-2:${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:table/modernisation-platform-terraform-state-lock"]
   }
 }


### PR DESCRIPTION
Delete is also required as per documentation:

https://developer.hashicorp.com/terraform/language/backend/s3#dynamodb-table-permissions

This and the read only policy role should now provide the full permissions.