### PR TITLE
Adding data-export permissions to github-actions-plan role

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -59,6 +59,8 @@ data "aws_iam_policy_document" "extra_permissions_plan" {
     effect = "Allow"
     actions = [
       "account:GetAlternateContact",
+      "bcm-data-exports:GetExport",
+      "bcm-data-exports:ListExports",
       "budgets:ListTagsForResource",
       "cur:DescribeReportDefinitions",
       "cur:ListTagsForResource",
@@ -66,7 +68,8 @@ data "aws_iam_policy_document" "extra_permissions_plan" {
       "identitystore:GetGroupId",
       "identitystore:DescribeGroup",
       "logs:ListTagsForResource",
-      "secretsmanager:GetSecretValue",
+      "secretsmanager:GetSecretValue"
+      
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## A reference to the issue / Description of it

[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739)

Adding Data Export permissions to the Github plan role to fix the error below,

https://github.com/ministryofjustice/aws-root-account/actions/runs/13495802753/job/37702701087?pr=1125#step:8:1508

## How has this been tested?

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed