### PR TITLE
feature 8739 - bumping Github permissions to run greenops cur report

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -144,6 +144,7 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
       "config:*",
       "cur:DescribeReportDefinitions",
       "cur:ListTagsForResource",
+      "cur:PutReportDefinition",
       "events:*",
       "fms:*",
       "guardduty:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

Bump Github permissions to enable us to create a Cost and Usage Report for PoC with Greenpixie #8739

## How has this been tested?

See unit tests below.


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed
