### PR TITLE
Enable Runtime monitoring for new accounts

### DIFF
--- a/modules/guardduty-org-sec/main.tf
+++ b/modules/guardduty-org-sec/main.tf
@@ -38,6 +38,30 @@ resource "aws_guardduty_organization_configuration_feature" "eks_runtime_monitor
   }
 }
 
+###########################################################################
+# Auto-enable Runtime Monitoring for new accounts in the AWS Organization #
+###########################################################################
+# Note we are leaving installing the security agent add-on as a manual process
+resource "aws_guardduty_organization_configuration_feature" "runtime_monitoring" {
+  provider    = aws.delegated_administrator
+  detector_id = var.administrator_detector_id
+  name        = "RUNTIME_MONITORING"
+  auto_enable = "NEW"
+
+  additional_configuration {
+    name        = "EKS_ADDON_MANAGEMENT"
+    auto_enable = "NONE"
+  }
+  additional_configuration {
+    name        = "ECS_FARGATE_AGENT_MANAGEMENT"
+    auto_enable = "NONE"
+  }
+  additional_configuration {
+    name        = "EC2_AGENT_MANAGEMENT"
+    auto_enable = "NONE"
+  }
+}
+
 ####################################
 # GuardDuty publishing destination #
 ####################################


### PR DESCRIPTION
We do not want to do this for all accounts currently, this way we have this configuration in code, but we can choose which accounts to add to this.

Also with the agent configurations, we do not want to automatically add the agents we need to add them and test their impact.