### PR TITLE
Use proper Terraform referencing for StackSet name

### DIFF
--- a/organisation-security/terraform/cortex-xdr-integration.tf
+++ b/organisation-security/terraform/cortex-xdr-integration.tf
@@ -61,5 +61,5 @@ resource "aws_cloudformation_stack_set_instance" "cortex_xdr_stack_set" {
   deployment_targets {
     organizational_unit_ids = [local.organizations_organization.roots[0].id]
   }
-  stack_set_name = "cortex-xdr-cloud-app-stack-set"
+  stack_set_name = aws_cloudformation_stack_set.cortex_xdr_stack_set.name
 }


### PR DESCRIPTION
This PR fixes a refactoring effort I conducted last week that wasn't properly extended through to the StackSet Instance. I'd naively assumed that the `stack_set_name` was the name for the instance, not the name of the StackSet being referenced.