### PR TITLE
Ensure stack instance is created as DELEGATED_ADMIN

### DIFF
--- a/organisation-security/terraform/cortex-xdr-integration.tf
+++ b/organisation-security/terraform/cortex-xdr-integration.tf
@@ -61,5 +61,6 @@ resource "aws_cloudformation_stack_set_instance" "cortex_xdr_stack_set" {
   deployment_targets {
     organizational_unit_ids = [local.organizations_organization.roots[0].id]
   }
+  call_as        = "DELEGATED_ADMIN"
   stack_set_name = aws_cloudformation_stack_set.cortex_xdr_stack_set.name
 }


### PR DESCRIPTION
By default an `aws_cloudformation_stack_set_instance` is created by the calling account. However, as the CloudFormation Stack Set was created by the delegated admin it is not visible through the API to the calling account.

You can confirm this by issuing a `aws cloudformation list-stack-sets` command and comparing this to the behaviour in the console where the Stack Set is visible.

This PR ensures that the `aws_cloudformation_stack_set_instance` uses the delegated admin to create the instance.