### PR TITLE
 #8739-permissions to sync/copy cur report in example account

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -243,6 +243,23 @@ data "aws_iam_policy_document" "cur_reports_s3_bucket" {
       identifiers = ["arn:aws:iam::386209384616:root"]
     }
   }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::moj-cur-reports",
+      "arn:aws:s3:::moj-cur-reports/*"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::083957762049:root"]
+    }
+  }
 }
 
 # moj-cur-reports-quicksight


### PR DESCRIPTION
## A reference to the issue / Description of it
[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739)

Added permissions to enable CUR report objects to be copied in example account for Sopht Greenops PoC

## How has this been tested?

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed