### PR TITLE
cur-v2-bucket added without KMS

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -547,11 +547,12 @@ module "cur_reports_v2_hourly_ap_poc_s3_bucket" {
 
   replication_rules = [
     {
-      id           = "replicate-cur-v2-reports"
-      prefix       = "moj-cost-and-usage-reports/"
-      status       = "Enabled"
-      deletemarker = "Enabled"
-      metrics      = "Enabled"
+      id                 = "replicate-cur-v2-reports"
+      prefix             = "moj-cost-and-usage-reports/"
+      status             = "Enabled"
+      deletemarker       = "Enabled"
+      replica_kms_key_id = ""
+      metrics            = "Enabled"
     }
   ]
 


### PR DESCRIPTION
## 👀 Purpose
 
**AWS root account - Setup separate export and single replication process to enable CaDeT pipeline PoC - [#185](https://github.com/ministryofjustice/cloud-optimisation-and-accountability/issues/185)**

Since the **`mojap-coat-cur-v2-hourly`** bucket in Analytical Platform Data Production does not have **kms keys configured** for **encrypting** and **decrypting** the **CUR reports**, we will first create a new S3 bucket **`moj-cur-reports-v2-hourly-replication-to-ap-poc`** in **Root account,** which will then be replicated CUR reports in AP account bucket

we will configure the **aws_bcmdataexports_export** resource in the **`data-export.tf`**. This configuration will set up the export of CUR data to the newly created **`moj-cur-reports-v2-hourly-replication-to-ap-poc`** from which we will replicate to **AP account bucket**. This is going to be a new PR we will raise once the **`moj-cur-reports-v2-hourly-replication-to-ap-poc`** has been created in root account


## ♻️ What's changed

Code to add a new Bucket **`moj-cur-reports-v2-hourly-replication-to-ap-poc`** using existing S3 module with required parameters to have without KMS keys used to encrypt. 

## 📓 Notes

<img width="1675" height="476" alt="image" src="https://github.com/user-attachments/assets/4fb00d46-11aa-43eb-b15e-225e4805a98f" />
