### PR TITLE
Update dsit-integration module version to v2.0.2

### DIFF
--- a/management-account/terraform/dsit-integration.tf
+++ b/management-account/terraform/dsit-integration.tf
@@ -1,7 +1,7 @@
 # Infrastructure to integrate cost reporting with DSIT central account: Data export, S3, and bucket replication
 
 module "dsit_cost_integration" {
-  source = "github.com/co-cddo/terraform-aws-focus?ref=a9c51283b8802f04c6c260d87f2b74e7cdeb87c0" # v1.2.0
+  source = "github.com/co-cddo/terraform-aws-focus?ref=949f1318da46d6e211b440a77b42c6a90205613b" # v2.0.2
 
   destination_account_id  = "203341582084"
   destination_bucket_name = "uk-gov-gds-cost-inbound"


### PR DESCRIPTION
## 👀 Purpose

- This PR upgrade the DSIT Integration module (how we share Cost and Usage data with DSIT) from v1.2.0 to v2.0.2. This allows us to share Cost Optimisation Hub recommendations and AWS carbon emissions data with DSIT.

## ♻️ What's changed

- Replace commit for `v1.2.0` with commit for `v2.0.2`

## 📝 Notes

- [Release v2.0.2](https://github.com/co-cddo/terraform-aws-focus/releases/tag/v2.0.2)