### PR TITLE
✨ Add Recent Effective Start Date to Modernisation Platform and Business Unit

### DIFF
--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -45,9 +45,10 @@ import {
 }
 
 resource "aws_ce_cost_category" "business_unit" {
-  name          = "Business Unit"
-  default_value = "Uncategorised Business Unit"
-  rule_version  = "CostCategoryExpression.v1"
+  name            = "Business Unit"
+  default_value   = "Uncategorised Business Unit"
+  rule_version    = "CostCategoryExpression.v1"
+  effective_start = "2025-02-01T00:00:00Z"
 
   # Rule 1: Prioritize the `business-unit` Tag for Allocating Cost
   dynamic "rule" {

--- a/management-account/terraform/cost-categories-modernisation-platform.tf
+++ b/management-account/terraform/cost-categories-modernisation-platform.tf
@@ -1,6 +1,7 @@
 resource "aws_ce_cost_category" "modernisation_platform" {
-  name         = "Modernisation Platform"
-  rule_version = "CostCategoryExpression.v1"
+  name            = "Modernisation Platform"
+  rule_version    = "CostCategoryExpression.v1"
+  effective_start = "2025-02-01T00:00:00Z"
 
   rule {
     type  = "REGULAR"


### PR DESCRIPTION
## 👀 Purpose

- Fixes #1138 and #1137 
- Adds explicit start date due to terraform ignoring it's removal and still applying the old value

## ♻️ What's changed

- Added Recent Effective Start Date to Modernisation Platform and Business Unit