### PR TITLE
🔥 Remove Modernisation Platform as The `Billing` Contact

### DIFF
--- a/management-account/terraform/account.tf
+++ b/management-account/terraform/account.tf
@@ -8,7 +8,7 @@ resource "aws_account_alternate_contact" "operations" {
 
 resource "aws_account_alternate_contact" "billing" {
   alternate_contact_type = "BILLING"
-  email_address          = "hosting-billing@digital.justice.gov.uk"
+  email_address          = "HostingBilling-gg@justice.gov.uk"
   name                   = "Hosting Billing"
   title                  = "Team"
   phone_number           = "+0000000000"

--- a/management-account/terraform/account.tf
+++ b/management-account/terraform/account.tf
@@ -8,8 +8,8 @@ resource "aws_account_alternate_contact" "operations" {
 
 resource "aws_account_alternate_contact" "billing" {
   alternate_contact_type = "BILLING"
-  email_address          = "modernisation-platform@digital.justice.gov.uk"
-  name                   = "Modernisation Platform"
+  email_address          = "hosting-billing@digital.justice.gov.uk"
+  name                   = "Hosting Billing"
   title                  = "Team"
   phone_number           = "+0000000000"
 }

--- a/organisation-security/terraform/account.tf
+++ b/organisation-security/terraform/account.tf
@@ -5,11 +5,3 @@ resource "aws_account_alternate_contact" "operations" {
   title                  = "Team"
   phone_number           = "+0000000000"
 }
-
-resource "aws_account_alternate_contact" "billing" {
-  alternate_contact_type = "BILLING"
-  email_address          = "modernisation-platform@digital.justice.gov.uk"
-  name                   = "Modernisation Platform"
-  title                  = "Team"
-  phone_number           = "+0000000000"
-}


### PR DESCRIPTION
## 👀 Purpose

- To reduce noise in the Modernisation Platform mailbox, as the billing contact seems to just receive invoices, which aren't relevant to the team

## ♻️ What's changed

- Removed Modernisation Platform as The `Billing` Contact for the Management Account and Organisation Security Account
- *Reverts to previous billing contact for Management Account

## 📓 Notes

- Looking at my notes, before https://github.com/ministryofjustice/aws-root-account/pull/1303 the billing contact for the management account was `hosting-billing@digital.justice.gov.uk` - this wasn't in code, so I accidentally overwrote it 🙈 So a part of this change puts that contact in code 🧑‍💻 Although this interestingly wasn't picked up by [Terraform Apply](https://github.com/ministryofjustice/aws-root-account/actions/runs/17263204474/job/48993360714#step:9:2951) 🤷
- Organistion Logging is not managed in code - so I will update that manually 🔧 