### PR TITLE
🔧 Fix Pipe Errors Not Propogating

### DIFF
--- a/.github/workflows/management-account-apply.yml
+++ b/.github/workflows/management-account-apply.yml
@@ -33,8 +33,12 @@ jobs:
         continue-on-error: true
       - run: terraform init
       - run: terraform validate -no-color
-      - run: terraform plan -no-color | ../../scripts/redaction.sh
-      - run: terraform apply -auto-approve | ../../scripts/redaction.sh
+      - run: |
+          set -o pipefail
+          terraform plan | ../../scripts/redaction.sh
+      - run: |
+          set -o pipefail
+          terraform apply | ../../scripts/redaction.sh
         if: github.event.ref == 'refs/heads/main'
 
       - name: Slack failure notification

--- a/.github/workflows/management-account-apply.yml
+++ b/.github/workflows/management-account-apply.yml
@@ -33,10 +33,12 @@ jobs:
         continue-on-error: true
       - run: terraform init
       - run: terraform validate -no-color
-      - run: |
+      - name: Terraform plan
+        run: |
           set -o pipefail
           terraform plan | ../../scripts/redaction.sh
-      - run: |
+      - name: Terraform apply
+        run: |
           set -o pipefail
           terraform apply | ../../scripts/redaction.sh
         if: github.event.ref == 'refs/heads/main'

--- a/.github/workflows/management-account-plan.yml
+++ b/.github/workflows/management-account-plan.yml
@@ -3,10 +3,10 @@ name: terraform plan (management-account)
 on:
   pull_request:
     paths:
-      - 'management-account/terraform/**'
-      - 'modules/**'
-      - '.github/workflows/management-account-plan.yml'
-      - '.github/workflows/management-account-apply.yml'
+      - "management-account/terraform/**"
+      - "modules/**"
+      - ".github/workflows/management-account-plan.yml"
+      - ".github/workflows/management-account-apply.yml"
   workflow_dispatch:
 
 jobs:
@@ -32,5 +32,6 @@ jobs:
         continue-on-error: true
       - run: terraform init
       - run: terraform validate -no-color
-      - run: terraform plan -no-color | ../../scripts/redaction.sh
-   
+      - run: |
+          set -o pipefail
+          terraform plan | ../../scripts/redaction.sh

--- a/.github/workflows/management-account-plan.yml
+++ b/.github/workflows/management-account-plan.yml
@@ -32,6 +32,7 @@ jobs:
         continue-on-error: true
       - run: terraform init
       - run: terraform validate -no-color
-      - run: |
+      - name: Terraform plan
+        run: |
           set -o pipefail
           terraform plan | ../../scripts/redaction.sh

--- a/.github/workflows/organisation-security-apply.yml
+++ b/.github/workflows/organisation-security-apply.yml
@@ -33,8 +33,12 @@ jobs:
         continue-on-error: true
       - run: terraform init
       - run: terraform validate -no-color
-      - run: terraform plan -no-color | ../../scripts/redaction.sh
-      - run: terraform apply -auto-approve | ../../scripts/redaction.sh
+      - run: |
+          set -o pipefail
+          terraform plan | ../../scripts/redaction.sh
+      - run: |
+          set -o pipefail
+          terraform apply | ../../scripts/redaction.sh
         if: github.event.ref == 'refs/heads/main'
 
       - name: Slack failure notification

--- a/.github/workflows/organisation-security-apply.yml
+++ b/.github/workflows/organisation-security-apply.yml
@@ -33,10 +33,12 @@ jobs:
         continue-on-error: true
       - run: terraform init
       - run: terraform validate -no-color
-      - run: |
+      - name: Terraform plan
+        run: |
           set -o pipefail
           terraform plan | ../../scripts/redaction.sh
-      - run: |
+      - name: Terraform apply
+        run: |
           set -o pipefail
           terraform apply | ../../scripts/redaction.sh
         if: github.event.ref == 'refs/heads/main'

--- a/.github/workflows/organisation-security-plan.yml
+++ b/.github/workflows/organisation-security-plan.yml
@@ -32,6 +32,7 @@ jobs:
         continue-on-error: true
       - run: terraform init
       - run: terraform validate -no-color
-      - run: |
+      - name: Terraform plan
+        run: |
           set -o pipefail
           terraform plan | ../../scripts/redaction.sh

--- a/.github/workflows/organisation-security-plan.yml
+++ b/.github/workflows/organisation-security-plan.yml
@@ -3,10 +3,10 @@ name: terraform plan (organisation-security)
 on:
   pull_request:
     paths:
-      - 'organisation-security/terraform/**'
-      - 'modules/**'
-      - '.github/workflows/organisation-security-plan.yml'
-      - '.github/workflows/organisation-security-apply.yml'
+      - "organisation-security/terraform/**"
+      - "modules/**"
+      - ".github/workflows/organisation-security-plan.yml"
+      - ".github/workflows/organisation-security-apply.yml"
   workflow_dispatch:
 
 jobs:
@@ -32,4 +32,6 @@ jobs:
         continue-on-error: true
       - run: terraform init
       - run: terraform validate -no-color
-      - run: terraform plan -no-color | ../../scripts/redaction.sh
+      - run: |
+          set -o pipefail
+          terraform plan | ../../scripts/redaction.sh


### PR DESCRIPTION
## 👀 Purpose

- To ensure pipe errors propagate to trigger the Slack alert for failing changes

## ♻️ What's changed

- Enabled the [pipefail](https://www.gnu.org/software/bash/manual/bash.html) setting when running terraform plan/apply

## 📝 Notes

- The previous run failed, so I'm expecting the changes to try and re-apply and trigger the alert 🧪 