### PR TITLE
🔧 Attempt to Fix Cost Category Not Creating

### DIFF
--- a/management-account/terraform/cost-categories.tf
+++ b/management-account/terraform/cost-categories.tf
@@ -7,6 +7,7 @@ resource "aws_ce_cost_category" "modernisation_platform" {
   rule_version    = "CostCategoryExpression.v1"
   effective_start = "2024-01-01T00:00:00Z"
   rule {
+    value = "Modernisation Platform"
     rule {
       dimension {
         key           = "LINKED_ACCOUNT"


### PR DESCRIPTION
## 👀 Purpose

- To attempt to fix the Cost Category creation throwing an [error](https://github.com/ministryofjustice/aws-root-account/actions/runs/13076683506/job/36490481910#step:9:1671)

```
│ Error: creating Cost Explorer Cost Category (Modernisation Platform): operation error Cost Explorer: CreateCostCategoryDefinition, https response error StatusCode: 400, RequestID: 2c84bdfe-1321-43cc-9d2b-4fddd0075eef, api error ValidationException: Failed to create Cost Category: Invalid Rule: Value and Rule must not be null.
│ 
│   with aws_ce_cost_category.modernisation_platform,
│   on cost-categories.tf line 5, in resource "aws_ce_cost_category" "modernisation_platform":
│    5: resource "aws_ce_cost_category" "modernisation_platform" {
│ 
╵
Error: Terraform exited with code 1.
```

## ♻️ What's changed

- Added a value for the rule - the [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ce_cost_category) state this is optional but all the examples provided have this 🕵️ So hoping this resolves it 🤞 