### PR TITLE
:wrench: Configure DataSync for historic CUR usage

### DIFF
--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -7,7 +7,7 @@ locals {
 # SOURCE - Root account S3 location
 resource "aws_datasync_location_s3" "root_account" {
   s3_bucket_arn = module.cur_reports_v2_hourly_s3_bucket.s3_bucket_arn
-  subdirectory  = local.source_subdirectory
+  subdirectory  = local.coat_ap_datasync_source_subdirectory
 
   s3_config {
     bucket_access_role_arn = module.coat_datasync_iam_role.arn
@@ -17,8 +17,8 @@ resource "aws_datasync_location_s3" "root_account" {
 # DESTINATION - APDP
 resource "aws_datasync_location_s3" "apdp_account" {
   region        = "eu-west-1"
-  s3_bucket_arn = "arn:aws:s3:::${local.destination_bucket}"
-  subdirectory  = local.destination_subdirectory
+  s3_bucket_arn = "arn:aws:s3:::${local.coat_ap_datasync_destination_bucket}"
+  subdirectory  = local.coat_ap_datasync_destination_subdirectory
 
   s3_config {
     bucket_access_role_arn = module.coat_datasync_iam_role.arn

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -4,7 +4,7 @@ resource "aws_datasync_location_s3" "root_account" {
   subdirectory  = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 
   s3_config {
-    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.name}" #TODO: review
+    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.name}"
   }
 }
 
@@ -15,7 +15,7 @@ resource "aws_datasync_location_s3" "apdp_account" {
   subdirectory  = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 
   s3_config {
-    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.name}" #TODO: review
+    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.name}"
   }
 }
 

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -1,7 +1,7 @@
 locals {
-  destination_bucket       = "mojap-data-production-coat-cur-reports-v2-hourly"
-  source_subdirectory      = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
-  destination_subdirectory = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
+  coat_ap_datasync_destination_bucket       = "mojap-data-production-coat-cur-reports-v2-hourly"
+  coat_ap_datasync_source_subdirectory      = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
+  coat_ap_datasync_destination_subdirectory = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 }
 
 # SOURCE - Root account S3 location

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -1,3 +1,7 @@
+locals {
+  destination_bucket = "mojap-data-production-coat-cur-reports-v2-hourly"
+}
+
 # SOURCE - Root account S3 location
 resource "aws_datasync_location_s3" "root_account" {
   s3_bucket_arn = module.cur_reports_v2_hourly_s3_bucket.s3_bucket_arn
@@ -11,7 +15,7 @@ resource "aws_datasync_location_s3" "root_account" {
 # DESTINATION - APDP
 resource "aws_datasync_location_s3" "apdp_account" {
   region        = "eu-west-1"
-  s3_bucket_arn = "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly"
+  s3_bucket_arn = "arn:aws:s3:::${local.destination_bucket}"
   subdirectory  = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 
   s3_config {

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -21,7 +21,7 @@ resource "aws_datasync_location_s3" "apdp_account" {
 
 resource "aws_datasync_task" "coat_to_apdp_task" {
   destination_location_arn = aws_datasync_location_s3.apdp_account.arn
-  name                     = "root-to-apdp-coat-cur-reports-v2-hourly"
+  name                     = "root-to-apdp-coat-cur-reports"
   source_location_arn      = aws_datasync_location_s3.root_account.arn
   task_mode                = "ENHANCED"
 }

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -4,7 +4,7 @@ resource "aws_datasync_location_s3" "root_account" {
   subdirectory  = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 
   s3_config {
-    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.name}"
+    bucket_access_role_arn = "${module.coat_datasync_iam_role.arn}"
   }
 }
 
@@ -15,7 +15,7 @@ resource "aws_datasync_location_s3" "apdp_account" {
   subdirectory  = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 
   s3_config {
-    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.name}"
+    bucket_access_role_arn = "${module.coat_datasync_iam_role.arn}"
   }
 }
 

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -11,7 +11,7 @@ resource "aws_datasync_location_s3" "root_account" {
 # DESTINATION - APDP
 resource "aws_datasync_location_s3" "apdp_account" {
   region        = "eu-west-1"
-  s3_bucket_arn = "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly" #TODO: review
+  s3_bucket_arn = "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly"
   subdirectory  = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 
   s3_config {

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -1,7 +1,7 @@
 # SOURCE - Root account S3 location
 resource "aws_datasync_location_s3" "root_account" {
   s3_bucket_arn = module.cur_reports_v2_hourly_s3_bucket.s3_bucket_arn
-  subdirectory  = "/" #TODO: ask COAT if this is correct
+  subdirectory  = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 
   s3_config {
     bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.name}" #TODO: review
@@ -12,7 +12,7 @@ resource "aws_datasync_location_s3" "root_account" {
 resource "aws_datasync_location_s3" "apdp_account" {
   region        = "eu-west-1"
   s3_bucket_arn = "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly" #TODO: review
-  subdirectory  = "/"                                                             #TODO: ask COAT where they want the data to go
+  subdirectory  = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 
   s3_config {
     bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.name}" #TODO: review

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -1,0 +1,27 @@
+# SOURCE - Root account S3 location
+resource "aws_datasync_location_s3" "root_account" {
+  s3_bucket_arn = module.cur_reports_v2_hourly_s3_bucket.s3_bucket_arn
+  subdirectory  = "/" #TODO: ask COAT if this is correct
+
+  s3_config {
+    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.role_name}" #TODO: review
+  }
+}
+
+# DESTINATION - APDP
+resource "aws_datasync_location_s3" "apdp_account" {
+  region        = "eu-west-1"
+  s3_bucket_arn = "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly" #TODO: review
+  subdirectory  = "/" #TODO: ask COAT where they want the data to go
+
+  s3_config {
+    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.role_name}" #TODO: review
+  }
+}
+
+resource "aws_datasync_task" "coat_to_apdp_task" {
+  destination_location_arn = aws_datasync_location_s3.apdp_account.arn
+  name                     = "root-to-apdp-coat-cur-reports-v2-hourly"
+  source_location_arn      = aws_datasync_location_s3.root_account.arn
+  task_mode                = "ENHANCED"
+}

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -1,14 +1,16 @@
 locals {
   destination_bucket = "mojap-data-production-coat-cur-reports-v2-hourly"
+  source_subdirectory = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
+  destination_subdirectory = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 }
 
 # SOURCE - Root account S3 location
 resource "aws_datasync_location_s3" "root_account" {
   s3_bucket_arn = module.cur_reports_v2_hourly_s3_bucket.s3_bucket_arn
-  subdirectory  = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
+  subdirectory  = local.source_subdirectory
 
   s3_config {
-    bucket_access_role_arn = "${module.coat_datasync_iam_role.arn}"
+    bucket_access_role_arn = module.coat_datasync_iam_role.arn
   }
 }
 
@@ -16,10 +18,10 @@ resource "aws_datasync_location_s3" "root_account" {
 resource "aws_datasync_location_s3" "apdp_account" {
   region        = "eu-west-1"
   s3_bucket_arn = "arn:aws:s3:::${local.destination_bucket}"
-  subdirectory  = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
+  subdirectory  = local.destination_subdirectory
 
   s3_config {
-    bucket_access_role_arn = "${module.coat_datasync_iam_role.arn}"
+    bucket_access_role_arn = module.coat_datasync_iam_role.arn
   }
 }
 

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -4,7 +4,7 @@ resource "aws_datasync_location_s3" "root_account" {
   subdirectory  = "/" #TODO: ask COAT if this is correct
 
   s3_config {
-    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.role_name}" #TODO: review
+    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.name}" #TODO: review
   }
 }
 
@@ -12,10 +12,10 @@ resource "aws_datasync_location_s3" "root_account" {
 resource "aws_datasync_location_s3" "apdp_account" {
   region        = "eu-west-1"
   s3_bucket_arn = "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly" #TODO: review
-  subdirectory  = "/" #TODO: ask COAT where they want the data to go
+  subdirectory  = "/"                                                             #TODO: ask COAT where they want the data to go
 
   s3_config {
-    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.role_name}" #TODO: review
+    bucket_access_role_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${module.coat_datasync_iam_policy.name}" #TODO: review
   }
 }
 

--- a/management-account/terraform/datasync.tf
+++ b/management-account/terraform/datasync.tf
@@ -1,6 +1,6 @@
 locals {
-  destination_bucket = "mojap-data-production-coat-cur-reports-v2-hourly"
-  source_subdirectory = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
+  destination_bucket       = "mojap-data-production-coat-cur-reports-v2-hourly"
+  source_subdirectory      = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
   destination_subdirectory = "moj-cost-and-usage-reports/MOJ-CUR-V2-HOURLY/"
 }
 

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -134,7 +134,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceAccount"
-      values = ["${local.accounts.active_only["analytical-platform-data-production"]}"]
+      values   = ["${local.accounts.active_only["analytical-platform-data-production"]}"]
     }
   }
 
@@ -158,7 +158,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceAccount"
-      values = ["${local.accounts.active_only["analytical-platform-data-production"]}"]
+      values   = ["${local.accounts.active_only["analytical-platform-data-production"]}"]
     }
   }
 

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -173,7 +173,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "kms:GenerateDataKey",
     ]
     resources = [
-      module.cur_v2_s3_kms.kms_key_arn
+      module.cur_v2_s3_kms.key_arn
     ]
   }
 

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -186,7 +186,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "kms:DescribeKey"
     ]
     resources = [
-      "arn:aws:kms:eu-west-1:${local.accounts.active_only["analytical-platform-data-production"]}:key/*"
+      "arn:aws:kms:eu-west-1:${local.accounts.active_only["analytical-platform-data-production"]}:key/0409ddbc-b6a2-46c4-a613-6145f6a16215"
     ]
   }
 }
