### PR TITLE
🌐 Update allowed regions

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -195,6 +195,9 @@ data "aws_iam_policy_document" "deny_non_eu_non_us_east_1_operations" {
       variable = "aws:RequestedRegion"
       values = [
         "eu-central-1", # Europe (Frankfurt)
+        "eu-north-1",   # Europe (Stockholm)
+        "eu-south-1",   # Europe (Milan)
+        "eu-south-2",   # Europe (Spain)
         "eu-west-1",    # Europe (Ireland)
         "eu-west-2",    # Europe (London)
         "eu-west-3",    # Europe (Paris)

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -268,6 +268,24 @@ data "aws_iam_policy_document" "deny_non_eu_non_us_east_1_operations" {
     ]
     resources = ["*"]
   }
+
+  # Deny everything except Amazon Bedrock in specific EU regions (exluding eu-west-1 and eu-west-2 as these are our default regions)
+  statement {
+    effect      = "Deny"
+    not_actions = ["bedrock:*"]
+    resources   = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values   = [
+        # "eu-central-1", # Europe (Frankfurt)
+        "eu-north-1",   # Europe (Stockholm)
+        "eu-south-1",   # Europe (Milan)
+        "eu-south-2",   # Europe (Spain)
+        # "eu-west-3"     # Europe (Paris)
+      ]
+    }
+  }
 }
 
 # Attach policy to lots of targets


### PR DESCRIPTION
## Proposed Changes

The Analytical Platform have received requests to enable Anthropic Claude 3.7 and 4 in Amazon Bedrock.

These models require new regions to be enabled (see https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html#inference-profiles-support-system)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>