### PR TITLE
Add Guarduty Filter for CP Trivy

### DIFF
--- a/organisation-security/terraform/guardduty-filters.tf
+++ b/organisation-security/terraform/guardduty-filters.tf
@@ -1,0 +1,25 @@
+resource "aws_guardduty_filter" "cloud_platform_trivy" {
+  name        = "CloudPlatformTrivy"
+  action      = "ARCHIVE"
+  detector_id = local.guardduty_administrator_detector_ids.eu_west_2
+  rank        = 1
+
+  finding_criteria {
+    criterion {
+      field  = "accountId"
+      equals = [local.cloud_platform_account_id]
+    }
+    criterion {
+      field  = "region"
+      equals = ["eu-west-2"]
+    }
+    criterion {
+      field  = "resource.kubernetesDetails.kubernetesWorkloadDetails.namespace"
+      equals = ["trivy-system"]
+    }
+  }
+  tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -25,6 +25,12 @@ locals {
     if account.name == "moj-network-operations-centre-production"
   ]...)
 
+  cloud_platform_account_id = coalesce([
+    for account in local.organizations_organization.accounts :
+    account.id
+    if account.name == "Cloud Platform"
+  ]...)
+
   organisation_account_numbers = [for account in local.organizations_organization.accounts : account.id]
 
   # AWS Organizational Units


### PR DESCRIPTION
For Trivy to run correctly on the cloud platform, it needs to have permissions which trigger a guarduty alert, flooding our high priority alert channels.  This filter will suppress these specific alerts which are not needed.