### PR TITLE
✨ Add Read Only Access to All Accounts to `aws-root-account-admin-team`

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -7,6 +7,11 @@ locals {
     },
     {
       github_team        = "aws-root-account-admin-team",
+      permission_set_arn = aws_ssoadmin_permission_set.billing.arn,
+      account_ids        = data.aws_organizations_organizational_unit_descendant_accounts.all_accounts.accounts[*].id
+    },
+    {
+      github_team        = "aws-root-account-admin-team",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [
         aws_organizations_organization.default.master_account_id,


### PR DESCRIPTION
## 👀 Purpose

- In relation to a [Slack Request](https://mojdt.slack.com/archives/C06P4KA0V0A/p1751632907893659) to have Read access to all accounts
- Reduce Hosting Leads reliance on the [OrganizationAccountAccessRole](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_access.html) to view accounts - as OrganizationAccountAccessRole role grants full admin permissions; instead use an explicit ReadOnly Read to view accounts in our Org

## ♻️ What's changed

- ✨ Add Read Only Access to All Accounts to aws-root-account-admin-team
- 🔥 Remove some of our other permissions to avoid key conflicts (and to reduce noise of options when signing into an account 🙈 ) 

## 📓 Notes

- Worthing noting that we're using a dynamic list via data call, so permissions will only update when the terraform is run i.e. if we want access to a newly created account, we need to run an apply here