### PR TITLE
Coat cur replication policy fix

### DIFF
--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -582,7 +582,8 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_replication" {
     ]
     resources = [
       module.cur_v2_s3_kms.key_arn,
-      "arn:aws:kms:eu-west-1:593291632749:key/0409ddbc-b6a2-46c4-a613-6145f6a16215"
+      "arn:aws:kms:eu-west-1:593291632749:key/0409ddbc-b6a2-46c4-a613-6145f6a16215",
+      "arn:aws:kms:eu-west-2:279191903737:key/ef7e1dc9-dc2b-4733-9278-46885b7040c7"
     ]
   }
 }

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -559,7 +559,9 @@ data "aws_iam_policy_document" "cur_reports_v2_hourly_replication" {
     ]
     resources = [
       "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly",
-      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly/*"
+      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly/*",
+      "arn:aws:s3:::coat-production-cur-v2-hourly",
+      "arn:aws:s3:::coat-production-cur-v2-hourly/*"
     ]
   }
   statement {


### PR DESCRIPTION
<!-- Explain the purpose of this pull request. Provide any relevant context or link related issues. -->
## :eyes: Purpose

- Fix to restore CUR reports replication from the root account to coat-production. 

- Added coat-production-cur-v2-hourly to the destination bucket permissions and corresponding KMS key to destination bucket kms. 

<!-- Describe what has been changed in this pull request. Be specific about what has been added, modified, or fixed. As part of good code hygiene, include a reminder for contributors to check and update packages to their latest versions. -->
## :recycle: What's Changed

- Added bucket and KMS key arn's into "DestinationBucketPermissions" and "DestinationBucketKMSKey" replication policy blocks. 

<!-- Add any additional notes, such as special instructions for testing, potential impacts on other areas of the codebase, etc. -->
## :memo: Notes

- [#5488 ](https://github.com/ministryofjustice/operations-engineering/issues/5488)
