### PR TITLE
Adding Permissions for Mod Platform Engineering Role to delete accounts in the MP OU 2

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -425,7 +425,7 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
     resources = ["arn:aws:dynamodb:eu-west-2:${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:table/modernisation-platform-terraform-state-lock"]
   }
   statement {
-    sid    = "VisualEditor0"
+    sid    = "ManageModernisationPlatformAccounts"
     effect = "Allow"
     actions = [
       "organizations:RemoveAccountFromOrganization",

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -425,6 +425,7 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
     resources = ["arn:aws:dynamodb:eu-west-2:${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:table/modernisation-platform-terraform-state-lock"]
   }
   statement {
+    sid    = "VisualEditor0"
     effect = "Allow"
     actions = [
       "organizations:RemoveAccountFromOrganization",
@@ -432,9 +433,7 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
       "organizations:CloseAccount",
       "organizations:MoveAccount"
     ]
-    resources = ["arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/${aws_organizations_organization.default.id}/${aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id}"]
-
-
+    resources = ["arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/o-o-b2fpbzyd95/ou-ou-j1kx-qxsrh1gv"]
   }
   statement {
     effect = "Allow"

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -433,7 +433,10 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
       "organizations:CloseAccount",
       "organizations:MoveAccount"
     ]
-    resources = ["arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/o-o-b2fpbzyd95/ou-ou-j1kx-qxsrh1gv"]
+    resources = [
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/o-o-b2fpbzyd95/ou-ou-j1kx-qxsrh1gv",
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:account/o-b2fpbzyd95/*"
+    ]
   }
   statement {
     effect = "Allow"

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -434,8 +434,8 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
       "organizations:MoveAccount"
     ]
     resources = [
-      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/o-o-b2fpbzyd95/ou-ou-j1kx-qxsrh1gv",
-      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:account/o-b2fpbzyd95/*"
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/${aws_organizations_organization.default.id}/${aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id}",
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:account/${aws_organizations_organization.default.id}/*"
     ]
   }
   statement {


### PR DESCRIPTION
[#8205](https://github.com/ministryofjustice/modernisation-platform/issues/8205)

I have updated the permissions for the Modernisation Platform Engineering role to enable the Mod Platform Team to remove/delete accounts without needing the manual work of the root account admin team

Follow up PR from this [PR](https://github.com/ministryofjustice/aws-root-account/pull/1206). Original PR did not work as intended, as the role does not have the required permissions

This new PR has updated code as advised by[ AWS Support](https://295814833350-u4qi4ikr.support.console.aws.amazon.com/support/home?region=us-east-1#/case/?displayId=174610117800625&language=en)
