### PR TITLE
Adding data exports permissions to the MP Engineering role and Github Actions role

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -252,6 +252,8 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
       "athena:Get*",
       "athena:List*",
       "athena:St*",
+      "bcm-data-exports:ListTagsForResource",
+      "bcm-data-exports:ListExports",
       "aws-marketplace:ViewSubscriptions",
       "cloudwatch:DisableAlarmActions",
       "cloudwatch:EnableAlarmActions",

--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -141,6 +141,7 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
       "bcm-data-exports:CreateExport",
       "bcm-data-exports:GetExport",
       "bcm-data-exports:ListExports",
+      "bcm-data-exports:ListTagsForResource",
       "bcm-data-exports:DeleteExport",
       "bcm-data-exports:UpdateExport",
       "bcm-data-exports:DescribeExport",


### PR DESCRIPTION
## A reference to the issue / Description of it

[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739)

Adding more Github permissions to the Modernisation Platform Engineering role to allow MP Engineers to list data exports in the console and also added permissions to the Github actions role to fix the error below,

https://github.com/ministryofjustice/aws-root-account/actions/runs/13454055896/job/37700541866#step:8:1478

## How has this been tested?

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed