### PR TITLE
#8739-removing-acl-from-greenops-cur-bucket

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -317,7 +317,6 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
     effect = "Allow"
     actions = [
       "s3:GetBucketPolicy",
-      "s3:GetBucketAcl"
     ]
     resources = ["arn:aws:s3:::moj-cur-reports-v2-hourly"]
 


### PR DESCRIPTION
## A reference to the issue / Description of it

[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739)

AWS now enforces S3 Bucket Ownership Controls, which disables ACLs by default. Removed ACL's for GreenOps Bucket as ACL's have been deprecated.

## How has this been tested?

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed