### PR TITLE
S3 Replication - Enable sse_kms_encrypted_objects

### DIFF
--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -171,6 +171,11 @@ resource "aws_s3_bucket_replication_configuration" "default" {
       id     = rule.value.id
       status = rule.value.status
 
+      source_selection_criteria {
+        sse_kms_encrypted_objects {
+          status = "Enabled"
+        }
+      }
       filter {
         prefix = rule.value.prefix
       }


### PR DESCRIPTION
Apply of previous PR# [1013](https://github.com/ministryofjustice/aws-root-account/pull/1013) failed (workflow run details [here](https://github.com/ministryofjustice/aws-root-account/actions/runs/11292371077/job/31408219767)) this PR adds in the configuration block required for Amazon S3 objects encrypted with AWS KMS.