### PR TITLE
Create CloudFormation stack for XDR/XSIAM

### DIFF
--- a/organisation-security/terraform/cortex-xdr-integration.tf
+++ b/organisation-security/terraform/cortex-xdr-integration.tf
@@ -23,3 +23,13 @@ resource "aws_ssm_parameter" "cortex_xdr_uuids" {
     xdr_stack_set = random_uuid.cortex_xdr_stack_set.result
   })
 }
+
+resource "aws_cloudformation_stack" "cortex_xdr_stack" {
+  name = "cortex-xdr-cloud-app"
+  parameters = {
+    CortexXDRRoleName = "CortexXDRCloudApp",
+    ExternalID        = sensitive(random_uuid.cortex_xdr_stack.result)
+  }
+  tags          = local.tags_organisation_management
+  template_body = data.aws_s3_object.cortex_xdr_templates["cortex-xdr-root-account.template"].body
+}


### PR DESCRIPTION
From the Palo Alto documentation on XDR/XSIAM for ingesting Cloud Assets [here](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Administrator-Guide/Ingest-Cloud-Assets-from-AWS), this PR creates a CF stack in the `organisation-security` account that XDR/XSIAM can assume.

A following PR will create a StackSet that will be deployed across accounts in our AWS Organization.