### PR TITLE
Add kms perms in correct CICD role

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -158,7 +158,7 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
       "identitystore:GetGroupId",
       "identitystore:DescribeGroup",
       "identitystore:CreateGroup",
-      "kms:Decrypt",
+      "kms:*",
       "lambda:*",
       "license-manager:*",
       "logs:*",

--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -60,7 +60,6 @@ data "aws_iam_policy_document" "oidc_assume_role_apply" {
       "identitystore:GetGroupId",
       "identitystore:DescribeGroup",
       "kms:Decrypt",
-      "kms:CreateKey",
       "lambda:*",
       "license-manager:*",
       "logs:*",


### PR DESCRIPTION
- Previously added kms perms in wrong CICD role, this PR rectifies this, giving additional perms to the github-actions-apply role created by the oidc module under the management account to facilitate kms key creation.