### PR TITLE
Give data export service permissions on focus s3 bucket

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -362,7 +362,6 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
       type        = "Service"
       identifiers = ["bcm-data-exports.amazonaws.com"]
     }
-
   }
 
   statement {
@@ -385,11 +384,33 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
 }
 
 # moj-focus-reports-greenops
+data "aws_iam_policy_document" "focus_reports_s3_bucket" {
+  version = "2008-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::moj-focus-1-reports",
+      "arn:aws:s3:::moj-focus-1-reports/*"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["bcm-data-exports.amazonaws.com"]
+    }
+  }
+}
 
 module "focus_reports_s3_bucket" {
   source = "../../modules/s3"
 
   bucket_name= "moj-focus-1-reports"
+  attach_policy          = true
+  policy                 = data.aws_iam_policy_document.focus_reports_s3_bucket.json
   enable_versioning = true
   enable_replication     = true
   replication_bucket_arn = "arn:aws:s3:::coat-production-focus-reports"


### PR DESCRIPTION
This should allow data exports to export FOCUS data to the focus s3 bucket.