### PR TITLE
✨ Add ReadAccess to MoJ Digital Services `dns-read` Team

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -92,6 +92,13 @@ locals {
       ]
     },
     {
+      github_team        = "dns-read",
+      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
+      account_ids = [
+        aws_organizations_account.moj_digital_services.id
+      ]
+    },
+    {
       github_team        = "cica",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [


### PR DESCRIPTION
## 👀 Purpose

- In relation to security investigations

## ♻️ What's changed

- Added a ReadOnly Access to the `dns-read` GitHub Team for MoJ Digital Services (where our DNS Estate lives)

## 📝 Notes

- This is a new team to specifically control ReadOnly Access to the MoJ Digital Services Account