### PR TITLE
Adding CreateGroup to apply role

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -151,6 +151,7 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
       "identitystore:ListGroups",
       "identitystore:GetGroupId",
       "identitystore:DescribeGroup",
+      "identitystore:CreateGroup",
       "kms:Decrypt",
       "lambda:*",
       "license-manager:*",


### PR DESCRIPTION
[This PR](https://github.com/ministryofjustice/aws-root-account/pull/1065) failed to apply because Apply role doesn't have CreateGroup permissions in `identitycenter`

This PR adds it.

Work is related to

https://github.com/ministryofjustice/analytical-platform/issues/6510