### PR TITLE
Adding a new role and new groups to identity center to be managed in Control Panel

### DIFF
--- a/management-account/terraform/data.tf
+++ b/management-account/terraform/data.tf
@@ -1,1 +1,3 @@
 data "aws_caller_identity" "current" {}
+
+data "aws_ssoadmin_instances" "moj" {}

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -194,7 +194,7 @@ data "aws_iam_policy_document" "modernisation_platform_github_actions_additional
 # AnalyticalPlatformIdentityCenterRole   #
 ##########################################
 
-data "aws_iam_policy_document" "analytical_platform_identity_center" {
+data "aws_iam_policy_document" "analytical_platform_identity_center_assume_role" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
@@ -254,7 +254,7 @@ resource "aws_iam_policy" "analytical_platform_identity_center" {
 
 resource "aws_iam_role" "analytical_platform_identity_center" {
   name               = "AnalyticalPlatformIdentityCenter"
-  assume_role_policy = data.aws_iam_policy_document.analytical_platform_identity_center.json
+  assume_role_policy = data.aws_iam_policy_document.analytical_platform_identity_center_assume_role.json
 }
 
 resource "aws_iam_role_policy_attachment" "analytical_platform_identity_center" {

--- a/management-account/terraform/identity-center-quicksight-groups.tf
+++ b/management-account/terraform/identity-center-quicksight-groups.tf
@@ -1,0 +1,17 @@
+resource "aws_identitystore_group" "analytical_platform_qs_readers" {
+  display_name      = "azure-aws-sso-analytical-platform-qs-readers"
+  description       = "Analytical Platform QuickSight Readers (membership managed via AP Control Panel)"
+  identity_store_id = tolist(data.aws_ssoadmin_instances.moj.identity_store_ids)[0]
+}
+
+resource "aws_identitystore_group" "analytical_platform_qs_authors" {
+  display_name      = "azure-aws-sso-analytical-platform-qs-authors"
+  description       = "Analytical Platform QuickSight Authors (membership managed via AP Control Panel)"
+  identity_store_id = tolist(data.aws_ssoadmin_instances.moj.identity_store_ids)[0]
+}
+
+resource "aws_identitystore_group" "analytical_platform_qs_admins" {
+  display_name      = "azure-aws-sso-analytical-platform-qs-admins"
+  description       = "Analytical Platform QuickSight Admins (membership managed via AP Control Panel)"
+  identity_store_id = tolist(data.aws_ssoadmin_instances.moj.identity_store_ids)[0]
+}

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -338,7 +338,7 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
     effect = "Allow"
     actions = [
       "dynamodb:PutItem",
-      "dynamodb:DeleteItem" 
+      "dynamodb:DeleteItem"
     ]
     resources = ["arn:aws:dynamodb:eu-west-2:${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:table/modernisation-platform-terraform-state-lock"]
   }


### PR DESCRIPTION
https://github.com/ministryofjustice/analytical-platform/issues/6510

This adds a role which can be assumed by Analytical Platform Control Panel which will allow it to add Identity Center users for QuickSight access only.

The goal is to simplify the process for account onboarding which currently involves 6 steps, and at least 2 handovers between AP team and the user.

This way, the user will be directly provisioned in identity center when they're granted access to QuickSight and removed when they're not. 