### PR TITLE
✨ Add Tagged Accounts to Business Unit Cost Allocation

### DIFF
--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -1,40 +1,63 @@
+data "awscc_organizations_accounts" "all" {}
+
+data "awscc_organizations_account" "all" {
+  for_each = data.awscc_organizations_accounts.all.ids
+  id       = each.value
+}
+
 locals {
   business_units = {
     "Central Digital" = {
       businss_unit_tag_values = ["Central Digital", "central-digital", "CJSE"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.central_digital.accounts[*].id
+      tagged_aws_accounts     = []
     },
     "CICA" = {
       businss_unit_tag_values = ["CICA", "cica"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.cica.accounts[*].id
+      tagged_aws_accounts     = []
     },
     "HMCTS" = {
       businss_unit_tag_values = ["HMCTS"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.hmcts.accounts[*].id
+      tagged_aws_accounts     = []
     },
     "HMPPS" = {
       businss_unit_tag_values = ["HMPPS", "hmpps"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.hmpps.accounts[*].id
+      tagged_aws_accounts = [
+        for k, v in data.awscc_organizations_account.all :
+        v.id
+        if one(flatten([
+          for tag in coalesce(v.tags, []) :
+          tag.value if tag.key == "business-unit"
+        ])) == "HMPPS"
+      ]
     },
     "LAA" = {
       businss_unit_tag_values = ["LAA", "laa", "legal-aid-agency"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.laa.accounts[*].id
+      tagged_aws_accounts     = []
     },
     "OPG" = {
       businss_unit_tag_values = ["OPG", "opg"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.opg.accounts[*].id
+      tagged_aws_accounts     = []
     },
     "Platforms" = {
       businss_unit_tag_values = ["Platforms", "Platform", "platforms"]
       aws_accounts            = []
+      tagged_aws_accounts     = []
     },
     "Technology Services" = {
       businss_unit_tag_values = ["Technology Services", "technology-services"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.technology_services.accounts[*].id
+      tagged_aws_accounts     = []
     },
     "YJB" = {
       businss_unit_tag_values = ["YJB", "yjb"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.yjb.accounts[*].id
+      tagged_aws_accounts     = []
     },
   }
 }
@@ -50,7 +73,7 @@ resource "aws_ce_cost_category" "business_unit" {
   rule_version    = "CostCategoryExpression.v1"
   effective_start = "2025-02-01T00:00:00Z"
 
-  # Rule 1: Prioritize the `business-unit` Tag for Allocating Cost
+  # Rule 1: Prioritize the Resources `business-unit` Tag for Allocating Cost
   dynamic "rule" {
     for_each = { for k, v in local.business_units : k => v if length(v.businss_unit_tag_values) > 0 }
     content {
@@ -67,7 +90,24 @@ resource "aws_ce_cost_category" "business_unit" {
     }
   }
 
-  # Rule 2: If No `business-unit` Tag, Assign Cost Based on the Organizational Unit
+  # Rule 2: If No Resource `business-unit` Tag, Assign Cost Based on the Account `business-unit` Tag
+  dynamic "rule" {
+    for_each = { for k, v in local.business_units : k => v if length(v.tagged_aws_accounts) > 0 }
+    content {
+      type  = "REGULAR"
+      value = rule.key
+
+      rule {
+        dimension {
+          key           = "LINKED_ACCOUNT"
+          values        = rule.value.tagged_aws_accounts
+          match_options = ["EQUALS"]
+        }
+      }
+    }
+  }
+
+  # Rule 3: If No `business-unit` Tag, Assign Cost Based on the Organizational Unit
   dynamic "rule" {
     for_each = { for k, v in local.business_units : k => v if length(v.aws_accounts) > 0 }
     content {

--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -28,10 +28,10 @@ locals {
       tagged_aws_accounts = [
         for k, v in data.awscc_organizations_account.all :
         v.id
-        if one(flatten([
+        if contains(["HMPPS", "hmpps"], try(one(flatten([
           for tag in coalesce(v.tags, []) :
           tag.value if tag.key == "business-unit"
-        ])) == "HMPPS"
+        ])), ""))
       ]
     },
     "LAA" = {

--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -20,49 +20,47 @@ locals {
     "Central Digital" = {
       businss_unit_tag_values = ["Central Digital", "central-digital", "CJSE"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.central_digital.accounts[*].id
-      tagged_aws_accounts     = []
+      tagged_aws_accounts     = [for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["Central Digital", "central-digital", "CJSE"], v.business_unit)]
     },
     "CICA" = {
       businss_unit_tag_values = ["CICA", "cica"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.cica.accounts[*].id
-      tagged_aws_accounts     = []
+      tagged_aws_accounts     = [for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["CICA", "cica"], v.business_unit)]
     },
     "HMCTS" = {
       businss_unit_tag_values = ["HMCTS"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.hmcts.accounts[*].id
-      tagged_aws_accounts     = []
+      tagged_aws_accounts     = [for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["HMCTS"], v.business_unit)]
     },
     "HMPPS" = {
       businss_unit_tag_values = ["HMPPS", "hmpps"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.hmpps.accounts[*].id
-      tagged_aws_accounts = [
-        for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["HMPPS", "hmpps"], v.business_unit)
-      ]
+      tagged_aws_accounts     = [for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["HMPPS", "hmpps"], v.business_unit)]
     },
     "LAA" = {
       businss_unit_tag_values = ["LAA", "laa", "legal-aid-agency"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.laa.accounts[*].id
-      tagged_aws_accounts     = []
+      tagged_aws_accounts     = [for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["LAA", "laa", "legal-aid-agency"], v.business_unit)]
     },
     "OPG" = {
       businss_unit_tag_values = ["OPG", "opg"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.opg.accounts[*].id
-      tagged_aws_accounts     = []
+      tagged_aws_accounts     = [for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["OPG", "opg"], v.business_unit)]
     },
     "Platforms" = {
       businss_unit_tag_values = ["Platforms", "Platform", "platforms"]
       aws_accounts            = []
-      tagged_aws_accounts     = []
+      tagged_aws_accounts     = [for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["Platforms", "Platform", "platforms"], v.business_unit)]
     },
     "Technology Services" = {
       businss_unit_tag_values = ["Technology Services", "technology-services"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.technology_services.accounts[*].id
-      tagged_aws_accounts     = []
+      tagged_aws_accounts     = [for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["Technology Services", "technology-services"], v.business_unit)]
     },
     "YJB" = {
       businss_unit_tag_values = ["YJB", "yjb"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.yjb.accounts[*].id
-      tagged_aws_accounts     = []
+      tagged_aws_accounts     = [for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["YJB", "yjb"], v.business_unit)]
     },
   }
 }

--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -36,9 +36,7 @@ locals {
       businss_unit_tag_values = ["HMPPS", "hmpps"]
       aws_accounts            = data.aws_organizations_organizational_unit_descendant_accounts.hmpps.accounts[*].id
       tagged_aws_accounts = [
-        for k, v in local.all_aws_accounts_with_business_unit_tag :
-        v.id
-        if v.business_unit == "HMPPS"
+        for k, v in local.all_aws_accounts_with_business_unit_tag : v.id if contains(["HMPPS", "hmpps"], v.business_unit)
       ]
     },
     "LAA" = {

--- a/management-account/terraform/cost-categories-business-unit.tf
+++ b/management-account/terraform/cost-categories-business-unit.tf
@@ -10,10 +10,10 @@ locals {
     for k, v in data.awscc_organizations_account.all :
     k => {
       "id" = v.id
-      "business_unit" = one(flatten([
+      "business_unit" = coalesce(one(flatten([
         for tag in coalesce(v.tags, []) :
         tag.value if tag.key == "business-unit"
-      ]))
+      ])), "Uncategorised Business Unit") # 👈 coalesce() needs a non-empty string and we don't want to return null because we want to use the value with contains()
     }
   }
   business_units = {

--- a/management-account/terraform/cost-categories-data.tf
+++ b/management-account/terraform/cost-categories-data.tf
@@ -1,5 +1,3 @@
-data "aws_organizations_organization" "all" {}
-
 data "aws_organizations_organizational_unit_descendant_accounts" "modernisation_platform" {
   parent_id = aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id
 }

--- a/management-account/terraform/cost-categories-data.tf
+++ b/management-account/terraform/cost-categories-data.tf
@@ -1,3 +1,5 @@
+data "aws_organizations_organization" "all" {}
+
 data "aws_organizations_organizational_unit_descendant_accounts" "modernisation_platform" {
   parent_id = aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id
 }

--- a/management-account/terraform/providers.tf
+++ b/management-account/terraform/providers.tf
@@ -4,6 +4,10 @@ provider "aws" {
   region = "eu-west-2"
 }
 
+provider "awscc" {
+  region = "eu-west-2"
+}
+
 # us-* providers
 
 provider "aws" {

--- a/management-account/terraform/versions.tf
+++ b/management-account/terraform/versions.tf
@@ -5,5 +5,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = "~> 1.31.0"
+    }
+
   }
 }


### PR DESCRIPTION
## 👀 Purpose

- To gain better insights to cost allocation based on existing data via Cost Categories

## ♻️ What's changed

- Added the awscc provider to enable easier access to account data with tags
- Added a new rule to the Business Unit Cost Category that will associate costs based on the business-unit tag of the AWS Account

## 📝 Notes

- I chose to go with the awscc provider since the was provider doesn't offer a data source with both the account IDs and the Tag Values (but I'd be happy for someone to take a second look and correct me 😁) - or if someone could suggest an alternative approach that looks a bit cleaner I'd be all for it! 🥳  