### PR TITLE
Move centralise root to correct account

### DIFF
--- a/management-account/terraform/organizations.tf
+++ b/management-account/terraform/organizations.tf
@@ -44,6 +44,14 @@ resource "aws_organizations_delegated_administrator" "stacksets_organisation_sec
   service_principal = "member.org.stacksets.cloudformation.amazonaws.com"
 }
 
+# Enable Centralised Root Account management
+resource "aws_iam_organizations_features" "root_iam" {
+  enabled_features = [
+    "RootCredentialsManagement",
+    "RootSessions"
+  ]
+}
+
 # Delegate Centralised IAM to organisation-security
 resource "aws_organizations_delegated_administrator" "iam_organisation_security" {
   account_id        = aws_organizations_account.organisation_security.id

--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -1,11 +1,3 @@
-# Enable Centralised Root Account management
-resource "aws_iam_organizations_features" "root_iam" {
-  enabled_features = [
-    "RootCredentialsManagement",
-    "RootSessions"
-  ]
-}
-
 ####################################
 # OIDC Provider for GitHub actions #
 ####################################


### PR DESCRIPTION
This must be enabled in the root account, hopefully the delegation still works as expected and allows the org sec account to take actions.