### PR TITLE
✨ Add SSO Admin SSO Role to `moj-official-sharedservices-noc` to Access `MOJ Official (Shared Services)`

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -370,6 +370,13 @@ locals {
       ]
     },
     {
+      github_team        = "moj-official-sharedservices-noc",
+      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
+      account_ids = [
+        aws_organizations_account.moj_official_shared_services.id,
+      ]
+    },
+    {
       github_team        = "modernisation-platform-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.aws_sso_read_only.arn,
       account_ids = [


### PR DESCRIPTION
## 👀 Purpose

- In relation to [user request from Slack](https://mojdt.slack.com/archives/C06P4KA0V0A/p1739790913869679)
- To give users admin access to a subset of Tech Services AWS Accounts (MOJ Official (Shared Services))

## ♻️ What's changed

- Assigned `moj-official-sharedservices-noc` the Admin SSO Role to access `MOJ Official (Shared Services)`

## 📝 Notes

- Request came from an existing Administrator of all Tech Services Accounts ✅ 