### PR TITLE
Create Cortex StackSet and deploy across AWS Organization

### DIFF
--- a/organisation-security/terraform/cortex-xdr-integration.tf
+++ b/organisation-security/terraform/cortex-xdr-integration.tf
@@ -26,11 +26,39 @@ resource "aws_ssm_parameter" "cortex_xdr_uuids" {
 
 resource "aws_cloudformation_stack" "cortex_xdr_stack" {
   capabilities = ["CAPABILITY_NAMED_IAM"]
-  name         = "cortex-xdr-cloud-app"
+  name         = "CortexXDRCloudApp"
   parameters = {
     CortexXDRRoleName = "CortexXDRCloudApp",
     ExternalID        = sensitive(random_uuid.cortex_xdr_stack.result)
   }
   tags          = local.tags_organisation_management
   template_body = data.aws_s3_object.cortex_xdr_templates["cortex-xdr-root-account.template"].body
+}
+
+resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
+  depends_on = [aws_cloudformation_stack.cortex_xdr_stack]
+  lifecycle {
+    ignore_changes = [parameters]
+  }
+  auto_deployment {
+    enabled                          = true
+    retain_stacks_on_account_removal = true
+  }
+  capabilities = ["CAPABILITY_NAMED_IAM"]
+  description  = "AWS CloudFormation Stack Set used by XSIAM/XDR"
+  name         = "CortexXDRCloudAppStackSet"
+  parameters = {
+    CortexXDRRoleName = "CortexXDRCloudApp",
+    ExternalID        = sensitive(random_uuid.cortex_xdr_stack_set.result)
+  }
+  permission_model = "SERVICE_MANAGED"
+  template_body    = jsonencode(data.aws_s3_object.cortex_xdr_templates["cortex-xdr-subordinate-account.template"].body)
+  tags             = local.tags_organisation_management
+}
+
+resource "aws_cloudformation_stack_set_instance" "cortex_xdr_stack_set" {
+  deployment_targets {
+    organizational_unit_ids = [local.organizations_organization.roots[0].id]
+  }
+  stack_set_name = "cortex-xdr-cloud-app-stack-set"
 }


### PR DESCRIPTION
This PR is tracked downstream as #[9359](https://github.com/ministryofjustice/modernisation-platform/issues/9359) in the **modernisation-platform** repository.

This PR does the following:

* Refactors the name of the `cortex-xdr-cloud-app` stack in line with existing CF stacks
* Introduces a StackSet to deploy a subordinate template across the MOJ AWS Organization

Through the successful implementation of this PR and the StackSet, the SOC-PM team will be able to integrate Cortex XDR/XSIAM Cloud App discovery across the entire MOJ AWS estate captured by this Organization.