### PR TITLE
Add service-area tag

### DIFF
--- a/management-account/terraform/organizations-policy-tags.tf
+++ b/management-account/terraform/organizations-policy-tags.tf
@@ -34,6 +34,11 @@ resource "aws_organizations_policy" "mandatory_tags" {
         ]
       }
     },
+    "service-area": {
+      "tag_key": {
+        ""@@assign": "service-area"
+      }
+    },
     "application": {
       "tag_key": {
         "@@assign": "application"

--- a/management-account/terraform/organizations-policy-tags.tf
+++ b/management-account/terraform/organizations-policy-tags.tf
@@ -36,7 +36,7 @@ resource "aws_organizations_policy" "mandatory_tags" {
     },
     "service-area": {
       "tag_key": {
-        ""@@assign": "service-area"
+        "@@assign": "service-area"
       }
     },
     "application": {


### PR DESCRIPTION
## 👀 Purpose

- This PR adds a new free text tag for `service-area` as a result of changes to [MoJ tagging policy](https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-infrastructure-owners.html).

## ♻️ What's changed

- Add `service-area` tag