### PR TITLE
Deploy `cf-template` bucket to org-security account

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -383,10 +383,3 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
     }
   }
 }
-
-# cf-template-storage
-module "cf_template_storage" {
-  source          = "../../modules/s3"
-  additional_tags = local.root_account
-  bucket_prefix   = "cf-template-storage"
-}

--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -18,6 +18,13 @@ resource "random_integer" "suffix" {
   max = 90000000000
 }
 
+# cf-template-storage
+module "cf_template_storage" {
+  source          = "../../modules/s3"
+  additional_tags = local.tags_organisation_management
+  bucket_prefix   = "cf-template-storage"
+}
+
 # cloudtrail--replication
 module "cloudtrail_replication_s3_bucket" {
   providers = {


### PR DESCRIPTION
This work is tracked downstream by [#9359](https://github.com/ministryofjustice/modernisation-platform/issues/9359) in the Modernisation Platform repository.

After discussion with @ewastempel and others, I'm going to deploy the Palo Alto Cortex XDR/XSIAM stack and stacksets through the `organisation-security` account. This account is a delegated administrator, and is better aligned with the purpose of how we use our accounts.

As a precursory step, however, I need a place to hold the CloudFormation templates that the stacks will use. This PR removes the `cf-templates*` S3 bucket from the `MOJ Master` account and redeploys it in the `organisation-security` account.

From there I will rebase #1157 and bring the PR back to review once the pipeline checks are passing.