### PR TITLE
Allow ModernisationPlatformGithubActionsRole to delete `*.tflock` files

### DIFF
--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -215,6 +215,12 @@ data "aws_iam_policy_document" "terraform_organisation_management_policy" {
   }
 
   statement {
+    effect    = "Allow"
+    actions   = ["s3:DeleteObject"]
+    resources = ["arn:aws:s3:::modernisation-platform-terraform-state/*.tflock"]
+  }
+
+  statement {
     effect = "Allow"
     actions = [
       "s3:PutObject",


### PR DESCRIPTION
Tracked upstream by [#8345](https://github.com/ministryofjustice/modernisation-platform/issues/8345).

This PR adds a statement allowing the `ModernisationPlatformGithubActionsRole` to delete native S3 lock files from the `modernisation-platform-terraform-state` S3 bucket.