### PR TITLE
Adding missing permissions to AP Identity Center role

### DIFF
--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -227,6 +227,11 @@ data "aws_iam_policy_document" "analytical_platform_identity_center" {
       "identitystore:ListGroups",
       "identitystore:ListUsers",
       "identitystore:DescribeUser",
+      "identitystore:GetUserId",
+      "identitystore:GetGroupId",
+      "identitystore:UpdateGroup",
+      "identitystore:GetGroupMembershipId",
+      "identitystore:UpdateUser",
     ]
     resources = [
       "arn:aws:identitystore::${data.aws_caller_identity.current.account_id}:identitystore/*",

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -289,9 +289,9 @@ module "cur_reports_greenopspoc_s3_bucket" {
   providers = {
     aws.bucket-replication = aws
   }
-  bucket_name   = "moj-cur-reports-greenopspoc"
-  bucket_policy         = [data.aws_iam_policy_document.cur_reports_greenopspoc_s3_policy.json]
-  ownership_controls  = "BucketOwnerEnforced"
+  bucket_name        = "moj-cur-reports-greenopspoc"
+  bucket_policy      = [data.aws_iam_policy_document.cur_reports_greenopspoc_s3_policy.json]
+  ownership_controls = "BucketOwnerEnforced"
 
   tags = {
     business-unit = "Platforms"


### PR DESCRIPTION
https://github.com/ministryofjustice/analytical-platform/issues/6510

This PR adds missing permissions to the AP Identity Center role to allow lookups if identity store ids and updating groups and users.

(Also, an additional file got fixed up in `terraform fmt`)