### PR TITLE
Improve deployment speed of Cortex Stack Set instances

### DIFF
--- a/organisation-security/terraform/cloudformation-cortex.tf
+++ b/organisation-security/terraform/cloudformation-cortex.tf
@@ -45,13 +45,13 @@ resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
     retain_stacks_on_account_removal = true
   }
   operation_preferences {
-    failure_tolerance_count   = 10
-    max_concurrent_percentage = 25
+    failure_tolerance_percentage = 100
+    max_concurrent_percentage    = 33
   }
-  call_as                 = "DELEGATED_ADMIN"
-  capabilities            = ["CAPABILITY_NAMED_IAM"]
-  description             = "AWS CloudFormation Stack Set used by XSIAM/XDR"
-  name                    = "CortexXDRCloudAppStackSet"
+  call_as      = "DELEGATED_ADMIN"
+  capabilities = ["CAPABILITY_NAMED_IAM"]
+  description  = "AWS CloudFormation Stack Set used by XSIAM/XDR"
+  name         = "CortexXDRCloudAppStackSet"
   parameters = {
     CortexXDRRoleName = "CortexXDRCloudAppStackSet",
     ExternalID        = sensitive(random_uuid.cortex_xdr_stack_set.result)


### PR DESCRIPTION
This PR is tracked downstream by #[9359](https://github.com/ministryofjustice/modernisation-platform/issues/9359) in the modernisation-platform repository.

Given the record of successful CF stack instance deployments this PR moves the failure percentage to 100%, implementing [soft failure tolerance](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/concurrency-mode.html#:~:text=Soft%20Failure%20Tolerance%3A%20This%20option%20decouples%20Failure%20tolerance%20from%20the%20actual%20concurrency.%20This%20allows%20stack%20set%20operations%20to%20run%20at%20the%20concurrency%20level%20set%20by%20the%20Maximum%20concurrent%20accounts%20value%2C%20regardless%20of%20the%20number%20of%20failures.).

This PR then moves the maximum concurrency to 33% to reduce the duration of a full deployment.