### PR TITLE
Apply XDR/XSIAM Stack Set on per-OU basis

### DIFF
--- a/organisation-security/terraform/cloudformation-cortex.tf
+++ b/organisation-security/terraform/cloudformation-cortex.tf
@@ -63,7 +63,17 @@ resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
 
 resource "aws_cloudformation_stack_set_instance" "cortex_xdr_stack_set" {
   deployment_targets {
-    organizational_unit_ids = [local.organizations_organization.roots[0].id]
+    organizational_unit_ids = [
+      local.ou_central_digital_id,
+      local.ou_cica_id,
+      local.ou_hmcts_id,
+      local.ou_hmpps_id,
+      local.ou_laa,
+      local.ou_platforms_and_architecture_id,
+      local.ou_security_engineering_id,
+      local.ou_technology_services,
+      local.ou_yjb_id
+    ]
   }
   call_as        = "DELEGATED_ADMIN"
   stack_set_name = aws_cloudformation_stack_set.cortex_xdr_stack_set.name

--- a/organisation-security/terraform/locals.tf
+++ b/organisation-security/terraform/locals.tf
@@ -34,6 +34,42 @@ locals {
   organisation_account_numbers = [for account in local.organizations_organization.accounts : account.id]
 
   # AWS Organizational Units
+  ## Central Digital
+  ou_central_digital_id = coalesce([
+    for ou in data.aws_organizations_organizational_units.organizational_units.children :
+    ou.id
+    if ou.name == "Central Digital"
+  ]...)
+
+  ## Criminal Injuries Compensation Authority
+  ou_cica_id = coalesce([
+    for ou in data.aws_organizations_organizational_units.organizational_units.children :
+    ou.id
+    if ou.name == "CICA"
+  ]...)
+
+  ## HM Courts & Tribunal Service
+  ou_hmcts_id = coalesce([
+    for ou in data.aws_organizations_organizational_units.organizational_units.children :
+    ou.id
+    if ou.name == "HMCTS"
+  ]...)
+
+  ## HM Prison and Probation Service
+  ou_hmpps_id = coalesce([
+    for ou in data.aws_organizations_organizational_units.organizational_units.children :
+    ou.id
+    if ou.name == "HMPPS"
+  ]...)
+
+  ## Legal Aid Agency
+  ou_laa = coalesce([
+    for ou in data.aws_organizations_organizational_units.organizational_units.children :
+    ou.id
+    if ou.name == "LAA"
+  ]...)
+
+  ## Office of the Public Guardian
   ou_opg = coalesce([
     for ou in data.aws_organizations_organizational_units.organizational_units.children :
     ou.id
@@ -64,6 +100,21 @@ locals {
     if ou.name == "Sirius"
   ]...)
 
+  ## Organisation Management
+  ou_organisation_management = coalesce([
+    for ou in data.aws_organizations_organizational_units.organizational_units.children :
+    ou.id
+    if ou.name == "Organisation Management"
+  ]...)
+
+  ## Security Engineering
+  ou_security_engineering_id = coalesce([
+    for ou in data.aws_organizations_organizational_units.organizational_units.children :
+    ou.id
+    if ou.name == "Security Engineering"
+  ]...)
+
+  ## Platforms and Architecture
   ou_platforms_and_architecture_id = coalesce([
     for ou in data.aws_organizations_organizational_units.organizational_units.children :
     ou.id
@@ -88,16 +139,18 @@ locals {
     if ou.name == "Modernisation Platform Member"
   ]...)
 
+  ## Technology Services
   ou_technology_services = coalesce([
     for ou in data.aws_organizations_organizational_units.organizational_units.children :
     ou.id
     if ou.name == "Technology Services"
   ]...)
 
-  ou_laa = coalesce([
+  ## Youth Justice Board
+  ou_yjb_id = coalesce([
     for ou in data.aws_organizations_organizational_units.organizational_units.children :
     ou.id
-    if ou.name == "LAA"
+    if ou.name == "YJB"
   ]...)
 
   # ous for license manager


### PR DESCRIPTION
This PR is tracked downstream by #[9359](https://github.com/ministryofjustice/modernisation-platform/issues/9359) in the modernisation-platform repository.

This PR achieves the following:
* Introduces new local values to reference top-level AWS Organization Units
* Deploy the Cortex subordinate-account CloudFormation Stack Set on a per-OU basis
  * This allows us to pause the deployment where this Stack Set may not yet be appropriate
  * I've excluded OPG in this PR, pending further discussion on Slack