### PR TITLE
Replace underscores in S3 bucket name

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -384,9 +384,9 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
   }
 }
 
-# moj-xdr-template-storage
-module "xdr_template_storage" {
+# cf-template-storage
+module "cf_template_storage" {
   source          = "../../modules/s3"
   additional_tags = local.root_account
-  bucket_prefix   = "xdr_template_storage"
+  bucket_prefix   = "cf-template-storage"
 }


### PR DESCRIPTION
Underscores aren't allowed in S3 bucket names, only hyphens and alphanumeric lowercase characters.

This PR fixes the incorrect name of the template storage bucket and adjusts the bucket name slightly in case future cloudformation templates need a place to stay.