### PR TITLE
new variable added for the replication rule

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -547,12 +547,13 @@ module "cur_reports_v2_hourly_ap_poc_s3_bucket" {
 
   replication_rules = [
     {
-      id                 = "replicate-cur-v2-reports"
-      prefix             = "moj-cost-and-usage-reports/"
-      status             = "Enabled"
-      deletemarker       = "Enabled"
-      replica_kms_key_id = ""
-      metrics            = "Enabled"
+      id                    = "replicate-cur-v2-reports"
+      prefix                = "moj-cost-and-usage-reports/"
+      status                = "Enabled"
+      deletemarker          = "Enabled"
+      replica_kms_key_id    = ""
+      metrics               = "Enabled"
+      kms_encrypted_objects = "Disabled"
     }
   ]
 

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -172,7 +172,7 @@ resource "aws_s3_bucket_replication_configuration" "default" {
 
       source_selection_criteria {
         sse_kms_encrypted_objects {
-          status = "Enabled"
+          status = try(rule.value.kms_encrypted_objects, "Enabled")
         }
       }
       filter {

--- a/modules/s3/variables.tf
+++ b/modules/s3/variables.tf
@@ -104,12 +104,13 @@ variable "replication_role_arn" {
 variable "replication_rules" {
   description = "Replication rules for the bucket"
   type = list(object({
-    id                 = string
-    prefix             = string
-    status             = string
-    deletemarker       = string
-    replica_kms_key_id = string
-    metrics            = string
+    id                    = string
+    prefix                = string
+    status                = string
+    deletemarker          = string
+    replica_kms_key_id    = string
+    metrics               = string
+    kms_encrypted_objects = optional(string, "Enabled")
   }))
   default = []
 }
@@ -125,3 +126,4 @@ variable "destination_kms_arn" {
   type        = string
   default     = ""
 }
+


### PR DESCRIPTION
Modify the existing **S3 module** by adding  an optional variable - **kms_encrypted_objects** to enable S3 replication to not to include source_selection_criteria --> sse_kms_encrypted_objects to **Disabled**