### PR TITLE
Add SSO permissions for LAA LZ prod account

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -381,3 +381,37 @@ resource "aws_organizations_policy_attachment" "modernisation_platform_member_ou
   target_id = each.value
   policy_id = aws_organizations_policy.modernisation_platform_member_ou_scp.id
 }
+
+
+# LAA Deny actions
+resource "aws_organizations_policy" "deny_all_actions_by_users" {
+  name        = "Deny all actions by users"
+  description = "Denies the ability to do anything with a user"
+  type        = "SERVICE_CONTROL_POLICY"
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
+  }
+
+  content = data.aws_iam_policy_document.deny_all_actions_by_users.json
+}
+
+data "aws_iam_policy_document" "deny_all_actions_by_users" {
+  statement {
+    effect    = "Deny"
+    actions   = ["*"]
+    resources = ["*"]
+ condition {
+      test     = "StringLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::*:user/*"]
+    }
+}
+}
+
+# Attach policy to laa production
+resource "aws_organizations_policy_attachment" "deny_all_actions_by_users" {
+  policy_id = aws_organizations_policy.deny_all_actions_by_users.id
+  target_id = aws_organizations_account.laa_production.id
+}

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -419,6 +419,20 @@ locals {
       ]
     },
     {
+      github_team        = "laa-lz-read-only",
+      permission_set_arn = aws_ssoadmin_permission_set.laa_read_only.arn,
+      account_ids = [
+        aws_organizations_account.laa_production.id
+      ]
+    },
+        {
+      github_team        = "laa-lz-admin",
+      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
+      account_ids = [
+        aws_organizations_account.laa_production.id
+      ]
+    },
+    {
       github_team        = "modernisation-platform",
       permission_set_arn = aws_ssoadmin_permission_set.security_audit.arn,
       account_ids = [

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -418,20 +418,20 @@ locals {
         aws_organizations_account.cloud_platform.id
       ]
     },
-    {
-      github_team        = "laa-lz-read-only",
-      permission_set_arn = aws_ssoadmin_permission_set.laa_read_only.arn,
-      account_ids = [
-        aws_organizations_account.laa_production.id
-      ]
-    },
-        {
-      github_team        = "laa-lz-admin",
-      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
-      account_ids = [
-        aws_organizations_account.laa_production.id
-      ]
-    },
+    # {
+    #   github_team        = "laa-lz-read-only",
+    #   permission_set_arn = aws_ssoadmin_permission_set.laa_read_only.arn,
+    #   account_ids = [
+    #     aws_organizations_account.laa_production.id
+    #   ]
+    # },
+    #     {
+    #   github_team        = "laa-lz-admin",
+    #   permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
+    #   account_ids = [
+    #     aws_organizations_account.laa_production.id
+    #   ]
+    # },
     {
       github_team        = "modernisation-platform",
       permission_set_arn = aws_ssoadmin_permission_set.security_audit.arn,

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -919,4 +919,24 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
     #tfsec:ignore:aws-iam-no-policy-wildcards
     resources = ["*"]
   }
+  statement {
+    sid    = "AllowSnapshotCopy"
+    effect = "Allow"
+    actions = [
+      "ec2:CopySnapshot"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "AllowKMSKeyUseForSnapshotCopy"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = ["arn:aws:kms:*:*:key/*"]
+  }
 }

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -884,3 +884,39 @@ resource "aws_ssoadmin_managed_policy_attachment" "laa_security_audit_inspector_
   managed_policy_arn = "arn:aws:iam::aws:policy/AmazonInspector2ReadOnlyAccess"
   permission_set_arn = aws_ssoadmin_permission_set.laa_security_audit.arn
 }
+
+# LAA Read Only
+
+resource "aws_ssoadmin_permission_set" "laa_read_only" {
+  name             = "LAAReadOnly"
+  description      = "LAA Read only access"
+  instance_arn     = local.sso_admin_instance_arn
+  session_duration = "PT1H"
+  tags             = {}
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "laa_read_only" {
+  instance_arn       = local.sso_admin_instance_arn
+  managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  permission_set_arn = aws_ssoadmin_permission_set.laa_read_only.arn
+}
+
+resource "aws_ssoadmin_permission_set_inline_policy" "laa_read_only_additional" {
+  instance_arn       = local.sso_admin_instance_arn
+  inline_policy      = data.aws_iam_policy_document.laa_read_only_additional.json
+  permission_set_arn = aws_ssoadmin_permission_set.laa_read_only.arn
+}
+
+data "aws_iam_policy_document" "laa_read_only_additional" {
+  statement {
+    sid = "DenyS3GetorPut"
+    effect = "Deny"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:PutObject",
+    ]
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+  }
+}


### PR DESCRIPTION
Readonly is given additional policy for expansion, currently removing permissions to view S3 objects