### PR TITLE
Feature/S3 Cross-Account Replication Functionality

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -188,13 +188,13 @@ data "aws_iam_policy_document" "terraform_state_s3_bucket" {
 module "cur_reports_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_name             = "moj-cur-reports"
-  attach_policy           = true
-  policy                  = data.aws_iam_policy_document.cur_reports_s3_bucket.json
-  enable_replication      = true
-  replication_bucket_arn  = "arn:aws:s3:::moj-cur-reports-modplatform-20240930164810837800000001"
-  replication_role_arn    = module.cur_reports_s3_bucket.replication_role_arn
-  replication_rules       = [
+  bucket_name            = "moj-cur-reports"
+  attach_policy          = true
+  policy                 = data.aws_iam_policy_document.cur_reports_s3_bucket.json
+  enable_replication     = true
+  replication_bucket_arn = "arn:aws:s3:::moj-cur-reports-modplatform-20240930164810837800000001"
+  replication_role_arn   = module.cur_reports_s3_bucket.replication_role_arn
+  replication_rules      = [
     {
       id     = "replicate-cur-athena"
       prefix = "CUR-ATHENA/"
@@ -202,7 +202,6 @@ module "cur_reports_s3_bucket" {
     }
   ]
 }
-
 
 data "aws_iam_policy_document" "cur_reports_s3_bucket" {
   version = "2008-10-17"

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -188,9 +188,19 @@ data "aws_iam_policy_document" "terraform_state_s3_bucket" {
 module "cur_reports_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_name   = "moj-cur-reports"
-  attach_policy = true
-  policy        = data.aws_iam_policy_document.cur_reports_s3_bucket.json
+  bucket_name              = "moj-cur-reports"
+  attach_policy            = true
+  policy                   = data.aws_iam_policy_document.cur_reports_s3_bucket.json
+  enable_replication       = true
+  replication_bucket_arn   = "arn:aws:s3:::moj-cur-reports-modplatform-20240930164810837800000001"
+  replication_role_arn     = aws_iam_role.replication_role.id
+  replication_rules = [
+    {
+      id     = "replicate-cur-athena"
+      prefix = "CUR-ATHENA/"  # Subfolder to replicate
+      status = "Enabled"
+    }
+  ]
 }
 
 data "aws_iam_policy_document" "cur_reports_s3_bucket" {

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -194,7 +194,7 @@ module "cur_reports_s3_bucket" {
   enable_replication     = true
   replication_bucket_arn = "arn:aws:s3:::moj-cur-reports-modplatform-20240930164810837800000001"
   replication_role_arn   = module.cur_reports_s3_bucket.replication_role_arn
-  replication_rules      = [
+  replication_rules = [
     {
       id     = "replicate-cur-athena"
       prefix = "CUR-ATHENA/"

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -188,20 +188,21 @@ data "aws_iam_policy_document" "terraform_state_s3_bucket" {
 module "cur_reports_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_name              = "moj-cur-reports"
-  attach_policy            = true
-  policy                   = data.aws_iam_policy_document.cur_reports_s3_bucket.json
-  enable_replication       = true
-  replication_bucket_arn   = "arn:aws:s3:::moj-cur-reports-modplatform-20240930164810837800000001"
-  replication_role_arn     = aws_iam_role.replication_role.id
-  replication_rules = [
+  bucket_name             = "moj-cur-reports"
+  attach_policy           = true
+  policy                  = data.aws_iam_policy_document.cur_reports_s3_bucket.json
+  enable_replication      = true
+  replication_bucket_arn  = "arn:aws:s3:::moj-cur-reports-modplatform-20240930164810837800000001"
+  replication_role_arn    = module.cur_reports_s3_bucket.replication_role_arn
+  replication_rules       = [
     {
       id     = "replicate-cur-athena"
-      prefix = "CUR-ATHENA/"  # Subfolder to replicate
+      prefix = "CUR-ATHENA/"
       status = "Enabled"
     }
   ]
 }
+
 
 data "aws_iam_policy_document" "cur_reports_s3_bucket" {
   version = "2008-10-17"

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -204,7 +204,6 @@ resource "aws_iam_role" "replication_role" {
 
 resource "aws_iam_role_policy" "replication" {
   for_each = var.enable_replication ? toset(["enabled"]) : []
-
   role = aws_iam_role.replication_role.id
 
   policy = jsonencode({

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -186,9 +186,9 @@ resource "aws_s3_bucket_replication_configuration" "default" {
 # IAM Policy for Replication #
 ##############################
 resource "aws_iam_role" "replication_role" {
-  count = var.enable_replication ? 1 : 0  # Create the role only if replication is enabled
+  count = var.enable_replication ? 1 : 0 # Create the role only if replication is enabled
 
-  name               = "${coalesce(var.bucket_name, "default-bucket-name")}-replication-role"
+  name = "${coalesce(var.bucket_name, "default-bucket-name")}-replication-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -204,10 +204,10 @@ resource "aws_iam_role" "replication_role" {
 }
 
 resource "aws_iam_role_policy" "replication" {
-  count = var.enable_replication ? 1 : 0  # Attach policy only if replication is enabled
+  count = var.enable_replication ? 1 : 0 # Attach policy only if replication is enabled
 
-  name   = "${aws_iam_role.replication_role[count.index].name}-policy"  # Use count.index for referencing
-  role   = aws_iam_role.replication_role[count.index].id
+  name = "${aws_iam_role.replication_role[count.index].name}-policy"
+  role = aws_iam_role.replication_role[count.index].id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -224,7 +224,7 @@ resource "aws_iam_role_policy" "replication" {
       {
         Action   = ["s3:ReplicateObject", "s3:ReplicateDelete", "s3:ReplicateTags"],
         Effect   = "Allow",
-        Resource = "arn:aws:s3:::${var.replication_bucket_arn}"  # Ensure you reference the correct bucket ARN
+        Resource = "arn:aws:s3:::${var.replication_bucket_arn}"
       },
     ]
   })

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -201,8 +201,6 @@ resource "aws_iam_role" "replication_role" {
       }
     ]
   })
-  
-  max_session_duration = 3600
 }
 
 resource "aws_iam_role_policy" "replication" {

--- a/modules/s3/outputs.tf
+++ b/modules/s3/outputs.tf
@@ -10,3 +10,7 @@ output "replication_configuration" {
   value       = var.enable_replication ? aws_s3_bucket_replication_configuration.default : null
   description = "Replication configuration for the S3 bucket"
 }
+
+output "replication_role_arn" {
+  value = aws_iam_role.replication_role.arn
+}

--- a/modules/s3/outputs.tf
+++ b/modules/s3/outputs.tf
@@ -5,3 +5,8 @@ output "bucket_name" {
 output "bucket" {
   value = aws_s3_bucket.default
 }
+
+output "replication_configuration" {
+  value       = var.enable_replication ? aws_s3_bucket_replication_configuration.default : null
+  description = "Replication configuration for the S3 bucket"
+}

--- a/modules/s3/outputs.tf
+++ b/modules/s3/outputs.tf
@@ -12,6 +12,6 @@ output "replication_configuration" {
 }
 
 output "replication_role_arn" {
-  value = length(aws_iam_role.replication_role) > 0 ? aws_iam_role.replication_role[0].arn : null
+  value       = length(aws_iam_role.replication_role) > 0 ? aws_iam_role.replication_role[0].arn : null
   description = "ARN of the replication role if it exists"
 }

--- a/modules/s3/outputs.tf
+++ b/modules/s3/outputs.tf
@@ -12,5 +12,6 @@ output "replication_configuration" {
 }
 
 output "replication_role_arn" {
-  value = aws_iam_role.replication_role.arn
+  value = length(aws_iam_role.replication_role) > 0 ? aws_iam_role.replication_role[0].arn : null
+  description = "ARN of the replication role if it exists"
 }

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -82,3 +82,31 @@ variable "object_lock_retention" {
   type    = any
   default = {}
 }
+
+variable "enable_replication" {
+  description = "Whether to enable cross-account replication"
+  type        = bool
+  default     = false
+}
+
+variable "replication_bucket_arn" {
+  description = "ARN of the destination bucket for replication"
+  type        = string
+  default     = ""
+}
+
+variable "replication_role_arn" {
+  description = "ARN of the IAM role for S3 replication"
+  type        = string
+  default     = ""
+}
+
+variable "replication_rules" {
+  description = "Replication rules for the bucket"
+  type = list(object({
+    id     = string
+    prefix = string
+    status = string
+  }))
+  default = []
+}


### PR DESCRIPTION
I am currently working on ticket https://github.com/ministryofjustice/modernisation-platform/issues/7169 where I require S3 replication on the `moj-cur-reports/cur-athena` bucket to Modernisation Platform `core-logging` as per slack conversation [here](https://mojdt.slack.com/archives/C06P4KA0V0A/p1727878593284919)

This pull request introduces support for optional S3 cross-account replication in the S3 module adding functionality to replicate objects between buckets in different AWS accounts.

New Variables:
`enable_replication`: Boolean flag to enable or disable replication (default: false).
`replication_role_arn`: ARN of the IAM role used for replication.
`replication_bucket_arn`: ARN of the destination bucket for replication.
`replication_rules`: Allows specifying replication rules, including prefixes and status.

IAM Role Creation:
The necessary IAM roles and policies are only created when replication is enabled.
The roles include permissions for S3 replication actions, such as `s3:ReplicateObject`, `s3:ReplicateDelete`, and `s3:ReplicateTags`.

Backward Compatibility:
This feature is backwards compatible, as replication functionality is optional and will only be enabled if the `enable_replication` variable is set to true.