### PR TITLE
Adding Permissions for Mod Platform Engineering Role to delete accounts in the MP OU 5

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -424,6 +424,26 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
     ]
     resources = ["arn:aws:dynamodb:eu-west-2:${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:table/modernisation-platform-terraform-state-lock"]
   }
+  statement {
+    sid    = "ModPlatAccountsAllowMoveFromSpecificOUBranchToRoot"
+    effect = "Allow"
+    actions = [
+      "organizations:MoveAccount"
+    ]
+    resources = [
+      // move will only succeed if the source OU is authorized below.
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:account/${aws_organizations_organization.default.id}/*",
+
+      // specific source OU we are allowing accounts to be moved from
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/${aws_organizations_organization.default.id}/${aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id}",
+
+      // Any nested OUs under the parent OU
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/${aws_organizations_organization.default.id}/*",
+
+      // Destination for moved account
+      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:root/${aws_organizations_organization.default.id}/${aws_organizations_organization.default.roots[0].id}"
+    ]
+  }
 }
 
 # Modernisation Platform end user permission sets are now managed in the modernisation-platform repository

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -431,16 +431,17 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
       "organizations:MoveAccount"
     ]
     resources = [
-      // move will only succeed if the source OU is authorized below.
+      
+      # move will only succeed if the source OU is authorized below.
       "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:account/${aws_organizations_organization.default.id}/*",
 
-      // specific source OU we are allowing accounts to be moved from
+      # specific source OU we are allowing accounts to be moved from
       "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/${aws_organizations_organization.default.id}/${aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id}",
 
-      // Any nested OUs under the parent OU
+      # Any nested OUs under the parent OU
       "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/${aws_organizations_organization.default.id}/*",
 
-      // Destination for moved account
+      # Destination for moved account
       "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:root/${aws_organizations_organization.default.id}/${aws_organizations_organization.default.roots[0].id}"
     ]
   }

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -424,26 +424,6 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
     ]
     resources = ["arn:aws:dynamodb:eu-west-2:${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:table/modernisation-platform-terraform-state-lock"]
   }
-   statement {
-    sid    = "ModernisationPlatformAccountsMoveAccountsInOU"
-    effect = "Allow"
-    actions = [
-      "organizations:MoveAccount"
-    ]
-    resources = [
-      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:ou/${aws_organizations_organization.default.id}/${aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id}"
-    ]
-  }
-  statement {
-    sid    = "ModernisationPlatformAccountsCloseAccount"
-    effect = "Allow"
-    actions = [
-      "organizations:CloseAccount"
-    ]
-    resources = [
-      "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:account/${aws_organizations_organization.default.id}/*"
-    ]
-  }
 }
 
 # Modernisation Platform end user permission sets are now managed in the modernisation-platform repository

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -425,13 +425,13 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
     resources = ["arn:aws:dynamodb:eu-west-2:${coalesce(local.modernisation_platform_accounts.modernisation_platform_id...)}:table/modernisation-platform-terraform-state-lock"]
   }
   statement {
-    sid    = "ModPlatAccountsAllowMoveFromSpecificOUBranchToRoot"
+    sid    = "ModPlatAccountsAllowMoveFromOUToRoot"
     effect = "Allow"
     actions = [
       "organizations:MoveAccount"
     ]
     resources = [
-      
+
       # move will only succeed if the source OU is authorized below.
       "arn:aws:organizations::${data.aws_caller_identity.current.account_id}:account/${aws_organizations_organization.default.id}/*",
 


### PR DESCRIPTION
[#8205](https://github.com/ministryofjustice/modernisation-platform/issues/8205). Made changes to try follow [AWS](https://docs.aws.amazon.com/organizations/latest/APIReference/API_MoveAccount.html) Guidance for move account. For it to work it needs resource type of  account, ou and root. Previous Pr's did not have all 3

<img width="963" alt="Screenshot 2025-05-09 at 19 33 24" src="https://github.com/user-attachments/assets/2fc7e373-448c-4acb-836f-b532eee37db1" />




https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsorganizations.html