### PR TITLE
Add secret for AWS SSO EntraID

### DIFF
--- a/management-account/terraform/secrets-manager.tf
+++ b/management-account/terraform/secrets-manager.tf
@@ -95,3 +95,8 @@ data "aws_secretsmanager_secret" "azure_aws_connectivity_details" {
 data "aws_secretsmanager_secret_version" "azure_aws_connectivity_details" {
   secret_id = data.aws_secretsmanager_secret.azure_aws_connectivity_details.id
 }
+
+resource "aws_secretsmanager_secret" "aws_sso_entraid_integration" {
+  name        = "aws-sso-entraid-integration"
+  description = "Azure client ID and secret for the Ministry of Justice owned OAuth app for AWS SSO"
+}


### PR DESCRIPTION
This is required to store the Microsoft Azure domain, application client and secret ID.