### PR TITLE
Add new `business-unit` tag values

### DIFF
--- a/management-account/terraform/organizations-policy-tags.tf
+++ b/management-account/terraform/organizations-policy-tags.tf
@@ -28,6 +28,8 @@ resource "aws_organizations_policy" "mandatory_tags" {
           "HMPPS",
           "OPG",
           "LAA",
+          "Central Digital"
+          "Technology Services"
           "HMCTS",
           "CICA",
           "Platforms"

--- a/management-account/terraform/organizations-policy-tags.tf
+++ b/management-account/terraform/organizations-policy-tags.tf
@@ -28,8 +28,8 @@ resource "aws_organizations_policy" "mandatory_tags" {
           "HMPPS",
           "OPG",
           "LAA",
-          "Central Digital"
-          "Technology Services"
+          "Central Digital",
+          "Technology Services",
           "HMCTS",
           "CICA",
           "Platforms"


### PR DESCRIPTION
## 👀 Purpose

- This PR adds the Business Unit values `Central Digital` and `Technology Services`. These are two missing BUs that are officially recognised. This also aligns us to the same BUs that are defined in Ardoq.

## ♻️ What's changed

- Add `business-unit` value `Central Digital`
- Add `business-unit` value `Technology Services`