### PR TITLE
Create IPAM pools for `modernisation-platform-core` OU

### DIFF
--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -110,6 +110,12 @@ locals {
   #   ou.id
   # ]
 
+  ou_modernisation_platform_core_arn = coalesce([
+    for ou in data.aws_organizations_organizational_units.modernisation_platform.children :
+    ou.arn
+    if ou.name == "Modernisation Platform Core"
+  ]...)
+
   ou_modernisation_platform_member_arn = coalesce([
     for ou in data.aws_organizations_organizational_units.modernisation_platform.children :
     ou.arn


### PR DESCRIPTION
This PR is tracked by [#8024](https://github.com/ministryofjustice/modernisation-platform/issues/8024) in the Modernisation Platform repo.

This PR sets out to create a private IPAM pools for Modernisation Platform `live_data` and `non_live_data` VPCs, creating a RAM shares to associate these pools with, and then associating this RAM share with the `Modernisation Platform Core` OU where it can be accepted.

This will allow accounts in the `Modernisation Platform Core` OU to accept the relevant RAM share and associate VPCs with the relevant IPAM pool in order to later set up CloudWatch metric alarms based on `VpcIPUsage` and `SubnetIPUsage`.