### PR TITLE
Update Bucket Name for Replication

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -192,7 +192,7 @@ module "cur_reports_s3_bucket" {
   attach_policy          = true
   policy                 = data.aws_iam_policy_document.cur_reports_s3_bucket.json
   enable_replication     = true
-  replication_bucket_arn = "arn:aws:s3:::moj-cur-reports-modplatform-20240930164810837800000001"
+  replication_bucket_arn = "arn:aws:s3:::moj-cur-reports-modplatform-20241021144023194000000001"
   replication_role_arn   = module.cur_reports_s3_bucket.replication_role_arn
   source_kms_arn         = data.aws_kms_alias.moj_cur_reports_kms_alias.target_key_arn
   destination_kms_arn    = data.aws_ssm_parameter.core_logging_kms_key_arn.value


### PR DESCRIPTION
The S3 bucket has been recreated in `core-logging`, this PR updates the bucket name for replication.