### PR TITLE
Addressing DNS security issues

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -428,6 +428,13 @@ locals {
         aws_organizations_organization.default.master_account_id
       ]
     },
+    {
+      github_team        = "operations-engineering",
+      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
+      account_ids = [
+        aws_organizations_account.tacticalproducts.id
+      ]
+    },
   ]
   sso_admin_account_assignments_expanded = flatten([
     for assignment in local.sso_admin_account_assignments : [


### PR DESCRIPTION
This is to provide admin access to the `operations-engineering` GH team for the `tacticalproducts` account in order to tackle DNS tech debt and address DNS security issues as requested in [this slack thread](https://mojdt.slack.com/archives/C06P4KA0V0A/p1734351851518559).