### PR TITLE
Add Mod Platform SSM Inventory Resource Data Sync s3 bucket and kms key

### DIFF
--- a/organisation-security/terraform/license-manager.tf
+++ b/organisation-security/terraform/license-manager.tf
@@ -52,34 +52,34 @@ resource "aws_s3_object" "oracle_db_lts_orch" {
 }
 
 # Cloudformation stack for Oracle Database auto detection
-resource "aws_cloudformation_stack" "oracleblts" {
-  name         = "OracleDbLTS"
-  capabilities = ["CAPABILITY_NAMED_IAM"]
-  parameters = {
-    IsDelegatedAdministrator = true
-    ArtifactsS3Bucket        = "license-manager-artifact-bucket"
-    AdministratorAccountId   = data.aws_caller_identity.current.id
-    OrganizationId           = local.organizations_organization.id
-    TargetOUs                = local.ou_modernisation_platform_member_id
-    TargetRegions            = "eu-west-2"
-    TargetKey                = "tag:OracleDbLTS-ManagedInstance"
-    TargetValues             = true
-    MaxConcurrency           = 4
-    MaxErrors                = 4
-    Schedule                 = "cron(15 0 ? * MON *)"
-  }
-  template_url = "https://aws-license-manager-service-643d94b3-abff-46cd-as.s3.eu-west-2.amazonaws.com/OracleDbLTS-Orch.yaml"
+# resource "aws_cloudformation_stack" "oracleblts" {
+#   name         = "OracleDbLTS"
+#   capabilities = ["CAPABILITY_NAMED_IAM"]
+#   parameters = {
+#     IsDelegatedAdministrator = true
+#     ArtifactsS3Bucket        = "license-manager-artifact-bucket"
+#     AdministratorAccountId   = data.aws_caller_identity.current.id
+#     OrganizationId           = local.organizations_organization.id
+#     TargetOUs                = local.ou_modernisation_platform_member_id
+#     TargetRegions            = "eu-west-2"
+#     TargetKey                = "tag:OracleDbLTS-ManagedInstance"
+#     TargetValues             = true
+#     MaxConcurrency           = 4
+#     MaxErrors                = 4
+#     Schedule                 = "cron(15 0 ? * MON *)"
+#   }
+#   template_url = "https://aws-license-manager-service-643d94b3-abff-46cd-as.s3.eu-west-2.amazonaws.com/OracleDbLTS-Orch.yaml"
 
-  depends_on = [
-    module.oracle_ec2_license_configurations,
-    aws_s3_object.oracle_db_lts_orch
-  ]
-  timeouts {
-    create = "60m"
-    update = "60m"
-    delete = "60m"
-  }
-}
+#   depends_on = [
+#     module.oracle_ec2_license_configurations,
+#     aws_s3_object.oracle_db_lts_orch
+#   ]
+#   timeouts {
+#     create = "60m"
+#     update = "60m"
+#     delete = "60m"
+#   }
+# }
 
 
 # Athena resources

--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -141,7 +141,7 @@ data "aws_iam_policy_document" "mp_ssm_inventory_resource_data_sync_bucket" {
       identifiers = ["ssm.amazonaws.com"]
     }
     actions   = ["s3:GetBucketAcl"]
-    resources = ["arn:aws:s3:::ssm-inventory-sync-bucket-euw2"]
+    resources = ["arn:aws:s3:::mp-ssm-inventory-resource-data-sync-${random_integer.suffix.result}"]
   }
 
   statement {
@@ -152,7 +152,7 @@ data "aws_iam_policy_document" "mp_ssm_inventory_resource_data_sync_bucket" {
       identifiers = ["ssm.amazonaws.com"]
     }
     actions   = ["s3:PutObject"]
-    resources = ["arn:aws:s3:::ssm-inventory-sync-bucket-euw2/*/accountid=*/*"]
+    resources = ["arn:aws:s3:::mp-ssm-inventory-resource-data-sync-${random_integer.suffix.result}/*/accountid=*/*"]
     condition {
       test     = "StringEquals"
       variable = "s3:x-amz-acl"
@@ -173,7 +173,7 @@ data "aws_iam_policy_document" "mp_ssm_inventory_resource_data_sync_bucket" {
       identifiers = ["ssm.amazonaws.com"]
     }
     actions   = ["s3:PutObjectTagging"]
-    resources = ["arn:aws:s3:::ssm-inventory-sync-bucket-euw2/*/accountid=*/*"]
+    resources = ["arn:aws:s3:::mp-ssm-inventory-resource-data-sync-${random_integer.suffix.result}/*/accountid=*/*"]
   }
 }
 

--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -186,7 +186,7 @@ resource "aws_kms_key" "mp_ssm_inventory_resource_data_sync" {
 }
 
 resource "aws_kms_alias" "mp_ssm_inventory_resource_data_sync" {
-  name          = "alias/mp-ssm-resource-data-sync"
+  name          = "alias/mp-ssm-inventory-resource-data-sync"
   target_key_id = aws_kms_key.mp_ssm_inventory_resource_data_sync.key_id
 }
 

