### PR TITLE
Remove logic and role assumption in org-sec providers

### DIFF
--- a/organisation-security/terraform/providers.tf
+++ b/organisation-security/terraform/providers.tf
@@ -1,20 +1,5 @@
-# Default provider
-
-provider "aws" {
-  alias  = "original-session"
-  region = "eu-west-2"
-}
-
-data "aws_caller_identity" "original_session" {
-  provider = aws.original-session
-}
-
 provider "aws" {
   region = "eu-west-2"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 # us-* providers
@@ -22,37 +7,21 @@ provider "aws" {
 provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "us-east-2"
   region = "us-east-2"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "us-west-1"
   region = "us-west-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "us-west-2"
   region = "us-west-2"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 # af-* providers
@@ -60,10 +29,6 @@ provider "aws" {
 provider "aws" {
   alias  = "af-south-1"
   region = "af-south-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 # ap-* providers
@@ -71,73 +36,41 @@ provider "aws" {
 provider "aws" {
   alias  = "ap-east-1"
   region = "ap-east-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "ap-southeast-3"
   region = "ap-southeast-3"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "ap-south-1"
   region = "ap-south-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "ap-northeast-3"
   region = "ap-northeast-3"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "ap-northeast-2"
   region = "ap-northeast-2"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "ap-southeast-1"
   region = "ap-southeast-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "ap-southeast-2"
   region = "ap-southeast-2"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "ap-northeast-1"
   region = "ap-northeast-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 # ca-* providers
@@ -145,10 +78,6 @@ provider "aws" {
 provider "aws" {
   alias  = "ca-central-1"
   region = "ca-central-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 # eu-* providers
@@ -156,55 +85,31 @@ provider "aws" {
 provider "aws" {
   alias  = "eu-central-1"
   region = "eu-central-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "eu-west-1"
   region = "eu-west-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "eu-west-2"
   region = "eu-west-2"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "eu-south-1"
   region = "eu-south-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "eu-west-3"
   region = "eu-west-3"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 provider "aws" {
   alias  = "eu-north-1"
   region = "eu-north-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-  }
 }
 
 # me-* providers
@@ -212,11 +117,6 @@ provider "aws" {
 provider "aws" {
   alias  = "me-south-1"
   region = "me-south-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-
-  }
 }
 
 # sa-* providers
@@ -224,9 +124,4 @@ provider "aws" {
 provider "aws" {
   alias  = "sa-east-1"
   region = "sa-east-1"
-
-  assume_role {
-    role_arn = can(regex("GitHubActions", data.aws_caller_identity.original_session.arn)) ? null : "arn:aws:iam::${local.organisation_security_account_id}:role/OrganizationAccountAccessRole"
-
-  }
 }


### PR DESCRIPTION
When running this tf on a pipeline it uses the github actions plan or apply role, and uses the permissions associated with that role.

When running this terraform locally, it assumes the OrganizationAccountAccessRole in the organisation-security account, as we normally run this with the root account credentials.  This was because historically, we didn't have organisation-security credentials via SSO, but we do now.

This change removes the logic, so the terraform will run with whatever permissions the credentials that run it have, this doesn't change anything for running on the pipeline, but for local terraform runs you will now need to run it with the organisation-security credentials.

This makes more sense, simplifies the code, plus we don't have to use root credentials unnecessarily any more.