### PR TITLE
Update XsiamIntegration User Permissions

### DIFF
--- a/organisation-security/terraform/iam-roles.tf
+++ b/organisation-security/terraform/iam-roles.tf
@@ -11,9 +11,8 @@ data "aws_iam_policy_document" "read_only_role" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
-      type = "AWS"
-      identifiers = ["arn:aws:iam::${local.root_account_id}:root",
-      "arn:aws:iam::${local.organisation_security_account_id}:user/XsiamIntegration"]
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.root_account_id}:root"]
     }
   }
 }

--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -89,18 +89,7 @@ resource "aws_iam_user" "xsiam_integration" {
   tags          = {}
 }
 
-resource "aws_iam_user_policy" "xsiam_integration_assume_readonly" {
-  name = "AssumeReadOnlyRole"
-  user = aws_iam_user.xsiam_integration.name
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = "sts:AssumeRole"
-        Resource = aws_iam_role.read_only.arn
-      }
-    ]
-  })
+resource "aws_iam_user_policy_attachment" "xsiam_integration" {
+  user       = aws_iam_user.xsiam_integration.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10248

## What's changed
I've directly attach the ReadOnly policy to the XsiamIntegration user instead of giving it permissions to assume the ReadOnly role. The setup in Xsiam doesn't seem to allow for that.