### PR TITLE
Refactor Cortex stack set deployment

### DIFF
--- a/organisation-security/terraform/cloudformation-cortex.tf
+++ b/organisation-security/terraform/cloudformation-cortex.tf
@@ -44,12 +44,16 @@ resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
     enabled                          = true
     retain_stacks_on_account_removal = true
   }
+  operation_preferences {
+    failure_tolerance_percentage = 0
+    max_concurrency_percentage   = 10
+  }
   call_as      = "DELEGATED_ADMIN"
   capabilities = ["CAPABILITY_NAMED_IAM"]
   description  = "AWS CloudFormation Stack Set used by XSIAM/XDR"
   name         = "CortexXDRCloudAppStackSet"
   parameters = {
-    CortexXDRRoleName = "CortexXDRCloudApp",
+    CortexXDRRoleName = "CortexXDRCloudAppStackSet",
     ExternalID        = sensitive(random_uuid.cortex_xdr_stack_set.result)
   }
   permission_model = "SERVICE_MANAGED"

--- a/organisation-security/terraform/cloudformation-cortex.tf
+++ b/organisation-security/terraform/cloudformation-cortex.tf
@@ -46,7 +46,7 @@ resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
   }
   operation_preferences {
     failure_tolerance_percentage = 0
-    max_concurrency_percentage   = 10
+    max_concurrent_percentage    = 10
   }
   call_as      = "DELEGATED_ADMIN"
   capabilities = ["CAPABILITY_NAMED_IAM"]


### PR DESCRIPTION
This PR is tracked downstream by #[9359](https://github.com/ministryofjustice/modernisation-platform/issues/9359) in the modernisation-platform repository.

This PR achieves the following:
* Resolves a duplicate role name error
* Refactors the file title in-line with existing naming conventions
* Amends the concurrency mode to speed up deployment

The previous implementation - while broadly successful - fell short of success due to the duplicate role name error and the strict failure tolerance mode. This PR will speed up the implementation by targeting a rolling percentage of accounts, while still ensuring that a failure results in a cessation of deployment.