### PR TITLE
Fix S3 Replication by Switching from KMS Key Alias to ARN

### DIFF
--- a/management-account/terraform/providers.tf
+++ b/management-account/terraform/providers.tf
@@ -127,3 +127,12 @@ provider "aws" {
   alias  = "sa-east-1"
   region = "sa-east-1"
 }
+
+# core-logging
+provider "aws" {
+  alias  = "core-logging"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${coalesce(local.modernisation_platform_accounts.core_logging_id...)}:role/OrganizationAccountAccessRole"
+  }
+}

--- a/management-account/terraform/providers.tf
+++ b/management-account/terraform/providers.tf
@@ -127,12 +127,3 @@ provider "aws" {
   alias  = "sa-east-1"
   region = "sa-east-1"
 }
-
-# core-logging
-provider "aws" {
-  alias  = "core-logging"
-  region = "eu-west-2"
-  assume_role {
-    role_arn = "arn:aws:iam::${coalesce(local.modernisation_platform_accounts.core_logging_id...)}:role/OrganizationAccountAccessRole"
-  }
-}

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -195,22 +195,21 @@ module "cur_reports_s3_bucket" {
   replication_bucket_arn = "arn:aws:s3:::moj-cur-reports-modplatform-20240930164810837800000001"
   replication_role_arn   = module.cur_reports_s3_bucket.replication_role_arn
   source_kms_arn         = "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:alias/aws/s3"
-  destination_kms_arn    = data.aws_kms_alias.moj_cur_reports_kms_alias.target_key_arn
+  destination_kms_arn    = data.aws_ssm_parameter.core_logging_kms_key_arn.value
   replication_rules = [
     {
       id                 = "replicate-cur-athena"
       prefix             = "CUR-ATHENA/"
       status             = "Enabled"
       deletemarker       = "Enabled"
-      replica_kms_key_id = data.aws_kms_alias.moj_cur_reports_kms_alias.target_key_arn
+      replica_kms_key_id = data.aws_ssm_parameter.core_logging_kms_key_arn.value
       metrics            = "Enabled"
     }
   ]
 }
 
-data "aws_kms_alias" "moj_cur_reports_kms_alias" {
-  provider = aws.core-logging
-  name     = "arn:aws:kms:eu-west-2:${coalesce(local.modernisation_platform_accounts.core_logging_id...)}:alias/moj-cur-reports-key"
+data "aws_ssm_parameter" "core_logging_kms_key_arn" {
+  name = "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/core-logging-kms-key"
 }
 
 data "aws_iam_policy_document" "cur_reports_s3_bucket" {

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -195,17 +195,22 @@ module "cur_reports_s3_bucket" {
   replication_bucket_arn = "arn:aws:s3:::moj-cur-reports-modplatform-20240930164810837800000001"
   replication_role_arn   = module.cur_reports_s3_bucket.replication_role_arn
   source_kms_arn         = "arn:aws:kms:*:${data.aws_caller_identity.current.account_id}:alias/aws/s3"
-  destination_kms_arn    = "arn:aws:kms:eu-west-2:${coalesce(local.modernisation_platform_accounts.core_logging_id...)}:alias/moj-cur-reports-key"
+  destination_kms_arn    = data.aws_kms_alias.moj_cur_reports_kms_alias.target_key_arn
   replication_rules = [
     {
       id                 = "replicate-cur-athena"
       prefix             = "CUR-ATHENA/"
       status             = "Enabled"
       deletemarker       = "Enabled"
-      replica_kms_key_id = "arn:aws:kms:eu-west-2:${coalesce(local.modernisation_platform_accounts.core_logging_id...)}:alias/moj-cur-reports-key"
+      replica_kms_key_id = data.aws_kms_alias.moj_cur_reports_kms_alias.target_key_arn
       metrics            = "Enabled"
     }
   ]
+}
+
+data "aws_kms_alias" "moj_cur_reports_kms_alias" {
+  provider = aws.core-logging
+  name     = "arn:aws:kms:eu-west-2:${coalesce(local.modernisation_platform_accounts.core_logging_id...)}:alias/moj-cur-reports-key"
 }
 
 data "aws_iam_policy_document" "cur_reports_s3_bucket" {


### PR DESCRIPTION
**KMS Key ARN Update for Replication**

- AWS support highlighted that the key alias cannot be used for S3 replication policies; the KMS key ARN is required.

- ~Added a data call to retrieve the correct KMS key ARN dynamically using `aws_kms_alias`, ensuring secure and accurate referencing.~

- Implemented retrieval of the KMS key ARN securely via AWS SSM Parameter Store, storing it in the master account to avoid complex updates for cross-account retrieval.

- Updated destination_kms_arn to fetch the correct string value from the SSM Parameter.
