### PR TITLE
Remove jsonencode() to prevent double encoding of templates

### DIFF
--- a/organisation-security/terraform/cortex-xdr-integration.tf
+++ b/organisation-security/terraform/cortex-xdr-integration.tf
@@ -34,7 +34,7 @@ resource "aws_cloudformation_stack" "cortex_xdr_stack" {
     ExternalID        = sensitive(random_uuid.cortex_xdr_stack.result)
   }
   tags          = local.tags_organisation_management
-  template_body = jsonencode(data.aws_s3_object.cortex_xdr_templates["cortex-xdr-root-account.template"].body)
+  template_body = data.aws_s3_object.cortex_xdr_templates["cortex-xdr-root-account.template"].body
 }
 
 resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
@@ -54,7 +54,7 @@ resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
     ExternalID        = sensitive(random_uuid.cortex_xdr_stack.result)
   }
   permission_model = "SERVICE_MANAGED"
-  template_body    = jsonencode(data.aws_s3_object.cortex_xdr_templates["cortex-xdr-subordinate-account.template"].body)
+  template_body    = data.aws_s3_object.cortex_xdr_templates["cortex-xdr-subordinate-account.template"].body
   tags             = local.tags_organisation_management
 }
 


### PR DESCRIPTION
This PR is tracked downstream by [#9359](https://github.com/ministryofjustice/modernisation-platform/issues/9359) in the modernisation-platform repository.

This PR removes the accidental double-encoding of templates.