### PR TITLE
Bump module version for `mp_ssm_inventory_resource_data_sync_s3`

### DIFF
--- a/organisation-security/terraform/s3.tf
+++ b/organisation-security/terraform/s3.tf
@@ -120,7 +120,7 @@ module "athena_results_s3_bucket" {
 
 # MP SSM Inventory Resource Data Sync S3 bucket - for syncing Modernisation Platform inventory data centrally (Similar to what's been built in organisation-security/terraform/ssm.tf but keeping this separate for now)
 module "mp_ssm_inventory_resource_data_sync_s3" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=52a40b0dd18aaef0d7c5565d93cc8997aad79636" # v8.2.0
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=474f27a3f9bf542a8826c76fb049cc84b5cf136f" # v8.2.1
   providers = {
     aws.bucket-replication = aws.eu-west-1
   }


### PR DESCRIPTION
According to the module release notes for [v8.2.1](https://github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket/releases/tag/v8.2.1) this resolves the following error:

```
│ Warning: Invalid Attribute Combination
│ 
│   with module.mp_ssm_inventory_resource_data_sync_s3.aws_s3_bucket_lifecycle_configuration.default,
│   on .terraform/modules/mp_ssm_inventory_resource_data_sync_s3/main.tf line 47, in resource "aws_s3_bucket_lifecycle_configuration" "default":
│   47: resource "aws_s3_bucket_lifecycle_configuration" "default" {
│ 
│ No attribute specified when one (and only one) of
│ [rule[0].filter[0].prefix.<.object_size_greater_than,rule[0].filter[0].prefix.<.object_size_less_than,rule[0].filter[0].prefix.<.and,rule[0].filter[0].prefix.<.tag]
│ is required
│ 
│ This will be an error in a future version of the provider
│ 
│ (and one more similar warning elsewhere)
```