### PR TITLE
Add billing permissions to webops team

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -68,6 +68,13 @@ locals {
       ]
     },
     {
+      github_team        = "webops",
+      permission_set_arn = aws_ssoadmin_permission_set.billing.arn,
+      account_ids = [
+        aws_organizations_account.cloud_platform.id,
+      ]
+    },
+    {
       github_team        = "operations-engineering",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [


### PR DESCRIPTION
After removing the admin permissions, the product owner is no longer able to do certain billing functions such as creating reports.  Adding the billing permissions should resolve this.