### PR TITLE
Add S3 Replication KMS functionality

### DIFF
--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -41,6 +41,11 @@ locals {
 
   # Modernisation Platform account IDs
   modernisation_platform_accounts = {
+    core_logging_id = [
+      for account_name, account_id in local.accounts.active_only :
+      account_id
+      if account_name == "core-logging"
+    ]
     core_network_services_id = [
       for account_name, account_id in local.accounts.active_only :
       account_id

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -194,11 +194,16 @@ module "cur_reports_s3_bucket" {
   enable_replication     = true
   replication_bucket_arn = "arn:aws:s3:::moj-cur-reports-modplatform-20240930164810837800000001"
   replication_role_arn   = module.cur_reports_s3_bucket.replication_role_arn
+  source_kms_arn         = "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:alias/aws/s3"
+  destination_kms_arn    = "arn:aws:kms:eu-west-2:${coalesce(local.modernisation_platform_accounts.core_logging_id...)}:alias/moj-cur-reports-key"
   replication_rules = [
     {
-      id     = "replicate-cur-athena"
-      prefix = "CUR-ATHENA/"
-      status = "Enabled"
+      id                 = "replicate-cur-athena"
+      prefix             = "CUR-ATHENA/"
+      status             = "Enabled"
+      deletemarker       = "Enabled"
+      replica_kms_key_id = "arn:aws:kms:eu-west-2:${coalesce(local.modernisation_platform_accounts.core_logging_id...)}:alias/moj-cur-reports-key"
+      metrics            = "Enabled"
     }
   ]
 }

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -218,10 +218,10 @@ resource "aws_iam_role_policy" "replication" {
   role = aws_iam_role.replication_role[count.index].id
   policy = jsonencode(
     {
-      "Version": "2012-10-17",
-      "Statement": [
+      "Version" : "2012-10-17",
+      "Statement" : [
         {
-          Sid = "SourceBucketPermissions",
+          Sid    = "SourceBucketPermissions",
           Effect = "Allow",
           Action = [
             "s3:GetObjectVersionTagging",
@@ -236,7 +236,7 @@ resource "aws_iam_role_policy" "replication" {
           ]
         },
         {
-          Sid = "DestinationBucketPermissions",
+          Sid    = "DestinationBucketPermissions",
           Effect = "Allow",
           Action = [
             "s3:ReplicateObject",
@@ -250,21 +250,21 @@ resource "aws_iam_role_policy" "replication" {
           ]
         },
         {
-          Sid = "SourceBucketKMSKey",
+          Sid    = "SourceBucketKMSKey",
           Action = [
             "kms:Decrypt",
             "kms:GenerateDataKey"
           ],
-          Effect = "Allow",
+          Effect   = "Allow",
           Resource = var.source_kms_arn
         },
         {
-          Sid = "DestinationBucketKMSKey",
+          Sid    = "DestinationBucketKMSKey",
           Action = [
             "kms:Encrypt",
             "kms:GenerateDataKey"
           ],
-          Effect = "Allow",
+          Effect   = "Allow",
           Resource = var.destination_kms_arn
         }
       ]

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -250,7 +250,7 @@ resource "aws_iam_role_policy" "replication" {
           ]
         },
         {
-          Sid    = "SourceBucketKMSKey",
+          Sid = "SourceBucketKMSKey",
           Action = [
             "kms:Decrypt",
             "kms:GenerateDataKey"
@@ -259,7 +259,7 @@ resource "aws_iam_role_policy" "replication" {
           Resource = var.source_kms_arn
         },
         {
-          Sid    = "DestinationBucketKMSKey",
+          Sid = "DestinationBucketKMSKey",
           Action = [
             "kms:Encrypt",
             "kms:GenerateDataKey"

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -180,13 +180,12 @@ resource "aws_s3_bucket_replication_configuration" "default" {
           status = rule.value.metrics
         }
         encryption_configuration {
-        replica_kms_key_id = rule.value.replica_kms_key_id
+          replica_kms_key_id = rule.value.replica_kms_key_id
         }
       }
       delete_marker_replication {
         status = rule.value.deletemarker
       }
-      
     }
   }
 }
@@ -218,56 +217,56 @@ resource "aws_iam_role_policy" "replication" {
   name = "${aws_iam_role.replication_role[count.index].name}-policy"
   role = aws_iam_role.replication_role[count.index].id
   policy = jsonencode(
-  {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        Sid = "SourceBucketPermissions",
-        Effect = "Allow",
-        Action = [
-          "s3:GetObjectVersionTagging",
-          "s3:GetObjectVersionAcl",
-          "s3:ListBucket",
-          "s3:GetObjectVersionForReplication",
-          "s3:GetReplicationConfiguration"
-        ],
-        Resource = [
-          "arn:aws:s3:::${var.bucket_name}/*",
-          "arn:aws:s3:::${var.bucket_name}"
-        ]
-      },
-      {
-        Sid = "DestinationBucketPermissions",
-        Effect = "Allow",
-        Action = [
-          "s3:ReplicateObject",
-          "s3:ObjectOwnerOverrideToBucketOwner",
-          "s3:GetObjectVersionTagging",
-          "s3:ReplicateTags",
-          "s3:ReplicateDelete"
-        ],
-        Resource = [
-          "arn:aws:s3:::${var.replication_bucket_arn}/*"
-        ]
-      },
-      {
-        Sid = "SourceBucketKMSKey",
-        Action = [
-          "kms:Decrypt",
-          "kms:GenerateDataKey"
-        ],
-        Effect = "Allow",
-        Resource = var.source_kms_arn
-      },
-      {
-        Sid = "DestinationBucketKMSKey",
-        Action = [
-          "kms:Encrypt",
-          "kms:GenerateDataKey"
-        ],
-        Effect = "Allow",
-        Resource = var.destination_kms_arn
-      }
-    ]
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          Sid = "SourceBucketPermissions",
+          Effect = "Allow",
+          Action = [
+            "s3:GetObjectVersionTagging",
+            "s3:GetObjectVersionAcl",
+            "s3:ListBucket",
+            "s3:GetObjectVersionForReplication",
+            "s3:GetReplicationConfiguration"
+          ],
+          Resource = [
+            "arn:aws:s3:::${var.bucket_name}/*",
+            "arn:aws:s3:::${var.bucket_name}"
+          ]
+        },
+        {
+          Sid = "DestinationBucketPermissions",
+          Effect = "Allow",
+          Action = [
+            "s3:ReplicateObject",
+            "s3:ObjectOwnerOverrideToBucketOwner",
+            "s3:GetObjectVersionTagging",
+            "s3:ReplicateTags",
+            "s3:ReplicateDelete"
+          ],
+          Resource = [
+            "arn:aws:s3:::${var.replication_bucket_arn}/*"
+          ]
+        },
+        {
+          Sid = "SourceBucketKMSKey",
+          Action = [
+            "kms:Decrypt",
+            "kms:GenerateDataKey"
+          ],
+          Effect = "Allow",
+          Resource = var.source_kms_arn
+        },
+        {
+          Sid = "DestinationBucketKMSKey",
+          Action = [
+            "kms:Encrypt",
+            "kms:GenerateDataKey"
+          ],
+          Effect = "Allow",
+          Resource = var.destination_kms_arn
+        }
+      ]
   })
 }

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -104,9 +104,24 @@ variable "replication_role_arn" {
 variable "replication_rules" {
   description = "Replication rules for the bucket"
   type = list(object({
-    id     = string
-    prefix = string
-    status = string
+    id                 = string
+    prefix             = string
+    status             = string
+    deletemarker       = string
+    replica_kms_key_id = string
+    metrics            = string
   }))
   default = []
+}
+
+variable "source_kms_arn" {
+  description = "ARN of source bucket KMS key"
+  type = string
+  default = ""
+}
+
+variable "destination_kms_arn" {
+  description = "ARN of destination bucket KMS key"
+  type = string
+  default = ""
 }

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -116,12 +116,12 @@ variable "replication_rules" {
 
 variable "source_kms_arn" {
   description = "ARN of source bucket KMS key"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "destination_kms_arn" {
   description = "ARN of destination bucket KMS key"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
**Key Changes
S3 Bucket Configuration:**
- Defined and configured replication rules with KMS encryption.
- Enabled cross-account replication, ensuring that objects replicated to the destination bucket are encrypted using a customer-managed KMS key.
- Switch back v2 configuration, adding delete marker replication enabled (previously switched due to referencing out-of-date documentation.

**IAM Role and Policy for Replication:**
- Refactored IAM role with the required permissions to handle cross-account replication with KMS encryption.

**KMS Key Configuration:**
- Ensured that the destination bucket uses a customer-managed KMS key (moj-cur-reports-key) which is owned by the destination account for cross-account replication.

**Replication Rules**
- replica_kms_key_id - KMS key used for replicating objects
- metrics - Replication metrics are enabled for monitoring and troubleshooting.
- deletemarker - Enabled for versioned objects, ensuring that delete markers are replicated to the destination bucket.