### PR TITLE
🔧 Fix Missing Property on Cost Category

### DIFF
--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -75,6 +75,7 @@ resource "aws_ce_cost_category" "business_unit" {
   dynamic "rule" {
     for_each = { for k, v in local.business_units : k => v if length(v.aws_accounts) > 0 }
     content {
+      type  = "REGULAR"
       value = rule.key
 
       rule {


### PR DESCRIPTION
## 👀 Purpose

- To fix terraform trying to re-apply a null value for Cost Category Rule Type due to AWS defaulting this value

## ♻️ What's changed

- Added "Regular" to Cost Category Rule

## 📝 Notes

- Example [Plan](https://github.com/ministryofjustice/aws-root-account/actions/runs/13434961245/job/37535073797?pr=1117) where this issues is present