### PR TITLE
✨ Add Admin and ReadOnly Roles For Security Account to Root Account Admin Team

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -13,14 +13,16 @@ locals {
       github_team        = "aws-root-account-admin-team",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [
-        aws_organizations_organization.default.master_account_id
+        aws_organizations_organization.default.master_account_id,
+        aws_organizations_account.organisation_security.id,
       ]
     },
     {
       github_team        = "aws-root-account-admin-team",
       permission_set_arn = aws_ssoadmin_permission_set.aws_sso_read_only.arn,
       account_ids = [
-        aws_organizations_organization.default.master_account_id
+        aws_organizations_organization.default.master_account_id,
+        aws_organizations_account.organisation_security.id,
       ]
     },
     {


### PR DESCRIPTION
## 👀 Purpose

- To give explicit admin access to the org security account for the root account admins (we already have this via the OrganisationAccess Role)

## ♻️ What's changed

- Added Admin and ReadOnly Roles For Security Account to Root Account Admin Team

## 📝 Notes

- Makes life a bit easier instead of having to jump through multiple accounts and roles, also makes the access explicit instead of implicit