### PR TITLE
Specify `administration_role_arn` for Cortex CloudFormation stack

### DIFF
--- a/organisation-security/terraform/cloudformation-cortex.tf
+++ b/organisation-security/terraform/cloudformation-cortex.tf
@@ -38,7 +38,7 @@ resource "aws_cloudformation_stack" "cortex_xdr_stack" {
 resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
   depends_on = [aws_cloudformation_stack.cortex_xdr_stack]
   lifecycle {
-    ignore_changes = [parameters]
+    ignore_changes = [parameters, administration_role_arn]
   }
   auto_deployment {
     enabled                          = true
@@ -48,7 +48,6 @@ resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
     failure_tolerance_percentage = 0
     max_concurrent_percentage    = 10
   }
-  administration_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/stacksets.cloudformation.amazonaws.com/AWSServiceRoleForCloudFormationStackSetsOrgAdmin"
   call_as                 = "DELEGATED_ADMIN"
   capabilities            = ["CAPABILITY_NAMED_IAM"]
   description             = "AWS CloudFormation Stack Set used by XSIAM/XDR"

--- a/organisation-security/terraform/cloudformation-cortex.tf
+++ b/organisation-security/terraform/cloudformation-cortex.tf
@@ -48,10 +48,11 @@ resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
     failure_tolerance_percentage = 0
     max_concurrent_percentage    = 10
   }
-  call_as      = "DELEGATED_ADMIN"
-  capabilities = ["CAPABILITY_NAMED_IAM"]
-  description  = "AWS CloudFormation Stack Set used by XSIAM/XDR"
-  name         = "CortexXDRCloudAppStackSet"
+  administration_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/stacksets.cloudformation.amazonaws.com/AWSServiceRoleForCloudFormationStackSetsOrgAdmin"
+  call_as                 = "DELEGATED_ADMIN"
+  capabilities            = ["CAPABILITY_NAMED_IAM"]
+  description             = "AWS CloudFormation Stack Set used by XSIAM/XDR"
+  name                    = "CortexXDRCloudAppStackSet"
   parameters = {
     CortexXDRRoleName = "CortexXDRCloudAppStackSet",
     ExternalID        = sensitive(random_uuid.cortex_xdr_stack_set.result)


### PR DESCRIPTION
While the Cortex CloudFormation stack creates successfully, the AWS API applies an `administration_role_arn` silently on resource creation. Without specifying this in code we experience thrashing of the CF stack where the lack of this attribute causes a recreation of all stacks.

This PR ignores changes to the `administration_role_arn` as setting it in code excludes us using the `auto_deploy {}` block.