### PR TITLE
Adds guardduty permissions to XsiamIntegration user

### DIFF
--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -98,7 +98,10 @@ data "aws_iam_policy_document" "xsiam_integration" {
   statement {
     effect = "Allow"
     actions = [
-      "securityhub:GetFindings"
+      "securityhub:GetFindings",
+      "guardduty:ListDetectors",
+      "guardduty:ListFindings",
+      "guardduty:GetFindings"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Issue
https://github.com/ministryofjustice/modernisation-platform/issues/10248

## What's Changed?
Adds guardduty permissions to XsiamIntegration user allowing SOC ability to query GuardDuty findings for the MoJ org