### PR TITLE
✨ Add `security-events: write` Permssion to Megalinter Workflow

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      security-events: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## 👀 Purpose

- Fixes #871 
- Allows megalinter to upload results to github security tab

## ♻️ What's changed

- ✨ Added the `security-events: write` permission to the Megalinter workflow

## 📝 Notes

- Permission taken from https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#uploading-a-code-scanning-analysis-with-github-actions and https://github.com/oxsecurity/megalinter/blob/main/README.md?plain=1#L451-L456