### PR TITLE
✨ Add `Technology Services` and `Central Digital` to Business Unit Cost Category

### DIFF
--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -1,7 +1,7 @@
 locals {
   business_units = {
     "Central Digital" = {
-      businss_unit_tag_values = ["Central Digital", "central-digital"]
+      businss_unit_tag_values = ["Central Digital", "central-digital", "CJSE"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.central_digital[*].id
     },
     "CICA" = {
@@ -29,7 +29,7 @@ locals {
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.opg.accounts[*].id
     },
     "Platforms" = {
-      businss_unit_tag_values = ["Platform", "Platforms", "platforms"]
+      businss_unit_tag_values = ["Platforms", "Platform", "platforms"]
       aws_accounts            = []
     },
     "Technology Services" = {

--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -1,5 +1,9 @@
 locals {
   business_units = {
+    "Central Digital" = {
+      businss_unit_tag_values = ["Central Digital", "central-digital"]
+      aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.central_digital[*].id
+    },
     "CICA" = {
       businss_unit_tag_values = ["CICA", "cica"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.cica.accounts[*].id
@@ -27,6 +31,10 @@ locals {
     "Platforms" = {
       businss_unit_tag_values = ["Platform", "Platforms", "platforms"]
       aws_accounts            = []
+    },
+    "Technology Services" = {
+      businss_unit_tag_values = ["Technology Services", "technology-services"]
+      aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.technology_services.accounts[*].id
     },
     "YJB" = {
       businss_unit_tag_values = ["YJB", "yjb"]

--- a/management-account/terraform/cost-categories-data.tf
+++ b/management-account/terraform/cost-categories-data.tf
@@ -2,6 +2,10 @@ data "aws_organizations_organizational_unit_descendant_accounts" "modernisation_
   parent_id = aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id
 }
 
+data "aws_organizations_organizational_unit_descendant_accounts" "central_digital" {
+  parent_id = aws_organizations_organizational_unit.central_digital.id
+}
+
 data "aws_organizations_organizational_unit_descendant_accounts" "hmpps" {
   parent_id = aws_organizations_organizational_unit.hmpps.id
 }
@@ -20,6 +24,10 @@ data "aws_organizations_organizational_unit_descendant_accounts" "cica" {
 
 data "aws_organizations_organizational_unit_descendant_accounts" "hmcts" {
   parent_id = aws_organizations_organizational_unit.hmcts.id
+}
+
+data "aws_organizations_organizational_unit_descendant_accounts" "technology_services" {
+  parent_id = aws_organizations_organizational_unit.technology_services.id
 }
 
 data "aws_organizations_organizational_unit_descendant_accounts" "yjb" {


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/5208
- To align our Business Unit Cost Categories with our [Technical Guidance](https://technical-guidance.service.justice.gov.uk/documentation/standards/documenting-infrastructure-owners.html#mandatory)

## ♻️ What's changed

- Added `Technology Services` and `Central Digital` to Business Unit Cost Category

## 📝 Notes

- Plan might look a bit weird due to rules being added as an ordered list, so adding in new items shifts everything 🙈