### PR TITLE
Cur v2 bucket: Perms for cross account data sync

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -381,7 +381,6 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
       type        = "Service"
       identifiers = ["bcm-data-exports.amazonaws.com"]
     }
-
   }
 
   statement {
@@ -398,7 +397,7 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_s3_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::211125434264:root"]
+      identifiers = ["arn:aws:iam::279191903737:root"]
     }
   }
 }


### PR DESCRIPTION
- Give permission for COAT prod MP account to read from cur v2 bucket for manual data sync.