### PR TITLE
Adding some extra S3 actions and KMS decrypt permissions for an encrypted bucket

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -836,13 +836,27 @@ data "aws_iam_policy_document" "laa_lz_s3_read_access" {
   statement {
     sid = "AllowListAndReadObjects"
     actions = [
-      "s3:GetObject",
-      "s3:GetObjectVersion",
-      "s3:GetBucketLocation",
+      "s3:ListBucketVersions",
       "s3:ListBucket",
-      "s3:ListBucketVersions"
+      "s3:GetObjectVersion",
+      "s3:GetObject",
+      "s3:GetBucketLocation",
+      "s3:GetBucketObjectLockConfiguration",
+      "s3:GetBucketVersioning",
+      "s3:GetBucketOwnershipControls"
     ]
 
     resources = local.laa_lz_data_locations_resources
+  }
+  statement {
+    sid    = "AllowS3DecryptWithCMK"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey"
+    ]
+    resources = [
+      "arn:aws:kms:eu-west-2:${local.aws_organizations_account.laa_production.id}:alias/s3"
+    ]
   }
 }

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -856,7 +856,7 @@ data "aws_iam_policy_document" "laa_lz_s3_read_access" {
       "kms:DescribeKey"
     ]
     resources = [
-      "arn:aws:kms:eu-west-2:${local.aws_organizations_account.laa_production.id}:alias/s3"
+      "arn:aws:kms:eu-west-2:${aws_organizations_account.laa_production.id}:alias/s3"
     ]
   }
 }


### PR DESCRIPTION
https://github.com/ministryofjustice/central-digital-architecture-backlog/issues/16

These s3 permissions were missing from the policy and have been added to allow object downloads and access to objects encrypted via a CMK.