### PR TITLE
Manually Enable consolidated control findings due to Terraform limitation

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -10,7 +10,8 @@ data "aws_caller_identity" "current" {}
 
 # Enable Security Hub
 resource "aws_securityhub_account" "default" {
-  control_finding_generator = "STANDARD_CONTROL"
+  # Consolidated Control Findings has been enabled manually, as no Terraform support currently exists for enabling it centrally.
+  control_finding_generator = "SECURITY_CONTROL"
   lifecycle {
     ignore_changes = [
       # When importing this can't be changed without destroying the resource


### PR DESCRIPTION
A comment has been added to the code for clarity regarding the manual setup of the control_finding_generator configuration, which is now set to SECURITY_CONTROL, as Terraform currently does not support enabling it centrally.