### PR TITLE
updated S3 file path/prefix for cur v2

### DIFF
--- a/management-account/terraform/data-export.tf
+++ b/management-account/terraform/data-export.tf
@@ -55,7 +55,7 @@ resource "aws_bcmdataexports_export" "moj_cur_v2_report" {
     destination_configurations {
       s3_destination {
         s3_bucket = module.cur_reports_v2_hourly_s3_bucket.bucket.bucket
-        s3_prefix = "moj-cost-and-usage-reports/"
+        s3_prefix = "moj-cost-and-usage-reports"
         s3_region = "eu-west-2"
         s3_output_configurations {
           overwrite   = "OVERWRITE_REPORT"


### PR DESCRIPTION
## A reference to the issue / Description of it

[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739)

Made s3_prefix cleaner for CURv2 data export bucket

## How has this been tested?

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed