### PR TITLE
Add scripts for bulk root account email update

### DIFF
--- a/scripts/bulk-account-email-update/README.md
+++ b/scripts/bulk-account-email-update/README.md
@@ -52,5 +52,5 @@ The scripts in this folder can be used to update the aws account root account em
 2. Run `./request_update_mp_emails.sh`- this will start the process and multiple emails will be sent to `aws@digital.justice.gov.uk` with an OTP for each account.
     - You will need admin credentials for `moj-master` `Administrator Access` set in your env
 3. Run the `gmail-reader.py` script - this will update `aws_mp_accounts.csv` with the OTPs
-    - You will need to have a suitable python environment set up and have the dependencies insttaled in `requirements.txt`
+    - You will need to have a suitable python environment set up and have the dependencies installed in `requirements.txt`
 4. Run the `./accept_update_mp_accounts.sh` - this will confirm the account email change and multiple emails will be sent to `aws@digital.justice.gov.uk`to confirm

--- a/scripts/bulk-account-email-update/README.md
+++ b/scripts/bulk-account-email-update/README.md
@@ -1,0 +1,56 @@
+
+## Scripts to bulk update root account emails
+
+The scripts in this folder can be used to update the aws account root account emails in bulk. This was used as part of issue [#9527](https://github.com/ministryofjustice/modernisation-platform/issues/9527) where we needed to remove the additional `+mp` tag in our emails which would not have been compatible with o365.
+
+##### Notes
+
+- This was performed as an ad-hoc local operation. We do not expect to repeat this process but we are leaving the code here just in case it's useful in future.
+
+- As the name suggests the `gmail-reader.py` script will only work for gmail. In future we will be migrating to o365. A similar Microsoft API might be able to be utilised but this would require a major update to this script.
+
+- All the other scripts are also focused on targetting emails with `+mp` in them but this regex could be easily updated as needed.
+
+## Pre-requisites
+
+1. To do this you will need `Administrator Access` to the `moj-master` account so that you have the relevant credentials/permissions to perform `account:accept-primary-email-update` and `account:start-primary-email-update`.
+
+2. You will need to be granted access to the `aws@digital.justice.gov.uk` gmail group so that the emails are sent to your inbox.
+
+3. You'll need to set up credentials to allow Google to access your inbox as follows:
+
+
+    ##### Step 1: Enable Gmail API for Your Personal Account
+
+    - Go to the Google Cloud Console.
+    - Click Select a project (top bar) → New Project.
+    - Name the project (e.g., Gmail API Access) → Click Create.
+    - In the left menu, go to APIs & Services > Library.
+    - Search for "Gmail API" → Click Enable.
+
+    ##### Step 2: Create OAuth Credentials for Your Personal Inbox
+    - Go to APIs & Services > Credentials.
+    - Click Create Credentials → Select OAuth Client ID.
+    - If prompted, configure the OAuth Consent Screen:
+    - Choose External (even in a Workspace environment).
+    - Fill in App Name (e.g., "Gmail OTP Extractor").
+    - Use your email for the User Support Email and Developer Contact Info.
+    - Click Save & Continue.
+    - Under Scopes, click "Add or Remove Scopes", then add: `https://www.googleapis.com/auth/gmail.readonly`
+    - Click Save & Continue.
+    - Under Test Users, add your own email.
+    - Click Save & Continue → Click Back to Dashboard.
+
+    ##### Step 3: Download credentials.json
+    - Go to APIs & Services > Credentials.
+    - Under "OAuth 2.0 Client IDs", find your Desktop App.
+    - Click Download JSON and save it as credentials.json in your script directory.
+
+## Usage guide
+
+1. First run `./find_mp_accounts.sh` - this will produce a csv with all matching accounts called `aws_mp_accounts.csv`
+2. Run `./request_update_mp_emails.sh`- this will start the process and multiple emails will be sent to `aws@digital.justice.gov.uk` with an OTP for each account.
+    - You will need admin credentials for `moj-master` `Administrator Access` set in your env
+3. Run the `gmail-reader.py` script - this will update `aws_mp_accounts.csv` with the OTPs
+    - You will need to have a suitable python environment set up and have the dependencies insttaled in `requirements.txt`
+4. Run the `./accept_update_mp_accounts.sh` - this will confirm the account email change and multiple emails will be sent to `aws@digital.justice.gov.uk`to confirm

--- a/scripts/bulk-account-email-update/README.md
+++ b/scripts/bulk-account-email-update/README.md
@@ -1,15 +1,12 @@
 
-## Scripts to bulk update root account emails
+# Scripts to bulk update root account emails
 
 The scripts in this folder can be used to update the aws account root account emails in bulk. This was used as part of issue [#9527](https://github.com/ministryofjustice/modernisation-platform/issues/9527) where we needed to remove the additional `+mp` tag in our emails which would not have been compatible with o365.
 
-##### Notes
-
-- This was performed as an ad-hoc local operation. We do not expect to repeat this process but we are leaving the code here just in case it's useful in future.
-
-- As the name suggests the `gmail-reader.py` script will only work for gmail. In future we will be migrating to o365. A similar Microsoft API might be able to be utilised but this would require a major update to this script.
-
-- All the other scripts are also focused on targetting emails with `+mp` in them but this regex could be easily updated as needed.
+>**Notes**
+>-  This was performed as an ad-hoc local operation. We do not expect to repeat this process but we are leaving the code here just in case it's useful in future.
+>- As the name suggests the `gmail-reader.py` script will only work for gmail. In future we will be migrating to o365. A similar Microsoft API might be able to be utilised but this would require a major update to this script.
+>- All the other scripts are also focused on targetting emails with `+mp` in them but this regex could be easily updated as needed.
 
 ## Pre-requisites
 
@@ -20,7 +17,7 @@ The scripts in this folder can be used to update the aws account root account em
 3. You'll need to set up credentials to allow Google to access your inbox as follows:
 
 
-    ##### Step 1: Enable Gmail API for Your Personal Account
+    **Step 1: Enable Gmail API for Your Personal Account**
 
     - Go to the Google Cloud Console.
     - Click Select a project (top bar) → New Project.
@@ -28,7 +25,7 @@ The scripts in this folder can be used to update the aws account root account em
     - In the left menu, go to APIs & Services > Library.
     - Search for "Gmail API" → Click Enable.
 
-    ##### Step 2: Create OAuth Credentials for Your Personal Inbox
+    **Step 2: Create OAuth Credentials for Your Personal Inbox**
     - Go to APIs & Services > Credentials.
     - Click Create Credentials → Select OAuth Client ID.
     - If prompted, configure the OAuth Consent Screen:
@@ -41,7 +38,7 @@ The scripts in this folder can be used to update the aws account root account em
     - Under Test Users, add your own email.
     - Click Save & Continue → Click Back to Dashboard.
 
-    ##### Step 3: Download credentials.json
+    **Step 3: Download credentials.json**
     - Go to APIs & Services > Credentials.
     - Under "OAuth 2.0 Client IDs", find your Desktop App.
     - Click Download JSON and save it as credentials.json in your script directory.

--- a/scripts/bulk-account-email-update/accept_update_mp_emails.sh
+++ b/scripts/bulk-account-email-update/accept_update_mp_emails.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# Script to accept the root email address change of mp accounts
+
+# CSV filename
+csv_file="aws_mp_accounts.csv"
+
+# Loop through each line in the CSV file and run aws account accept-primary-email-update using the OTP and wait 5 seconds
+while IFS=',' read -r account_id current_email new_email name otp; do
+    # Skip the header line
+    if [[ "$account_id" == "AccountID" ]]; then
+        continue
+    fi
+
+   # Remove quotes and any whitespace from the fields
+    account_id=$(echo "$account_id" | tr -d '"' | tr -d ' ')
+    current_email=$(echo "$current_email" | tr -d '"' | tr -d ' ')
+    new_email=$(echo "$new_email" | tr -d '"' | tr -d ' ')
+    name=$(echo "$name" | tr -d '"' | tr -d ' ')
+    otp=$(echo "$otp" | tr -d '"' | tr -d ' ' | tr -d '\r' | tr -d '\n')
+
+    # Validate OTP format
+    if ! [[ "$otp" =~ ^[A-Za-z0-9]{6}$ ]]; then
+        echo "Error: Invalid OTP format for $name: '$otp'"
+        continue
+    fi
+
+    # Run the command to accept the email address change
+    echo "Accepting email update for $name with OTP: $otp"
+    aws account accept-primary-email-update --account-id "$account_id" --otp "$otp" --primary-email "$new_email" --no-cli-pager
+
+    # Wait for 5 seconds before the next iteration
+    sleep 5
+done < "$csv_file"

--- a/scripts/bulk-account-email-update/find_mp_accounts.sh
+++ b/scripts/bulk-account-email-update/find_mp_accounts.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+# Script to find AWS accounts with "+mp" in root email and display in table format
+# Shows both current email and new email without the "+mp" part
+# Excludes suspended accounts and outputs results to Excel-compatible CSV file
+# Requirements: AWS CLI, jq, and appropriate AWS permissions
+
+# Check for required dependencies
+if ! command -v aws &> /dev/null; then
+    echo "Error: AWS CLI is not installed or not in PATH"
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed or not in PATH"
+    exit 1
+fi
+
+# CSV filename
+csv_file="aws_mp_accounts.csv"
+
+# Create CSV header with special format for Excel
+echo "AccountID,Current Email,New Email,Name,OTP" > "$csv_file"
+
+# Store results in a temporary file to avoid subshell issues
+temp_results=$(mktemp)
+
+# List all accounts in the organization and save to temp file
+# Filter for accounts that have "+mp" in email AND are not suspended
+aws organizations list-accounts | \
+jq -r '.Accounts[] | select(.Email | contains("+mp")) | select(.Status != "SUSPENDED") | 
+    [.Id, .Email, .Name] | @tsv' > "$temp_results"
+
+# Process results for display and CSV output
+while IFS=$'\t' read -r account_id email name; do
+    # Create the new email by removing "+mp" part
+    # This handles both user+mp@domain.com and user+mp+something@domain.com formats
+    new_email=$(echo "$email" | sed 's/\(.*\)\+mp\(.*\)@\(.*\)/\1\2@\3/')
+    
+    # Add to CSV with special format for the account ID to prevent Excel from converting it to scientific notation
+    echo "\"$account_id\",\"$email\",\"$new_email\",\"$name\"" >> "$csv_file"
+    
+    # Increment counter
+    ((count++))
+done < "$temp_results"
+
+# Sort the CSV file by the "Name" column (4th column) in ascending order
+header=$(head -n 1 "$csv_file")
+tail -n +2 "$csv_file" | sort -t, -k4,4 > "${csv_file}.sorted"
+echo "$header" > "$csv_file"
+cat "${csv_file}.sorted" >> "$csv_file"
+rm "${csv_file}.sorted"
+
+# Calculate total
+total=$((count - 1))
+
+# Clean up
+rm "$temp_results"
+
+echo "Search complete. Found $total active accounts with '+mp' in email."
+echo "Results saved to $csv_file"

--- a/scripts/bulk-account-email-update/gmail-reader.py
+++ b/scripts/bulk-account-email-update/gmail-reader.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     gmail_service = authenticate_gmail()
 
     # Path to the CSV file
-    csv_file_path = '/Users/richard.green/Desktop/account-email-update/aws_mp_accounts.csv'
+    csv_file_path = './aws_mp_accounts.csv'
 
     # Fetch OTPs and update the CSV file
     get_otp_from_emails(gmail_service, csv_file_path)

--- a/scripts/bulk-account-email-update/gmail-reader.py
+++ b/scripts/bulk-account-email-update/gmail-reader.py
@@ -1,0 +1,121 @@
+import base64
+from bs4 import BeautifulSoup
+import csv
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+import re
+
+# Define Gmail API scope
+SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
+
+def authenticate_gmail():
+    """Authenticate and return the Gmail API service"""
+    flow = InstalledAppFlow.from_client_secrets_file("credentials.json", SCOPES)
+    creds = flow.run_local_server(port=0)
+    return build("gmail", "v1", credentials=creds)
+
+def extract_body(payload):
+    """Recursively extract the plain text or HTML body from the email payload."""
+    if "parts" in payload:
+        for part in payload["parts"]:
+            if part.get("mimeType") == "text/plain":
+                body_data = part.get("body", {}).get("data", "")
+                return base64.urlsafe_b64decode(body_data).decode("utf-8")
+            elif part.get("mimeType") == "text/html":
+                body_data = part.get("body", {}).get("data", "")
+                html_content = base64.urlsafe_b64decode(body_data).decode("utf-8")
+                # Parse HTML and extract text
+                soup = BeautifulSoup(html_content, "html.parser")
+                return soup.get_text()
+            elif "parts" in part:
+                # Recursively check nested parts
+                result = extract_body(part)
+                if result:
+                    return result
+    return ""
+
+def update_otp(file_path, email, otp):
+    """Update the OTP column in the CSV file for the given email."""
+    rows = []
+    updated = False
+    with open(file_path, mode='r', newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        fieldnames = reader.fieldnames
+        for row in reader:
+            if row['Current Email'] == email or row['New Email'] == email:
+                row['OTP'] = otp  # Update the OTP column
+                updated = True
+            rows.append(row)
+
+    with open(file_path, mode='w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    if updated:
+        print(f"CSV updated for Email: {email}, OTP: {otp}")
+    else:
+        print(f"Email not found in CSV: {email}")
+
+def get_otp_from_emails(service, csv_file_path):
+    """Fetch OTPs and recipient email addresses from AWS verification emails and update the CSV file."""
+    query = 'subject:"Verify the new email address for the AWS account root user"'
+    
+    # Initialize variables for pagination
+    next_page_token = None
+    all_messages = []
+    
+    # Fetch all messages using pagination
+    while True:
+        results = service.users().messages().list(
+            userId="me",
+            q=query,
+            pageToken=next_page_token,
+            maxResults=500  # Increase max results per page
+        ).execute()
+        
+        if 'messages' in results:
+            all_messages.extend(results['messages'])
+        
+        # Check if there are more pages
+        next_page_token = results.get('nextPageToken')
+        if not next_page_token:
+            break
+    
+    print(f"Found {len(all_messages)} messages.")
+
+    for msg in all_messages:
+        msg_id = msg["id"]
+        msg_data = service.users().messages().get(userId="me", id=msg_id, format="full").execute()
+        payload = msg_data.get("payload", {})
+
+        # Extract email body
+        body = extract_body(payload)
+
+        # Normalize the email body
+        normalized_body = body.replace("\r\n", " ").strip()
+        normalized_body = re.sub(r"\s+", " ", normalized_body)  # Collapse multiple spaces into one
+
+        # Extract recipient email address from the body
+        email_match = re.search(r"to use your email address \(([^)]+)\)", normalized_body)
+        recipient_email = email_match.group(1) if email_match else None
+
+        # Extract OTP from email body
+        otp_match = re.search(r"please use the following code to verify your email address:\s*(\d{6})\.", normalized_body)
+        otp = otp_match.group(1) if otp_match else None
+
+        if recipient_email and otp:
+            print(f"Processing Email: {recipient_email}, OTP: {otp}")
+            update_otp(csv_file_path, recipient_email, otp)  # Update the CSV file
+        else:
+            print(f"Failed to extract OTP or email from message ID: {msg_id}")
+
+if __name__ == "__main__":
+    # Authenticate with Gmail API
+    gmail_service = authenticate_gmail()
+
+    # Path to the CSV file
+    csv_file_path = '/Users/richard.green/Desktop/account-email-update/aws_mp_accounts.csv'
+
+    # Fetch OTPs and update the CSV file
+    get_otp_from_emails(gmail_service, csv_file_path)

--- a/scripts/bulk-account-email-update/request_update_mp_emails.sh
+++ b/scripts/bulk-account-email-update/request_update_mp_emails.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+# Script to update the root email address of AWS accounts
+
+# CSV filename
+csv_file="aws_mp_accounts.csv"
+
+# Loop through each line in the CSV file and run aws account start-primary-email-update command and wait 5 seconds
+while IFS=',' read -r account_id current_email new_email name otp; do
+    # Skip the header line
+    if [[ "$account_id" == "AccountID" ]]; then
+        continue
+    fi
+
+    # Remove quotes from the fields
+    account_id=$(echo "$account_id" | sed 's/^"//;s/"$//')
+    current_email=$(echo "$current_email" | sed 's/^"//;s/"$//')
+    new_email=$(echo "$new_email" | sed 's/^"//;s/"$//')
+    name=$(echo "$name" | sed 's/^"//;s/"$//')
+    otp=$(echo "$otp" | sed 's/^"//;s/"$//')
+
+    # Print command to show which account email is being updated
+    printf "Requesting email update for: $name\nNew email: $new_email\n--------------\n"
+
+    # Run the command to update the email address
+    aws account start-primary-email-update --account-id "$account_id" --primary-email "$new_email" --no-cli-pager
+
+    # Wait for 5 seconds before the next iteration
+    sleep 5
+done < "$csv_file"

--- a/scripts/bulk-account-email-update/requirements.txt
+++ b/scripts/bulk-account-email-update/requirements.txt
@@ -1,0 +1,4 @@
+bs4
+google-auth-httplib2 
+google-auth-oauthlib
+google-api-python-client


### PR DESCRIPTION
## Issue

https://github.com/ministryofjustice/modernisation-platform/issues/9527 - bulk update of root account emails for MP

## What's changed

I've added the scripts which I used as part of issue [#9527](https://github.com/ministryofjustice/modernisation-platform/issues/9527) where we needed to remove the additional `+mp` tag in our emails which would not have been compatible with o365.

This was performed as an ad-hoc local operation. We do not expect to repeat this process but I'm leaving the code here just in case it's useful in future.