### PR TITLE
bumping Github permissions to run bcm data export

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -138,6 +138,7 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
     actions = [
       "account:*AlternateContact",
       "apigateway:*",
+      "bcm-data-exports:CreateExport",
       "budgets:*",
       "ce:*",
       "cloudtrail:*",


### PR DESCRIPTION
## A reference to the issue / Description of it

[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739)

Bumping Github permissions to run bcm data export inorder to fix the error in the link below,

https://github.com/ministryofjustice/aws-root-account/actions/runs/13438191364/job/37545627677#step:9:1577


## How has this been tested?

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed