### PR TITLE
Attach bucket policy to allow export of focus data

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -385,11 +385,32 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
 }
 
 # moj-focus-reports-greenops
+data "aws_iam_policy_document" "focus_reports_s3_bucket" {
+  version = "2008-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetBucketLocation",
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::moj-focus-1-reports",
+      "arn:aws:s3:::moj-focus-1-reports/*"
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["bcm-data-exports.amazonaws.com"]
+    }
+  }
+}
 
 module "focus_reports_s3_bucket" {
   source = "../../modules/s3"
 
   bucket_name   = "moj-focus-1-reports"
   force_destroy = true
-
+  attach_policy = true
+  policy = data.aws_iam_policy_document.focus_reports_s3_bucket.json
 }


### PR DESCRIPTION
- This bucket policy should allow data exports to export FOCUS data to S3.