### PR TITLE
Increase CloudFormation concurrency

### DIFF
--- a/organisation-security/terraform/cloudformation-cortex.tf
+++ b/organisation-security/terraform/cloudformation-cortex.tf
@@ -45,8 +45,8 @@ resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
     retain_stacks_on_account_removal = true
   }
   operation_preferences {
-    failure_tolerance_percentage = 0
-    max_concurrent_percentage    = 10
+    failure_tolerance_count   = 10
+    max_concurrent_percentage = 25
   }
   call_as      = "DELEGATED_ADMIN"
   capabilities = ["CAPABILITY_NAMED_IAM"]


### PR DESCRIPTION
A previous deployment of the `CortexXDRCloudAppStackSet` CloudFormation Stack Set took around 2hrs 20mins to deploy.

By setting a less conservative concurrency percentage we can improve the deployment speed. However, without also increasing the failure count we have to wait for every deployment in a wave to complete before starting any further deployments.