--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -110,3 +110,115 @@ module "athena_results_s3_bucket" {
     }
   }
 }
+
+# MP SSM Inventory Resource Data Sync S3 bucket - for syncing Modernisation Platform inventory data centrally (Similar to what's been built in organisation-security/terraform/ssm.tf but keeping this separate for now)
+module "mp_ssm_inventory_resource_data_sync_s3_bucket" {
+  source = "../../modules/s3"
+
+  bucket_name = "mp-ssm-inventory-resource-data-sync-${random_integer.suffix.result}"
+  bucket_acl  = "private"
+
+  attach_policy        = true
+  policy               = data.aws_iam_policy_document.mp_ssm_inventory_resource_data_sync_bucket.json
+  require_ssl_requests = true
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  }
+}
+
+# MP SSM Inventory Resource Data Sync S3 bucket policy
+data "aws_iam_policy_document" "mp_ssm_inventory_resource_data_sync_bucket" {
+  statement {
+    sid    = "SSMBucketPermissionsCheck"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+    actions   = ["s3:GetBucketAcl"]
+    resources = ["arn:aws:s3:::ssm-inventory-sync-bucket-euw2"]
+  }
+
+  statement {
+    sid    = "SSMBucketDelivery"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::ssm-inventory-sync-bucket-euw2/*/accountid=*/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceOrgID"
+      values   = [data.aws_organizations_organization.root_account.id]
+    }
+  }
+
+  statement {
+    sid    = "SSMBucketDeliveryTagging"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+    actions   = ["s3:PutObjectTagging"]
+    resources = ["arn:aws:s3:::ssm-inventory-sync-bucket-euw2/*/accountid=*/*"]
+  }
+}
+
+# KMS key for encrypting contents of the MP SSM Inventory Resource Data Sync S3 bucket
+resource "aws_kms_key" "mp_ssm_inventory_resource_data_sync" {
+  description         = "Used for Inventory Resource Data Sync from org member accounts"
+  policy              = data.aws_iam_policy_document.mp_ssm_inventory_resource_data_sync_kms.json
+  is_enabled          = true
+  enable_key_rotation = true
+}
+
+resource "aws_kms_alias" "mp_ssm_inventory_resource_data_sync" {
+  name          = "alias/ssm-resource-sync"
+  target_key_id = aws_kms_key.mp_ssm_inventory_resource_data_sync.key_id
+}
+
+data "aws_iam_policy_document" "mp_ssm_inventory_resource_data_sync_kms" {
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+  statement {
+    sid       = "ssm-access-policy-statement"
+    effect    = "Allow"
+    actions   = ["kms:GenerateDataKey"]
+    resources = ["*"]
+    principals {
+      type        = "Service"
+      identifiers = ["ssm.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = local.organisation_account_numbers
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:ssm:*:*:resource-data-sync/*"]
+    }
+  }
+}

--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "mp_ssm_inventory_resource_data_sync_bucket" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceOrgID"
-      values   = [data.aws_organizations_organization.root_account.id]
+      values   = [local.organizations_organization.id]
     }
   }
 

--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -186,7 +186,7 @@ resource "aws_kms_key" "mp_ssm_inventory_resource_data_sync" {
 }
 
 resource "aws_kms_alias" "mp_ssm_inventory_resource_data_sync" {
-  name          = "alias/ssm-resource-sync"
+  name          = "alias/mp-ssm-resource-data-sync"
   target_key_id = aws_kms_key.mp_ssm_inventory_resource_data_sync.key_id
 }
 

--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -212,8 +212,8 @@ data "aws_iam_policy_document" "mp_ssm_inventory_resource_data_sync_kms" {
     }
     condition {
       test     = "StringEquals"
-      variable = "aws:SourceAccount"
-      values   = local.organisation_account_numbers
+      variable = "aws:SourceOrgID"
+      values   = [local.organizations_organization.id]
     }
     condition {
       test     = "ArnLike"


### PR DESCRIPTION
## Why?

The use case is explained in this issue:
https://github.com/ministryofjustice/modernisation-platform/issues/8360

## What's Changing?

Adds a SSM inventory sync s3 bucket and associated policy which grants the SSM service permission to add objects as long as they are in they originate from our organization.

After creating this, in a seperate PR in the Modernisation Platform I will be creating a resource data sync in the bootstrap so that we can pool information from all MP accounts so they can be centrally queried in this bucket using Athena.

I had previously built this bucket in the [Mod Platform account](https://github.com/ministryofjustice/modernisation-platform/pull/8485) but after discussion we felt it best lives in the `organisation-security` account. (I will raise a PR to remove that).

It's worth mentioning that this looks very similar (almost duplicates) the infrastructure built in `organisation-security/terraform/ssm.tf` but that ties in with another work thread where we are gathering oracle licensing data. For now we agreed to keep these seperate but it could merge in future.

