### PR TITLE
Add YJAF AWS account access to modernisation_platform_engineering

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -260,6 +260,7 @@ locals {
         aws_organizations_account.modernisation_platform.id,
         aws_organizations_organization.default.master_account_id,
         aws_organizations_account.organisation_security.id
+        aws_organizations_account.youth_justice_framework_management.id
       ]
     },
     {

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -259,15 +259,15 @@ locals {
       account_ids = [
         aws_organizations_account.modernisation_platform.id,
         aws_organizations_organization.default.master_account_id,
-        aws_organizations_account.organisation_security.id,
-        aws_organizations_account.youth_justice_framework_management.id
+        aws_organizations_account.organisation_security.id
       ]
     },
     {
       github_team        = "modernisation-platform-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [
-        aws_organizations_account.modernisation_platform.id
+        aws_organizations_account.modernisation_platform.id,
+        aws_organizations_account.youth_justice_framework_management.id
       ]
     },
     {

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -259,7 +259,7 @@ locals {
       account_ids = [
         aws_organizations_account.modernisation_platform.id,
         aws_organizations_organization.default.master_account_id,
-        aws_organizations_account.organisation_security.id
+        aws_organizations_account.organisation_security.id,
         aws_organizations_account.youth_justice_framework_management.id
       ]
     },


### PR DESCRIPTION
## 👀 Purpose

- This PR enables admin assess to `Youth Justice Framework Management` AWS account for `modernisation-platform-engineering` via SSO.

This is part of the handover of YJAF AWS access to Modernisation Platform.

## ♻️ What's changed

- Add `aws_organizations_account.youth_justice_framework_management.id` to `modernisation-platform-engineers`

## Notes

- Related to [#8945](https://github.com/ministryofjustice/modernisation-platform/issues/8945)