### PR TITLE
Adding LAA account assignment and adding back the accidentally deleted one.

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -68,6 +68,13 @@ locals {
       ]
     },
     {
+      github_team        = "webops",
+      permission_set_arn = aws_ssoadmin_permission_set.billing.arn,
+      account_ids = [
+        aws_organizations_account.cloud_platform.id,
+      ]
+    },
+    {
       github_team        = "operations-engineering",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [
@@ -444,7 +451,14 @@ locals {
       account_ids = [
         aws_organizations_organization.default.master_account_id
       ]
-    }
+    },
+    {
+      github_team        = "azure-aws-sso-laa-readers",
+      permission_set_arn = aws_ssoadmin_permission_set.laa_lz_s3_read_acces.arn,
+      account_ids = [
+        aws_organizations_account.laa_production.id,
+      ]
+    },
   ]
   sso_admin_account_assignments_expanded = flatten([
     for assignment in local.sso_admin_account_assignments : [


### PR DESCRIPTION
https://github.com/ministryofjustice/central-digital-architecture-backlog/issues/16

Assignming new read-selected-data perms to LAA Prod (and adding back accidentally deleted webops assignment)