### PR TITLE
Fixing policy to allow viewing buckets via the console

### DIFF
--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -135,7 +135,7 @@ locals {
   # LAA Data Location locals
 
 
-  laa_lz_data_locations = try(jsondecode(aws_secretsmanager_secret_version.laa_lz_data_locations.secret_string).locations, [])
+  laa_lz_data_locations = try(jsondecode(data.aws_secretsmanager_secret_version.laa_lz_data_locations_version.secret_string).locations, [])
   laa_lz_data_locations_resources = flatten([
     for location in local.laa_lz_data_locations : [
       "arn:aws:s3:::${location}",

--- a/management-account/terraform/secrets-manager.tf
+++ b/management-account/terraform/secrets-manager.tf
@@ -122,3 +122,13 @@ resource "aws_secretsmanager_secret_version" "laa_lz_data_locations" {
     ]
   }
 }
+
+# Retrieving LAA Existing Secret
+
+data "aws_secretsmanager_secret" "laa_lz_data_locations" {
+  name = "laa-landing-zone-data-locations"
+}
+
+data "aws_secretsmanager_secret_version" "laa_lz_data_locations_version" {
+  secret_id = data.aws_secretsmanager_secret.laa_lz_data_locations.id
+}

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -826,6 +826,14 @@ resource "aws_ssoadmin_permission_set_inline_policy" "s3_read_access_inline" {
 
 data "aws_iam_policy_document" "laa_lz_s3_read_access" {
   statement {
+    sid = "AllowListAllBucketsForConsole"
+    actions = [
+      "s3:ListAllMyBuckets"
+    ]
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+  }
+  statement {
     sid = "AllowListAndReadObjects"
     actions = [
       "s3:GetObject",


### PR DESCRIPTION
https://github.com/ministryofjustice/central-digital-architecture-backlog/issues/16

Correcting a few errors:

* Policy did not include list all my buckets which meant users weren't able to to see any buckets listed
* Policy had dummy values in the policy doc instead of reading from secret