### PR TITLE
Create cf template storage bucket in management account

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -441,6 +441,13 @@ data "aws_iam_policy_document" "focus_reports_s3_bucket" {
   }
 }
 
+# cf-template-storage
+module "cf_template_storage" {
+  source          = "../../modules/s3"
+  additional_tags = local.tags_organisation_management
+  bucket_prefix   = "cf-template-storage"
+}
+
 module "focus_reports_s3_bucket" {
   source = "../../modules/s3"
 


### PR DESCRIPTION
This PR creates an s3 bucket in the management account for CloudFormation template storage. 

This allows us to store templates locally within the account, instead of needing to handle secured access across accounts. This will then allow us to migrate the Cortex cortex-xdr-root-account.template and associated stack across to this account.