### PR TITLE
Add Centralised root iam management

### DIFF
--- a/management-account/terraform/organizations.tf
+++ b/management-account/terraform/organizations.tf
@@ -11,6 +11,7 @@ resource "aws_organizations_organization" "default" {
     "fms.amazonaws.com",
     "guardduty.amazonaws.com",
     "health.amazonaws.com",
+    "iam.amazonaws.com",
     "inspector2.amazonaws.com",
     "ipam.amazonaws.com",
     "license-management.marketplace.amazonaws.com",
@@ -41,6 +42,12 @@ resource "aws_organizations_organization" "default" {
 resource "aws_organizations_delegated_administrator" "stacksets_organisation_security" {
   account_id        = aws_organizations_account.organisation_security.id
   service_principal = "member.org.stacksets.cloudformation.amazonaws.com"
+}
+
+# Delegate Centralised IAM to organisation-security
+resource "aws_organizations_delegated_administrator" "iam_organisation_security" {
+  account_id        = aws_organizations_account.organisation_security.id
+  service_principal = "iam.amazonaws.com"
 }
 
 # Enable RAM sharing with the organization without requiring acceptors

--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -1,3 +1,11 @@
+# Enable Centralised Root Account management
+resource "aws_iam_organizations_features" "root_iam" {
+  enabled_features = [
+    "RootCredentialsManagement",
+    "RootSessions"
+  ]
+}
+
 ####################################
 # OIDC Provider for GitHub actions #
 ####################################


### PR DESCRIPTION
This gives us more control over root accounts, and allows us to perform certain priviledged activities without going into the member root account. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-enable-root-access.html