### PR TITLE
Add hosting-tech-leads to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/operations-engineering @ministryofjustice/aws-root-account-admin-team
+* @ministryofjustice/aws-root-account-admin-team @ministryofjustice/hosting-tech-leads


### PR DESCRIPTION
This team will do approvals for the root account going forward.

Removing the ops eng team as it doesn't exist or is not visible causing errors in the codeowners file.