### PR TITLE
Allow admin access to PKI accounts for eucs-architects

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -287,6 +287,14 @@ locals {
       ]
     },
     {
+      github_team        = "eucs-architects",
+      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
+      account_ids = [
+        aws_organizations_account.moj_official_public_key_infrastructure_dev.id,
+        aws_organizations_account.moj_official_public_key_infrastructure.id,
+      ]
+    },
+    {
       github_team        = "moj-official-techops",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [


### PR DESCRIPTION
## 👀 Purpose

- This PR allows `eucs-architects` GitHub Team members to have SSO access to the PKI AWS accounts. 

## ♻️ What's changed

- Add tf block for `eucs-architects`

## 📝 Notes

[Request](https://mojdt.slack.com/archives/C01BUKJSZD4/p1734001196268669)