### PR TITLE
Add missing capability to CF stack resource

### DIFF
--- a/organisation-security/terraform/cortex-xdr-integration.tf
+++ b/organisation-security/terraform/cortex-xdr-integration.tf
@@ -25,7 +25,8 @@ resource "aws_ssm_parameter" "cortex_xdr_uuids" {
 }
 
 resource "aws_cloudformation_stack" "cortex_xdr_stack" {
-  name = "cortex-xdr-cloud-app"
+  capabilities = ["CAPABILITY_NAMED_IAM"]
+  name         = "cortex-xdr-cloud-app"
   parameters = {
     CortexXDRRoleName = "CortexXDRCloudApp",
     ExternalID        = sensitive(random_uuid.cortex_xdr_stack.result)


### PR DESCRIPTION
Tracked downstream by #[9359](https://github.com/ministryofjustice/modernisation-platform/issues/9359) in the **modernisation-platform** repository.

This PR adds a missing capability value to the resource responsible for deploying the master CloudFormation stack from [this documentation](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSIAM/Cortex-XSIAM-Administrator-Guide/Ingest-Cloud-Assets-from-AWS).