### PR TITLE
Integrate cost data with DSIT account

### DIFF
--- a/management-account/terraform/cddo-integration.tf
+++ b/management-account/terraform/cddo-integration.tf
@@ -1,0 +1,8 @@
+# Infrastructure for integration with CDDO central account: Data export, S3, and bucket replication
+
+module "cddo_infra" {
+source = "[github.com/co-cddo/terraform-aws-focus?ref=v1.1.0](https://www.google.com/url?q=http%3A%2F%2Fgithub.com%2Fco-cddo%2Fterraform-aws-focus%3Fref%3Dv1.1.0&sa=D&ust=1743337080000000&usg=AOvVaw0JmgkcLkM7mKLFE3qmMv2g)"
+
+destination_account_id = "203341582084"
+destination_bucket_name = "uk-gov-gds-cost-inbound"
+}

--- a/management-account/terraform/cddo-integration.tf
+++ b/management-account/terraform/cddo-integration.tf
@@ -1,6 +1,6 @@
-# Infrastructure for integration with CDDO central account: Data export, S3, and bucket replication
+# Infrastructure for integration with DSIT central account: Data export, S3, and bucket replication
 
-module "cddo_infra" {
+module "dsit_infra" {
 source = "[github.com/co-cddo/terraform-aws-focus?ref=v1.1.0](https://www.google.com/url?q=http%3A%2F%2Fgithub.com%2Fco-cddo%2Fterraform-aws-focus%3Fref%3Dv1.1.0&sa=D&ust=1743337080000000&usg=AOvVaw0JmgkcLkM7mKLFE3qmMv2g)"
 
 destination_account_id = "203341582084"

--- a/management-account/terraform/dsit-integration.tf
+++ b/management-account/terraform/dsit-integration.tf
@@ -1,7 +1,7 @@
 # Infrastructure to integrate cost reporting with DSIT central account: Data export, S3, and bucket replication
 
 module "dsit_infra" {
-source = "[github.com/co-cddo/terraform-aws-focus?ref=v1.1.0](https://www.google.com/url?q=http%3A%2F%2Fgithub.com%2Fco-cddo%2Fterraform-aws-focus%3Fref%3Dv1.1.0&sa=D&ust=1743337080000000&usg=AOvVaw0JmgkcLkM7mKLFE3qmMv2g)"
+source = "github.com/co-cddo/terraform-aws-focus?ref=v1.1.0](https://www.google.com/url?q=http%3A%2F%2Fgithub.com%2Fco-cddo%2Fterraform-aws-focus%3Fref%3Dv1.1.0&sa=D&ust=1743337080000000&usg=AOvVaw0JmgkcLkM7mKLFE3qmMv2g"
 
 destination_account_id = "203341582084"
 destination_bucket_name = "uk-gov-gds-cost-inbound"

--- a/management-account/terraform/dsit-integration.tf
+++ b/management-account/terraform/dsit-integration.tf
@@ -1,7 +1,7 @@
 # Infrastructure to integrate cost reporting with DSIT central account: Data export, S3, and bucket replication
 
 module "dsit_infra" {
-source = "github.com/co-cddo/terraform-aws-focus?ref=v1.1.0](https://www.google.com/url?q=http%3A%2F%2Fgithub.com%2Fco-cddo%2Fterraform-aws-focus%3Fref%3Dv1.1.0&sa=D&ust=1743337080000000&usg=AOvVaw0JmgkcLkM7mKLFE3qmMv2g"
+source = "github.com/co-cddo/terraform-aws-focus?ref=v1.1.0"
 
 destination_account_id = "203341582084"
 destination_bucket_name = "uk-gov-gds-cost-inbound"

--- a/management-account/terraform/dsit-integration.tf
+++ b/management-account/terraform/dsit-integration.tf
@@ -1,6 +1,6 @@
 # Infrastructure to integrate cost reporting with DSIT central account: Data export, S3, and bucket replication
 
-module "dsit_infra" {
+module "dsit_cost_integration" {
 source = "github.com/co-cddo/terraform-aws-focus?ref=v1.1.0"
 
 destination_account_id = "203341582084"

--- a/management-account/terraform/dsit-integration.tf
+++ b/management-account/terraform/dsit-integration.tf
@@ -1,4 +1,4 @@
-# Infrastructure for integration with DSIT central account: Data export, S3, and bucket replication
+# Infrastructure to integrate cost reporting with DSIT central account: Data export, S3, and bucket replication
 
 module "dsit_infra" {
 source = "[github.com/co-cddo/terraform-aws-focus?ref=v1.1.0](https://www.google.com/url?q=http%3A%2F%2Fgithub.com%2Fco-cddo%2Fterraform-aws-focus%3Fref%3Dv1.1.0&sa=D&ust=1743337080000000&usg=AOvVaw0JmgkcLkM7mKLFE3qmMv2g)"


### PR DESCRIPTION
As part of an initiative by DSIT, we would like to share our cost data with them. To do this we use a Terraform module (https://github.com/co-cddo/terraform-aws-focus?ref=v1.1.0) to configure a FOCUS data export with bucket replication to a DSIT AWS account. This PR is associated with this ticket on the COAT board: https://github.com/orgs/ministryofjustice/projects/52/views/4?pane=issue&itemId=104021685&issue=ministryofjustice%7Coperations-engineering%7C5288