### PR TITLE
change to source to eliminate the log file name error

### DIFF
--- a/organisation-security/terraform/license-manager.tf
+++ b/organisation-security/terraform/license-manager.tf
@@ -46,8 +46,8 @@ module "oracle_ec2_license_configurations" {
 # Upload the YAML file to the existing S3 bucket
 resource "aws_s3_object" "oracle_db_lts_orch" {
   bucket = "license-manager-artifact-bucket" # Existing S3 bucket name
-  key    = "OracleDbLTS-Orchestrate.yaml"
-  source = file("${path.module}/cloudformation/OracleDbLTS-Orch.yaml")
+  key    = "OracleDbLTS-Orch.yaml"
+  source = file("./cloudformation/OracleDbLTS-Orch.yaml")
   acl    = "private"
 }
 


### PR DESCRIPTION
due to the source being to long we are trying to use a literal folder path instead of a module path