### PR TITLE
Switch S3 replication config from v2 to v1

### DIFF
--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -170,10 +170,7 @@ resource "aws_s3_bucket_replication_configuration" "default" {
     content {
       id     = rule.value.id
       status = rule.value.status
-
-      filter {
-        prefix = rule.value.prefix
-      }
+      prefix = rule.value.prefix
 
       destination {
         bucket = var.replication_bucket_arn


### PR DESCRIPTION
This PR removes the `filter` field from the replication configuration which in turn AWS will then identify as a `v1 `config and replicate deletion markers rather than using `v2` configuration where deletion markers have to be specified and set as disabled - further information can be found here https://aws.amazon.com/blogs/storage/managing-delete-marker-replication-in-amazon-s3/