### PR TITLE
Permissions for S3 data transfer

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -379,25 +379,7 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::211125434264:root"]
-    }
-  }
-
-    statement {
-    effect = "Allow"
-    actions = [
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:GetObjectTagging"
-    ]
-    resources = [
-      "arn:aws:s3:::moj-cur-reports-v2-hourly",
-      "arn:aws:s3:::moj-cur-reports-v2-hourly/*"
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::279191903737:root"]
+      identifiers = ["arn:aws:iam::211125434264:root", "arn:aws:iam::279191903737:root"]
     }
   }
 }

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -382,4 +382,22 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
       identifiers = ["arn:aws:iam::211125434264:root"]
     }
   }
+
+    statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:GetObjectTagging"
+    ]
+    resources = [
+      "arn:aws:s3:::moj-cur-reports-v2-hourly",
+      "arn:aws:s3:::moj-cur-reports-v2-hourly/*"
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::279191903737:root"]
+    }
+  }
 }


### PR DESCRIPTION
Give coat production account permissions to read from cur v2 hourly s3 bucket for s3 data transfer.