### PR TITLE
Move XDR root account stack

### DIFF
--- a/management-account/terraform/cloudformation-cortex.tf
+++ b/management-account/terraform/cloudformation-cortex.tf
@@ -1,0 +1,33 @@
+data "aws_s3_objects" "cortex_xdr_templates" {
+  bucket = module.cf_template_storage.bucket_name
+  prefix = "cortex-xdr"
+}
+
+data "aws_s3_object" "cortex_xdr_templates" {
+  for_each = toset(data.aws_s3_objects.cortex_xdr_templates.keys)
+  bucket   = module.cf_template_storage.bucket_name
+  key      = each.key
+}
+
+resource "random_uuid" "cortex_xdr_stack" {}
+
+resource "aws_ssm_parameter" "cortex_xdr_uuids" {
+  description = "Map of random UUID values used to secure external access for IAM role assumption"
+  name        = "cortex_xdr_uuids"
+  tags        = local.tags_organisation_management
+  type        = "SecureString"
+  value = jsonencode({
+    xdr_stack = random_uuid.cortex_xdr_stack.result
+  })
+}
+
+resource "aws_cloudformation_stack" "cortex_xdr_stack" {
+  capabilities = ["CAPABILITY_NAMED_IAM"]
+  name         = "CortexXDRCloudApp"
+  parameters = {
+    CortexXDRRoleName = "CortexXDRCloudApp",
+    ExternalID        = sensitive(random_uuid.cortex_xdr_stack.result)
+  }
+  tags          = local.tags_organisation_management
+  template_body = data.aws_s3_object.cortex_xdr_templates["cortex-xdr-root-account.template"].body
+}

--- a/management-account/terraform/versions.tf
+++ b/management-account/terraform/versions.tf
@@ -9,6 +9,9 @@ terraform {
       source  = "hashicorp/awscc"
       version = "~> 1.31.0"
     }
-
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6.3"
+    }
   }
 }

--- a/organisation-security/terraform/cloudformation-cortex.tf
+++ b/organisation-security/terraform/cloudformation-cortex.tf
@@ -9,8 +9,6 @@ data "aws_s3_object" "cortex_xdr_templates" {
   key      = each.key
 }
 
-resource "random_uuid" "cortex_xdr_stack" {}
-
 resource "random_uuid" "cortex_xdr_stack_set" {}
 
 resource "aws_ssm_parameter" "cortex_xdr_uuids" {
@@ -19,24 +17,11 @@ resource "aws_ssm_parameter" "cortex_xdr_uuids" {
   tags        = local.tags_organisation_management
   type        = "SecureString"
   value = jsonencode({
-    xdr_stack     = random_uuid.cortex_xdr_stack.result,
     xdr_stack_set = random_uuid.cortex_xdr_stack_set.result
   })
 }
 
-resource "aws_cloudformation_stack" "cortex_xdr_stack" {
-  capabilities = ["CAPABILITY_NAMED_IAM"]
-  name         = "CortexXDRCloudApp"
-  parameters = {
-    CortexXDRRoleName = "CortexXDRCloudApp",
-    ExternalID        = sensitive(random_uuid.cortex_xdr_stack.result)
-  }
-  tags          = local.tags_organisation_management
-  template_body = data.aws_s3_object.cortex_xdr_templates["cortex-xdr-root-account.template"].body
-}
-
 resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
-  depends_on = [aws_cloudformation_stack.cortex_xdr_stack]
   lifecycle {
     ignore_changes = [parameters, administration_role_arn]
   }

--- a/organisation-security/terraform/versions.tf
+++ b/organisation-security/terraform/versions.tf
@@ -5,7 +5,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-
     random = {
       source  = "hashicorp/random"
       version = "~> 3.6.3"


### PR DESCRIPTION
This PR is tracked downstream by [#9359](https://github.com/ministryofjustice/modernisation-platform/issues/9359) in the modernisation-platform repository.

This PR migrates the XDR root account stack to the management account where it can retrieve rich data from AWS Organizations API calls.