### PR TITLE
#8739 adding object tagging to cur bucket

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -248,6 +248,7 @@ data "aws_iam_policy_document" "cur_reports_s3_bucket" {
     effect = "Allow"
     actions = [
       "s3:GetObject",
+      "s3:GetObjectTagging",
       "s3:ListBucket"
     ]
     resources = [
@@ -325,7 +326,6 @@ data "aws_iam_policy_document" "cur_reports_greenopspoc_s3_policy" {
     effect = "Allow"
     actions = [
       "s3:GetBucketPolicy",
-      "s3:GetObjectTagging",
       "s3:GetBucketAcl"
     ]
     resources = ["arn:aws:s3:::moj-cur-reports-greenopspoc"]

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -325,6 +325,7 @@ data "aws_iam_policy_document" "cur_reports_greenopspoc_s3_policy" {
     effect = "Allow"
     actions = [
       "s3:GetBucketPolicy",
+      "s3:GetObjectTagging",
       "s3:GetBucketAcl"
     ]
     resources = ["arn:aws:s3:::moj-cur-reports-greenopspoc"]


### PR DESCRIPTION
## A reference to the issue / Description of it
[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739)

Added "s3:GetObjectTagging", permissions to enable CUR report objects to be copied in example account for Sopht Greenops PoC

## How has this been tested?

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed