### PR TITLE
Add cost-optimization-hub:UpdateEnrollmentStatus to GitHubActionsApply

### DIFF
--- a/organisation-security/terraform/iam.tf
+++ b/organisation-security/terraform/iam.tf
@@ -51,6 +51,7 @@ data "aws_iam_policy_document" "oidc_assume_role_apply" {
       "ce:*",
       "cloudtrail:*",
       "config:*",
+      "cost-optimization-hub:UpdateEnrollmentStatus",
       "cur:*",
       "events:*",
       "fms:*",


### PR DESCRIPTION
## 👀 Purpose

- This PR adds `cost-optimization-hub:UpdateEnrollmentStatus` to `GitHubActionsApply` role. This is required in support on the upgrade of [DSIT Integration module](#1304 ). Apply pipeline is currently failing due to lack of permission to implement the upgrade. This PR adds the specific permission.

## ♻️ What's changed

- Add additional permission to the `github-actions-apply` role

## 📝 Notes

- [Fix Failing Apply](https://mojdt.slack.com/archives/C06P4KA0V0A/p1756467584843749)