### PR TITLE
🔥 Remove Effective Start Date From Cost Categories

### DIFF
--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -45,10 +45,9 @@ import {
 }
 
 resource "aws_ce_cost_category" "business_unit" {
-  name            = "Business Unit"
-  default_value   = "Uncategorised Business Unit"
-  rule_version    = "CostCategoryExpression.v1"
-  effective_start = "2024-02-01T00:00:00Z"
+  name          = "Business Unit"
+  default_value = "Uncategorised Business Unit"
+  rule_version  = "CostCategoryExpression.v1"
 
   # Rule 1: Prioritize the `business-unit` Tag for Allocating Cost
   dynamic "rule" {

--- a/management-account/terraform/cost-categories-cloud-platform.tf
+++ b/management-account/terraform/cost-categories-cloud-platform.tf
@@ -1,7 +1,7 @@
 resource "aws_ce_cost_category" "cloud_platform" {
-  name            = "Cloud Platform"
-  rule_version    = "CostCategoryExpression.v1"
-  effective_start = "2024-01-01T00:00:00Z"
+  name         = "Cloud Platform"
+  rule_version = "CostCategoryExpression.v1"
+
   rule {
     type  = "REGULAR"
     value = "Cloud Platform"

--- a/management-account/terraform/cost-categories-environment.tf
+++ b/management-account/terraform/cost-categories-environment.tf
@@ -1,7 +1,7 @@
 resource "aws_ce_cost_category" "environment" {
-  name            = "Environment"
-  rule_version    = "CostCategoryExpression.v1"
-  effective_start = "2025-01-01T00:00:00Z"
+  name         = "Environment"
+  rule_version = "CostCategoryExpression.v1"
+
   rule {
     type  = "REGULAR"
     value = "Production"
@@ -13,7 +13,6 @@ resource "aws_ce_cost_category" "environment" {
       }
     }
   }
-
 
   rule {
     type  = "REGULAR"

--- a/management-account/terraform/cost-categories-modernisation-platform.tf
+++ b/management-account/terraform/cost-categories-modernisation-platform.tf
@@ -1,7 +1,7 @@
 resource "aws_ce_cost_category" "modernisation_platform" {
-  name            = "Modernisation Platform"
-  rule_version    = "CostCategoryExpression.v1"
-  effective_start = "2024-02-01T00:00:00Z"
+  name         = "Modernisation Platform"
+  rule_version = "CostCategoryExpression.v1"
+
   rule {
     type  = "REGULAR"
     value = "Modernisation Platform"

--- a/management-account/terraform/cost-categories-strategic-hosting-platform.tf
+++ b/management-account/terraform/cost-categories-strategic-hosting-platform.tf
@@ -1,8 +1,7 @@
 resource "aws_ce_cost_category" "strategic_hosting_platform" {
-  name            = "Strategic Hosting Platform"
-  default_value   = "Off Strategic Hosting Platform"
-  rule_version    = "CostCategoryExpression.v1"
-  effective_start = "2024-02-01T00:00:00Z"
+  name          = "Strategic Hosting Platform"
+  default_value = "Off Strategic Hosting Platform"
+  rule_version  = "CostCategoryExpression.v1"
 
   rule {
     type  = "REGULAR"


### PR DESCRIPTION
## 👀 Purpose

- Fixes #1137
- To remove all effective start dates, since having it causes the [apply to fail](https://github.com/ministryofjustice/aws-root-account/actions/runs/13649922570/job/38155974040#step:9:2197) when the rules are amended and the date goes over 12 months in the past 👇 some of these rules are dynamic, so are expected to change over time 

```
╷
│ Error: updating Cost Explorer Cost Category (arn:aws:ce::***:costcategory/c52f8445-757f-404e-bb15-5009ba09fe15): operation error Cost Explorer: UpdateCostCategoryDefinition, https response error StatusCode: 400, RequestID: 3d24ad13-8ea6-48fa-a9a8-7390d189fb19, api error ValidationException: Failed to update Cost Category: Effective start cannot be more than 12 months ago
│ 
│   with aws_ce_cost_category.business_unit,
│   on cost-categories-business-unit.tf line 47, in resource "aws_ce_cost_category" "business_unit":
│   47: resource "aws_ce_cost_category" "business_unit" {
│ 
╵
╷
│ Error: updating Cost Explorer Cost Category (arn:aws:ce::***:costcategory/e5bd64e3-7b3c-4ee8-aff1-a555860e44b8): operation error Cost Explorer: UpdateCostCategoryDefinition, https response error StatusCode: 400, RequestID: 47fee610-8bf5-44ff-958e-d8f659324cc1, api error ValidationException: Failed to update Cost Category: Effective start cannot be more than 12 months ago
│ 
│   with aws_ce_cost_category.modernisation_platform,
│   on cost-categories-modernisation-platform.tf line 1, in resource "aws_ce_cost_category" "modernisation_platform":
│    1: resource "aws_ce_cost_category" "modernisation_platform" {
│ 
╵
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```

## ♻️ What's changed

- Removed all effective start dates from Cost Categories