### PR TITLE
Adding Permissions for Mod Platform Engineering Role to delete accounts in the MP OU

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -433,7 +433,9 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
       "organizations:CloseAccount",
       "organizations:MoveAccount"
     ]
-    resources = ["arn:aws:organizations::295814833350:ou/o-o-b2fpbzyd95/ou-ou-j1kx-qxsrh1gv"]
+    resources = ["arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/${aws_organizations_organization.default.id}/${aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id}"]
+
+
   }
   statement {
     effect = "Allow"

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -424,6 +424,24 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
     ]
     resources = ["arn:aws:dynamodb:eu-west-2:${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:table/modernisation-platform-terraform-state-lock"]
   }
+  statement {
+    sid    = "VisualEditor0"
+    effect = "Allow"
+    actions = [
+      "organizations:RemoveAccountFromOrganization",
+      "organizations:UpdateOrganizationalUnit",
+      "organizations:CloseAccount",
+      "organizations:MoveAccount"
+    ]
+    resources = ["arn:aws:organizations::295814833350:ou/o-o-b2fpbzyd95/ou-ou-j1kx-qxsrh1gv"]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "organizations:LeaveOrganization"
+    ]
+    resources = ["*"]
+  }
 }
 
 # Modernisation Platform end user permission sets are now managed in the modernisation-platform repository

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -425,7 +425,6 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
     resources = ["arn:aws:dynamodb:eu-west-2:${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:table/modernisation-platform-terraform-state-lock"]
   }
   statement {
-    sid    = "VisualEditor0"
     effect = "Allow"
     actions = [
       "organizations:RemoveAccountFromOrganization",


### PR DESCRIPTION
[#8205](https://github.com/ministryofjustice/modernisation-platform/issues/8205)


I have updated the permissions for the Modernisation Platform Engineering role to enable the Mod Platform Team to remove/delete accounts without needing the manual work of the root account admin team