### PR TITLE
🔧 Fix Alert Step Failing

### DIFF
--- a/.github/workflows/management-account-apply.yml
+++ b/.github/workflows/management-account-apply.yml
@@ -42,7 +42,37 @@ jobs:
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           payload: |
-            {"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"View Workflow"},"url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","style":"primary"},{"type":"button","text":{"type":"plain_text","text":"View Commit"},"url":"https://github.com/${{ github.repository }}/commit/${{ github.sha }}"}]}]}
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _`${{ format(github.event.head_commit.message, 'replace', '\\n', ' ') }}`_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},
+                {
+                  "type": "actions",
+                  "elements":[
+                    {
+                      "type":"button",
+                      "text": {
+                        "type": "plain_text",
+                        "text":"View Workflow"
+                      },
+                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "style": "primary"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type":"plain_text",
+                        "text":"View Commit"
+                      },
+                      "url":"https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+                    }
+                  ]
+                }
+              ]
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/organisation-security-apply.yml
+++ b/.github/workflows/organisation-security-apply.yml
@@ -42,7 +42,37 @@ jobs:
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
           payload: |
-            {"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _${{ github.event.head_commit.message }}_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},{"type":"actions","elements":[{"type":"button","text":{"type":"plain_text","text":"View Workflow"},"url":"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}","style":"primary"},{"type":"button","text":{"type":"plain_text","text":"View Commit"},"url":"https://github.com/${{ github.repository }}/commit/${{ github.sha }}"}]}]}
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _`${{ format(github.event.head_commit.message, 'replace', '\\n', ' ') }}`_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},
+                {
+                  "type": "actions",
+                  "elements":[
+                    {
+                      "type":"button",
+                      "text": {
+                        "type": "plain_text",
+                        "text":"View Workflow"
+                      },
+                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "style": "primary"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type":"plain_text",
+                        "text":"View Commit"
+                      },
+                      "url":"https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+                    }
+                  ]
+                }
+              ]
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/test-alert-workflow.yml
+++ b/.github/workflows/test-alert-workflow.yml
@@ -1,0 +1,53 @@
+name: Test Alert Workflow
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Slack failure notification
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _`${{ format(github.event.head_commit.message, 'replace', '\\n', ' ') }}`_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},
+                {
+                  "type": "actions",
+                  "elements":[
+                    {
+                      "type":"button",
+                      "text": {
+                        "type": "plain_text",
+                        "text":"View Workflow"
+                      },
+                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+                      "style": "primary"
+                    },
+                    {
+                      "type": "button",
+                      "text": {
+                        "type":"plain_text",
+                        "text":"View Commit"
+                      },
+                      "url":"https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_TESTING }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/aws-root-account/issues/1009
- To fix a bug with the current implementation where a multi-line commit messages causes a JSON parse error

## ♻️ What's changed

- Formatted and stripped newlines from commit messages to try and ensure multi-line commit messages don't cause a JSON parse error
- Temporarily added a test workflow to send an alert to my testing channel, just to spot any issues when this PR is merged 👀 

## 📓 Notes

- Expanded the JSON blocks so they're easier to amend