### PR TITLE
added an extend to the cloud formation stack

### DIFF
--- a/organisation-security/terraform/license-manager.tf
+++ b/organisation-security/terraform/license-manager.tf
@@ -64,6 +64,11 @@ resource "aws_cloudformation_stack" "oracleblts" {
   depends_on = [
     module.oracle_ec2_license_configurations
   ]
+  timeouts {
+    create = "60m"
+    update = "60m"
+    delete = "60m"
+  }
 }
 
 # Trigger automation


### PR DESCRIPTION
The PR add an increase to the timeout for the cloud formation stack as the last run timed out after 30 minutes which prevented the rest of the terraform to run