### PR TITLE
feature8739-adding permissions to enable deletion of cur

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -145,6 +145,7 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
       "cur:DescribeReportDefinitions",
       "cur:ListTagsForResource",
       "cur:PutReportDefinition",
+      "cur:DeleteReportDefinition",
       "events:*",
       "fms:*",
       "guardduty:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

Adding permission to enable deletion of cost and usage reports, to fix the error below,

https://mojdt.slack.com/archives/C06P4KA0V0A/p1737103902883039

## How has this been tested?

See unit tests below.


## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed