### PR TITLE
Remove `HQ` from `business-unit` tag defaults

### DIFF
--- a/management-account/terraform/organizations-policy-tags.tf
+++ b/management-account/terraform/organizations-policy-tags.tf
@@ -24,7 +24,6 @@ resource "aws_organizations_policy" "mandatory_tags" {
       },
       "tag_value": {
         "@@assign": [
-          "HQ",
           "HMPPS",
           "OPG",
           "LAA",


### PR DESCRIPTION
## 👀 Purpose

- This PR updates the tagging policy to remove the use of `HQ` `business-unit` tag. That value has been replaced by `Central Digital` and `Technology Services` to better reflect the current org and accounting structure. This policy is currently not enforced so does not impact any users.

## ♻️ What's changed

- Remove `HQ` from `business-unit` tag defaults

## 📝 Notes

- [Discussion](https://mojdt.slack.com/archives/CPVD6398C/p1740485700973479)