### PR TITLE
🔧 Fix Slack Alert Failing by Only Using Commit Header

### DIFF
--- a/.github/workflows/management-account-apply.yml
+++ b/.github/workflows/management-account-apply.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Save Commit Header
         run: |
-          echo "COMMIT_MESSAGE_HEADER=$(git log -1 --pretty=%B | head -n 1)" >> $GITHUB_ENV
+          echo "COMMIT_MESSAGE_HEADER=$(git log -1 --pretty=%B | head -n 1)" >> "${GITHUB_ENV}"
       - name: Slack failure notification
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0

--- a/.github/workflows/management-account-apply.yml
+++ b/.github/workflows/management-account-apply.yml
@@ -37,6 +37,9 @@ jobs:
       - run: terraform apply -auto-approve
         if: github.event.ref == 'refs/heads/main'
 
+      - name: Save Commit Header
+        run: |
+          echo "COMMIT_MESSAGE_HEADER=$(git log -1 --pretty=%B | head -n 1)" >> $GITHUB_ENV
       - name: Slack failure notification
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
@@ -48,7 +51,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _`${{ format(github.event.head_commit.message, 'replace', '\\n', ' ') }}`_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},
+                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _`${{ env.COMMIT_MESSAGE_HEADER }}`_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},
                 {
                   "type": "actions",
                   "elements":[

--- a/.github/workflows/organisation-security-apply.yml
+++ b/.github/workflows/organisation-security-apply.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Save Commit Header
         run: |
-          echo "COMMIT_MESSAGE_HEADER=$(git log -1 --pretty=%B | head -n 1)" >> $GITHUB_ENV
+          echo "COMMIT_MESSAGE_HEADER=$(git log -1 --pretty=%B | head -n 1)" >> "${GITHUB_ENV}"
       - name: Slack failure notification
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0

--- a/.github/workflows/organisation-security-apply.yml
+++ b/.github/workflows/organisation-security-apply.yml
@@ -37,6 +37,9 @@ jobs:
       - run: terraform apply -auto-approve
         if: github.event.ref == 'refs/heads/main'
 
+      - name: Save Commit Header
+        run: |
+          echo "COMMIT_MESSAGE_HEADER=$(git log -1 --pretty=%B | head -n 1)" >> $GITHUB_ENV
       - name: Slack failure notification
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
@@ -48,7 +51,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _`${{ format(github.event.head_commit.message, 'replace', '\\n', ' ') }}`_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},
+                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _`${{ env.COMMIT_MESSAGE_HEADER }}`_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},
                 {
                   "type": "actions",
                   "elements":[

--- a/.github/workflows/test-alert-workflow.yml
+++ b/.github/workflows/test-alert-workflow.yml
@@ -1,6 +1,9 @@
 name: Test Alert Workflow
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -13,6 +16,10 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Save Commit Header
+        run: |
+          echo "COMMIT_MESSAGE_HEADER=$(git log -1 --pretty=%B | head -n 1)" >> $GITHUB_ENV
       - name: Slack failure notification
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:
@@ -23,7 +30,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _`${{ format(github.event.head_commit.message, 'replace', '\\n', ' ') }}`_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},
+                    "text": ":x: *GitHub Workflow Failed!* \n\nA workflow has failed in the repository *<https://github.com/${{ github.repository }}|${{ github.repository }}>*.\n\n*Workflow:* `${{ github.workflow }}`\n*Branch:* `${{ github.ref_name }}`\n*Commit:* `${{ github.sha }}` - _`${{ env.COMMIT_MESSAGE_HEADER }}`_\n*Author:* `${{ github.event.head_commit.author.name }}`"}},
                 {
                   "type": "actions",
                   "elements":[

--- a/.github/workflows/test-alert-workflow.yml
+++ b/.github/workflows/test-alert-workflow.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Save Commit Header
         run: |
-          echo "COMMIT_MESSAGE_HEADER=$(git log -1 --pretty=%B | head -n 1)" >> $GITHUB_ENV
+          echo "COMMIT_MESSAGE_HEADER=$(git log -1 --pretty=%B | head -n 1)" >> "${GITHUB_ENV}"
       - name: Slack failure notification
         uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         with:


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/aws-root-account/issues/1009
- To fix JSON parse error on multi-line commits by only using the commit header title in the message

## ♻️ What's changed

- Replace the current strategy of replacing new line characters (which didn't work) with only retrieving the commit message header for displaying in Slack

## 📝 Notes

- Temporary workflow still there to test this in my testing channel 🧪 