### PR TITLE
Remove private bucket acl

### DIFF
--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -116,7 +116,6 @@ module "mp_ssm_inventory_resource_data_sync_s3_bucket" {
   source = "../../modules/s3"
 
   bucket_name = "mp-ssm-inventory-resource-data-sync-${random_integer.suffix.result}"
-  bucket_acl  = "private"
 
   attach_policy        = true
   policy               = data.aws_iam_policy_document.mp_ssm_inventory_resource_data_sync_bucket.json


### PR DESCRIPTION
## Why?
https://mojdt.slack.com/archives/C06P4KA0V0A/p1732274217576039

TF apply failed building an S3 bucket for MP resource data sync.

## What's Changed?

I've removed the bucket ACL statement as I'm preferring to use an IAM policy to manage access.