### PR TITLE
Updating policy for xsiam integration user

### DIFF
--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -105,5 +105,5 @@ data "aws_iam_policy_document" "xsiam_integration" {
 }
 resource "aws_iam_user_policy_attachment" "xsiam_integration" {
   user       = aws_iam_user.xsiam_integration.name
-  policy_arn = aws_iam_access_policy.xsiam_integration.arn
+  policy_arn = aws_iam_policy.xsiam_integration.arn
 }

--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -89,9 +89,8 @@ resource "aws_iam_user" "xsiam_integration" {
   tags          = {}
 }
 
-resource "aws_iam_access_policy" "xsiam_integration" {
+resource "aws_iam_policy" "xsiam_integration" {
   name   = "XsiamIntegrationAccessPolicy"
-  user   = aws_iam_user.xsiam_integration.name
   policy = data.aws_iam_policy_document.xsiam_integration.json
 }
 

--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -89,7 +89,22 @@ resource "aws_iam_user" "xsiam_integration" {
   tags          = {}
 }
 
+resource "aws_iam_access_policy" "xsiam_integration" {
+  name   = "XsiamIntegrationAccessPolicy"
+  user   = aws_iam_user.xsiam_integration.name
+  policy = data.aws_iam_policy_document.xsiam_integration.json
+}
+
+data "aws_iam_policy_document" "xsiam_integration" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "securityhub:GetFindings"
+    ]
+    resources = ["*"]
+  }
+}
 resource "aws_iam_user_policy_attachment" "xsiam_integration" {
   user       = aws_iam_user.xsiam_integration.name
-  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  policy_arn = aws_iam_access_policy.xsiam_integration.arn
 }


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10248

## What's changing?
I'm scoping the xsiam integration user policy to `securityhub:GetFindings` as this is the only permission required for the [integration](https://xsoar.pan.dev/docs/reference/integrations/aws-security-hub-event-collector).

This can be updated in future if needed.