### PR TITLE
Delegate service-managed stacksets to org-sec account

### DIFF
--- a/management-account/terraform/organizations.tf
+++ b/management-account/terraform/organizations.tf
@@ -37,10 +37,16 @@ resource "aws_organizations_organization" "default" {
   feature_set = "ALL"
 }
 
-# Delegate Cloudformation Stacksets to organisation-security
+# Delegate self-managed CloudFormation Stack Sets to organisation-security
 resource "aws_organizations_delegated_administrator" "stacksets_organisation_security" {
   account_id        = aws_organizations_account.organisation_security.id
   service_principal = "member.org.stacksets.cloudformation.amazonaws.com"
+}
+
+# Delegate service-managed CloudFormation Stack Sets to organisation-security
+resource "aws_organizations_delegated_administrator" "service_managed_stacksets_organisation_security" {
+  account_id        = aws_organizations_account.organisation_security.id
+  service_principal = "stacksets.cloudformation.amazonaws.com"
 }
 
 # Enable RAM sharing with the organization without requiring acceptors


### PR DESCRIPTION
This PR is tracked downstream by #[9359](https://github.com/ministryofjustice/modernisation-platform/issues/9359) in the **modernisation-platform** repository.

In order to create `SERVICE_MANAGED` AWS CloudFormation StackSets that can target the whole AWS Organization through a non-root account, this permission needs to be delegated to the `organisation-security` account.