### PR TITLE
 #8739 - creating resource that produces cur v2 reports

### DIFF
--- a/management-account/terraform/cost-and-usage-reports.tf
+++ b/management-account/terraform/cost-and-usage-reports.tf
@@ -52,21 +52,3 @@ resource "aws_cur_report_definition" "athena_integration" {
   s3_prefix = "CUR-ATHENA"
 }
 
-
-resource "aws_cur_report_definition" "moj_cur_report" {
-  provider = aws.us-east-1
-
-  report_name                = "MOJ-CUR-V2-HOURLY"
-  time_unit                  = "HOURLY"
-  format                     = "Parquet"
-  compression                = "Parquet"
-  additional_schema_elements = ["RESOURCES", "SPLIT_COST_ALLOCATION_DATA"]
-  additional_artifacts       = ["ATHENA"]
-  report_versioning          = "OVERWRITE_REPORT"
-
-  # S3 configuration
-  s3_bucket = module.cur_reports_v2_hourly_s3_bucket.bucket.bucket
-  s3_region = "eu-west-2"
-  s3_prefix = "moj-cost-and-usage-reports/"
-}
-

--- a/management-account/terraform/data-exports.tf
+++ b/management-account/terraform/data-exports.tf
@@ -1,0 +1,32 @@
+resource "aws_bcmdataexports_export" "moj_cur_report" {
+  export {
+    name = "MOJ-CUR-V2-HOURLY"
+    data_query {
+      query_statement = "SELECT * FROM COST_AND_USAGE_REPORT"
+      table_configurations = {
+        COST_AND_USAGE_REPORT = {
+          TIME_GRANULARITY                      = "HOURLY",
+          INCLUDE_RESOURCES                     = "TRUE",
+          INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY = "TRUE",
+          INCLUDE_SPLIT_COST_ALLOCATION_DATA    = "TRUE",
+        }
+      }
+    }
+    destination_configurations {
+      s3_destination {
+        s3_bucket = module.cur_reports_v2_hourly_s3_bucket.bucket.bucket
+        s3_prefix = "moj-cost-and-usage-reports/"
+        s3_region = "eu-west-2"
+        s3_output_configurations {
+          overwrite   = "OVERWRITE_REPORT"
+          format      = "PARQUET"
+          compression = "PARQUET"
+          output_type = "CUSTOM"
+        }
+      }
+    }
+    refresh_cadence {
+      frequency = "SYNCHRONOUS"
+    }
+  }
+}


### PR DESCRIPTION
## A reference to the issue / Description of it

[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739)

Current Cost and Usage report is producing CUR v1 reports, but we need CUR v2 reports. This PR is to remove the v1 report and produce a report which produces data in the v2 format

## How has this been tested?

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed