### PR TITLE
🛶 Fix resources that are forever drifting

### DIFF
--- a/management-account/terraform/backup.tf
+++ b/management-account/terraform/backup.tf
@@ -3,7 +3,7 @@ resource "aws_backup_global_settings" "eu_west_1" {
 
   global_settings = {
     "isCrossAccountBackupEnabled" = "true"
-    "isMpaEnabled"                = "true"
+    "isMpaEnabled"                = "false"
   }
 
   depends_on = [aws_organizations_organization.default]

--- a/management-account/terraform/backup.tf
+++ b/management-account/terraform/backup.tf
@@ -3,6 +3,7 @@ resource "aws_backup_global_settings" "eu_west_1" {
 
   global_settings = {
     "isCrossAccountBackupEnabled" = "true"
+    "isMpaEnabled"                = "true"
   }
 
   depends_on = [aws_organizations_organization.default]

--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -36,5 +36,5 @@ resource "aws_cloudtrail" "default" {
   is_organization_trail         = false
 
   kms_key_id     = aws_kms_key.cloudtrail.arn
-  sns_topic_name = aws_sns_topic.cloudtrail.arn
+  sns_topic_name = trimprefix(aws_sns_topic.cloudtrail.arn, "arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:")
 }


### PR DESCRIPTION
## Proposed Changes

Management account's Terraform is constantly trying to correct two resources https://github.com/ministryofjustice/aws-root-account/actions/runs/15781858979/job/44489206521`

To address this, I've

- set `isMpaEnabled` to `false` in `aws_backup_global_settings.global_settings`
- used [`trimprefix`](https://developer.hashicorp.com/terraform/language/functions/trimprefix) when setting CloudTrail's SNS topic name because [`aws_sns_topic`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic#attribute-reference) doesn't provide and attribute that returns the name

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>