@@ -198,7 +198,7 @@ module "coat_datasync_iam_policy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "6.2.1"
 
-  name_prefix = "coat-datasync-iam-policy"
+  name_prefix = "coat-datasync"
 
   policy = data.aws_iam_policy_document.coat_datasync_iam_policy.json
 }

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -116,7 +116,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "s3:ListBucketMultipartUploads",
     ]
     resources = [
-      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly"
+      "arn:aws:s3:::${local.coat_ap_datasync_destination_bucket}"
     ]
     condition {
       test     = "StringEquals"

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -117,7 +117,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "dms:StartReplicationTask",
       "dms:StopReplicationTask",
     ]
-    resources = ["*"] #TODO: tighten this up
+    resources = ["*"]
   }
 
   statement {
@@ -129,12 +129,11 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "s3:ListBucketMultipartUploads",
     ]
     resources = [
-      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly" #TODO: Update call
+      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly"
     ]
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceAccount"
-      # values   = ["593291632749"] #TODO: Update call to APDP
       values = ["${local.accounts.active_only["analytical-platform-data-production"]}"]
     }
   }
@@ -154,13 +153,12 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "s3:PutObjectTagging",
     ]
     resources = [
-      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly/*" #TODO: Update call
+      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly/*"
     ]
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceAccount"
-      values   = ["593291632749"] #TODO: Updatecall to APDP
-      # values = [${local.accounts.active_only["analytical-platform-data-production"]}] #No idea if this is correct - based off of something else I've read in this repo
+      values = ["${local.accounts.active_only["analytical-platform-data-production"]}"]
     }
   }
 
@@ -188,8 +186,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "kms:DescribeKey"
     ]
     resources = [
-      "arn:aws:kms:eu-west-1:593291632749:key/*" #TODO: Update call to APDP / tighten this up
-      # "arn:aws:kms:eu-west-1:${local.accounts.active_only["analytical-platform-data-production"]}:key/*" #ASK: No idea if this is correct - based off of something else I've read in this repo
+      "arn:aws:kms:eu-west-1:${local.accounts.active_only["analytical-platform-data-production"]}:key/*"
     ]
   }
 }

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -134,8 +134,8 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceAccount"
-      values   = ["593291632749"] #TODO: Update call to APDP
-      # values = [${local.accounts.active_only["analytical-platform-data-production"]}] #No idea if this is correct - based off of something else I've read in this repo
+      # values   = ["593291632749"] #TODO: Update call to APDP
+      values = [${local.accounts.active_only["analytical-platform-data-production"]}]
     }
   }
 

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -117,7 +117,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "dms:StartReplicationTask",
       "dms:StopReplicationTask",
     ]
-    resources = ["*"]  #TODO: tighten this up
+    resources = ["*"] #TODO: tighten this up
   }
 
   statement {

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -108,19 +108,6 @@ data "aws_iam_policy_document" "billing_full_access" {
 ######################
 data "aws_iam_policy_document" "coat_datasync_iam_policy" {
   statement {
-    sid    = "CoatDatasyncDmsPermissions"
-    effect = "Allow"
-    actions = [
-      "dms:DescribeEndpoints",
-      "dms:DescribeReplicationInstances",
-      "dms:DescribeReplicationTasks",
-      "dms:StartReplicationTask",
-      "dms:StopReplicationTask",
-    ]
-    resources = ["*"]
-  }
-
-  statement {
     sid    = "CoatDatasyncS3BucketPermissions"
     effect = "Allow"
     actions = [

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -140,7 +140,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "s3:PutObjectTagging",
     ]
     resources = [
-      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly/*"
+      "arn:aws:s3:::${local.coat_ap_datasync_destination_bucket}/*"
     ]
     condition {
       test     = "StringEquals"

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       test     = "StringEquals"
       variable = "aws:ResourceAccount"
       # values   = ["593291632749"] #TODO: Update call to APDP
-      values = [${local.accounts.active_only["analytical-platform-data-production"]}]
+      values = ["${local.accounts.active_only["analytical-platform-data-production"]}"]
     }
   }
 

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -325,7 +325,7 @@ module "coat_datasync_iam_role" {
   name            = "coat-datasync"
   use_name_prefix = false
 
-  TrustStatement = {
+  trust_policy_permissions = {
     DataSync = {
       actions = [
         "sts:AssumeRole",

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -325,7 +325,7 @@ module "coat_datasync_iam_role" {
   name            = "coat-datasync"
   use_name_prefix = false
 
-  trust_policy_permissions = {
+  TrustStatement = {
     DataSync = {
       actions = [
         "sts:AssumeRole",

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -310,3 +310,39 @@ resource "aws_iam_role_policy_attachment" "analytical_platform_identity_center" 
   role       = aws_iam_role.analytical_platform_identity_center.name
   policy_arn = aws_iam_policy.analytical_platform_identity_center.arn
 }
+
+######################
+# COAT DataSync Role #
+######################
+
+module "coat_datasync_iam_role" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.2.1"
+
+  name            = "CoatDataSyncRole"
+  use_name_prefix = false
+
+  trust_policy_permissions = {
+    DataSync = {
+      actions = [
+        "sts:AssumeRole",
+      ]
+      principals = concat(
+        [
+          {
+            type        = "Service"
+            identifiers = ["datasync.amazonaws.com"]
+          }
+        ]
+      )
+    }
+  }
+
+  policies = {
+    custom = module.coat_datasync_iam_policy.arn
+  }
+}
+

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -322,7 +322,7 @@ module "coat_datasync_iam_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role"
   version = "6.2.1"
 
-  name            = "CoatDataSyncRole"
+  name            = "coat-datasync"
   use_name_prefix = false
 
   trust_policy_permissions = {


### PR DESCRIPTION
_Damn no development container in here. What a shame!_ 😜

This PR relates to [this](https://github.com/orgs/ministryofjustice/projects/27/views/18?pane=issue&itemId=124508041&issue=ministryofjustice%7Canalytical-platform%7C8496) piece of work.

It duplicates configuration done in [this](https://github.com/ministryofjustice/analytical-platform/pull/8635) PR which has successfully configured DataSync between `analytical-platform-data-engineering-sandbox-a` and `analytical-platform-data-production`.

This PR configures: 
- two datasync locations (source - [this S3 bucket](https://github.com/ministryofjustice/aws-root-account/blob/3693caff24762467d6ce2c96b517075c2406ebd4/management-account/terraform/s3.tf#L302), destination - [this bucket in APDP](https://github.com/ministryofjustice/analytical-platform/blob/52cfa3e4b916be9539c55b8966cbaf6d49c3162e/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf#L28) - subdirectories were specified by the COAT team)
- a datasync task `root-to-apdp-coat-cur-reports`
- associated IAM role and policy

These consume a previously configured bucket and key. 