### PR TITLE
add get object tagging perm to bucket policy

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -369,7 +369,8 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
     effect = "Allow"
     actions = [
       "s3:GetObject",
-      "s3:ListBucket"
+      "s3:ListBucket",
+      "s3:GetObjectTagging"
     ]
     resources = [
       "arn:aws:s3:::moj-cur-reports-v2-hourly",


### PR DESCRIPTION
s3 datasync to copy data from root account cur v2 bucket to bucket in ops-eng-dev MP account is currently failing due to lack of GetObjectTagging permission. This PR aims to rectify this issue.