### PR TITLE
♻ Refactor Operations Engineering Permissions From SSOReadOnly to ReadOnly

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -415,7 +415,7 @@ locals {
     },
     {
       github_team        = "operations-engineering",
-      permission_set_arn = aws_ssoadmin_permission_set.aws_sso_read_only.arn,
+      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
       account_ids = [
         aws_organizations_organization.default.master_account_id
       ]


### PR DESCRIPTION
## 👀 Purpose

- Fixes #1050 
- In relation to https://github.com/ministryofjustice/operations-engineering/issues/5050
- To give Operations Engineering ReadOnly access to the Master Account

## ♻️ What's changed

- Swapped SSOReadOnly for ReadOnly for Operations Engineering

## 📝 Notes

- SSOReadOnly does not provide ReadOnly access to the account