### PR TITLE
Updating split cost to true to enable reporting on Kubernetes resources

### DIFF
--- a/management-account/terraform/data-export.tf
+++ b/management-account/terraform/data-export.tf
@@ -48,7 +48,7 @@ resource "aws_bcmdataexports_export" "moj_cur_v2_report" {
           TIME_GRANULARITY                      = "HOURLY",
           INCLUDE_RESOURCES                     = "TRUE",
           INCLUDE_MANUAL_DISCOUNT_COMPATIBILITY = "FALSE",
-          INCLUDE_SPLIT_COST_ALLOCATION_DATA    = "FALSE",
+          INCLUDE_SPLIT_COST_ALLOCATION_DATA    = "TRUE",
         }
       }
     }


### PR DESCRIPTION
## A reference to the issue / Description of it

[#8739](https://github.com/ministryofjustice/modernisation-platform/issues/8739)

Updating split cost to true to enable reporting on Kubernetes resources

## How has this been tested?

See unit tests below.

## Checklist (check `x` in `[ ]` of list items)

- [x] I have performed a self-review of my own code
- [x] All checks have passed