### PR TITLE
🔧 Fix Dynamic Rule Containing Null Value by Filtering Empty Lists

### DIFF
--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -48,7 +48,7 @@ resource "aws_ce_cost_category" "business_unit" {
 
   # Rule 1: Prioritize the `business-unit` Tag for Allocating Cost
   dynamic "rule" {
-    for_each = local.business_units
+    for_each = { for k, v in local.business_units : k => v if length(v.businss_unit_tag_values) > 0 }
     content {
       type  = "REGULAR"
       value = rule.key
@@ -65,7 +65,7 @@ resource "aws_ce_cost_category" "business_unit" {
 
   # Rule 2: If No `business-unit` Tag, Assign Cost Based on the Organizational Unit
   dynamic "rule" {
-    for_each = local.business_units
+    for_each = { for k, v in local.business_units : k => v if length(v.aws_accounts) > 0 }
     content {
       value = rule.key
 


### PR DESCRIPTION
## 👀 Purpose

- Fixes #1090 - [terrorm apply error](https://github.com/ministryofjustice/aws-root-account/actions/runs/13157708009/job/36718548447#step:9:1861)
```
│ Error: updating Cost Explorer Cost Category (arn:aws:ce::***:costcategory/c52f8445-757f-404e-bb15-5009ba09fe15): operation error Cost Explorer: UpdateCostCategoryDefinition, https response error StatusCode: 400, RequestID: 094e90fe-ba46-4752-8417-70dd00d0d082, api error ValidationException: 2 validation errors detected: Value null at 'rules.12.member.rule.dimensions.values' failed to satisfy constraint: Member must not be null; Value null at 'rules.15.member.rule.dimensions.values' failed to satisfy constraint: Member must not be null
│ 
│   with aws_ce_cost_category.business_unit,
│   on cost-categories-business-unit.tf line 43, in resource "aws_ce_cost_category" "business_unit":
│   43: resource "aws_ce_cost_category" "business_unit" {
│ 
╵
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```

## ♻️ What's changed

- Filtered out rules that contain an empty list

## 📝 Notes

- You'll notice that the rule numbers mentioned in the error align with the objects that contain empty AWS accounts in the locals 🕵️ 