### PR TITLE
template change and time out increased

### DIFF
--- a/organisation-security/terraform/cloudformation/OracleDbLTS-Orch.yaml
+++ b/organisation-security/terraform/cloudformation/OracleDbLTS-Orch.yaml
@@ -406,7 +406,7 @@ Resources:
       MemorySize: 256
       Role: !GetAtt OracleDbLTSUtilityFunctionRole.Arn
       Runtime: "python3.9"
-      Timeout: 60
+      Timeout: 900
       Code:
         ZipFile: !Sub |
           import boto3
@@ -641,7 +641,7 @@ Resources:
 
               # Determine what action to take.
               if event['RequestType'] in ['Create', 'Update']:
-                print(event)
+                print(deploymentTargets)
                 for dt in deploymentTargets:
                   targetDeploymentList.extend(get_child_ou_ids(dt))
                   targetDeploymentList.append(dt)
@@ -694,7 +694,7 @@ Resources:
       TargetKey: !Ref TargetKey
       TargetValues: !Ref TargetValues
       Schedule: !Ref Schedule
-      ServiceTimeout: 120
+      ServiceTimeout: 1000
 
   OracleDbLTSOrchestrate:
     Type: "AWS::SSM::Document"

--- a/organisation-security/terraform/license-manager.tf
+++ b/organisation-security/terraform/license-manager.tf
@@ -75,7 +75,7 @@ resource "aws_cloudformation_stack" "oracleblts" {
     aws_s3_object.oracle_db_lts_orch
   ]
   timeouts {
-    create = "60m"
+    create = "120m"
     update = "60m"
     delete = "60m"
   }


### PR DESCRIPTION
After providing an update to the AWS they have sent me new cloud formation template which adds more memory and increased the time out from 30 to 60.

I have also increased the time out for create on the terraform code from 60 to 120 this should hopefully help with the stack creation.