### PR TITLE
Create bucket for storage of XDR/XSIAM templates

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -383,3 +383,10 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
     }
   }
 }
+
+# moj-xdr-template-storage
+module "xdr_template_storage" {
+  source          = "../../modules/s3"
+  additional_tags = local.root_account
+  bucket_prefix   = "xdr_template_storage"
+}

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -14,8 +14,7 @@ resource "aws_s3_bucket" "default" {
 # Bucket ACL #
 ##############
 resource "aws_s3_bucket_acl" "default" {
-  depends_on = [aws_s3_bucket_ownership_controls.default]
-
+  count = var.object_ownership == "BucketOwnerEnforced" ? 0 : 1
   bucket = aws_s3_bucket.default.id
   acl    = var.bucket_acl
 }


### PR DESCRIPTION
This bucket will allow private storage of templates for Palo Alto XDR/XSIAM which can then be used to deploy the templates across the MOJ AWS Organization.

More discussion can be seen on Slack [here](https://mojdt.slack.com/archives/C06P4KA0V0A/p1743504574345829).

We don't see a lot of value in either storing the templates in GitHub or reinterpreting them into Terraform, but should we change to this approach then this bucket ought to be removed.

I've also updated the S3 module to make bucket ACLs conditional, and only created when `BucketOwnerEnforced` is **not** set which should resolve #1068 