### PR TITLE
Remove replication infrastructure and add data export permissions

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -385,24 +385,31 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
 }
 
 # moj-focus-reports-greenops
+data "aws_iam_policy_document" "focus_reports_s3_bucket" {
+  version = "2008-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::moj-focus-1-reports",
+      "arn:aws:s3:::moj-focus-1-reports/*"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["bcm-data-exports.amazonaws.com"]
+    }
+  }
+}
 
 module "focus_reports_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_name= "moj-focus-1-reports"
-  enable_versioning = true
-  enable_replication     = true
-  replication_bucket_arn = "arn:aws:s3:::coat-production-focus-reports"
-  replication_role_arn   = module.focus_reports_s3_bucket.replication_role_arn
-  destination_kms_arn    = "arn:aws:kms:eu-west-2:279191903737:key/807c9d94-a20e-4df4-b5a9-d8e08bd24323"
-  replication_rules = [
-    {
-      id                 = "replicate-focus-reports"
-      prefix             = "moj-focus-reports/"
-      status             = "Enabled"
-      deletemarker       = "Enabled"
-      replica_kms_key_id = "arn:aws:kms:eu-west-2:279191903737:key/807c9d94-a20e-4df4-b5a9-d8e08bd24323"
-      metrics            = "Enabled"
-    }
-  ]
+  bucket_nam = "moj-focus-1-reports"
+  attach_policy = true
+  policy = data.aws_iam_policy_document.focus_reports_s3_bucket.json
 }

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -409,7 +409,8 @@ data "aws_iam_policy_document" "focus_reports_s3_bucket" {
 module "focus_reports_s3_bucket" {
   source = "../../modules/s3"
 
-  bucket_nam = "moj-focus-1-reports"
+  bucket_name = "moj-focus-1-reports"
+  
   attach_policy = true
   policy = data.aws_iam_policy_document.focus_reports_s3_bucket.json
 }


### PR DESCRIPTION
- Remove bucket replication infrastructure to unblock pipeline
- Add data export permissions to export FOCUS data to S3