### PR TITLE
✨ Add Read Only Role For Operations Engineering to Master Account

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -411,6 +411,13 @@ locals {
         aws_organizations_organization.default.master_account_id
       ]
     },
+    {
+      github_team        = "operations-engineering",
+      permission_set_arn = aws_ssoadmin_permission_set.aws_sso_read_only.arn,
+      account_ids = [
+        aws_organizations_organization.default.master_account_id
+      ]
+    },
   ]
   sso_admin_account_assignments_expanded = flatten([
     for assignment in local.sso_admin_account_assignments : [


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/5050
- As Operations Engineering pivots to its new FinOps directive, they will need access to several AWS services in the master account, including billing and cost data, standards, security and compliance

## ♻️ What's changed

- Added the ReadOnly role to `operations-engineering` for the MoJ Master Account

## 📝 Notes

- Eventually we will need to add in additional permissions to allow Operations Engineering to amend Savings Plans, reserved instances and potentially more - but Read Only at the moment to enable the team to accurately assess services that currently exist in the master account and how the information can help us make effective decisions in relation to FinOps