### PR TITLE
Add suppression rules for EICAR test file for CP

### DIFF
--- a/organisation-security/terraform/guardduty-filters.tf
+++ b/organisation-security/terraform/guardduty-filters.tf
@@ -23,3 +23,65 @@ resource "aws_guardduty_filter" "cloud_platform_trivy" {
       component = "Security"
   })
 }
+
+resource "aws_guardduty_filter" "cloud_platform_eicr_txt" {
+  name        = "EICARSuppression_txt"
+  action      = "ARCHIVE"
+  detector_id = local.guardduty_administrator_detector_ids.eu_west_2
+  rank        = 2
+
+  finding_criteria {
+    criterion {
+      field  = "accountId"
+      equals = [local.cloud_platform_account_id]
+    }
+    criterion {
+      field  = "region"
+      equals = ["eu-west-2"]
+    }
+    criterion {
+      field  = "service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.threatNames.filePaths.hash"
+      equals = ["275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f"]
+    }
+  }
+  tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+import {
+  to = aws_guardduty_filter.cloud_platform_eicr_txt
+  id = "${local.guardduty_administrator_detector_ids.eu_west_2}:EICARSuppression"
+}
+
+resource "aws_guardduty_filter" "cloud_platform_eicr_com" {
+  name        = "EICARSuppression_com"
+  action      = "ARCHIVE"
+  detector_id = local.guardduty_administrator_detector_ids.eu_west_2
+  rank        = 3
+
+  finding_criteria {
+    criterion {
+      field  = "accountId"
+      equals = [local.cloud_platform_account_id]
+    }
+    criterion {
+      field  = "region"
+      equals = ["eu-west-2"]
+    }
+    criterion {
+      field  = "service.ebsVolumeScanDetails.scanDetections.threatDetectedByName.threatNames.filePaths.hash"
+      equals = ["131f95c51cc819465fa1797f6ccacf9d494aaaff46fa3eac73ae63ffbdfd8267"]
+    }
+  }
+  tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
+import {
+  to = aws_guardduty_filter.cloud_platform_eicr_com
+  id = "${local.guardduty_administrator_detector_ids.eu_west_2}:EICARSuppression_com"
+}


### PR DESCRIPTION
CP users are testing their systems with this file which raises a high priority alert in Guardduty and pages on call people if out of hours. Suppressing this rule.

Had to create and import to test the filters worked.