### PR TITLE
Export cur v2 into coat production account s3 bucket

### DIFF
--- a/management-account/terraform/data-export.tf
+++ b/management-account/terraform/data-export.tf
@@ -57,7 +57,7 @@ resource "aws_bcmdataexports_export" "moj_cur_v2_report" {
     }
     destination_configurations {
       s3_destination {
-        s3_bucket = module.cur_reports_v2_hourly_s3_bucket.bucket.bucket
+        s3_bucket = "coat-production-cur-v2-hourly"
         s3_prefix = "moj-cost-and-usage-reports"
         s3_region = "eu-west-2"
         s3_output_configurations {


### PR DESCRIPTION
- We want to send the CUR v2 data export into out team COAT production account so we can take ownership of this data and be able to easily analyse it.