### PR TITLE
:wrench: Add `datasync:*` permissions to OIDC

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -152,6 +152,7 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
       "cur:ListTagsForResource",
       "cur:PutReportDefinition",
       "cur:DeleteReportDefinition",
+      "datasync:*",
       "events:*",
       "fms:*",
       "guardduty:*",


### PR DESCRIPTION
This PR seeks to resolve [this](https://github.com/ministryofjustice/aws-root-account/actions/runs/17618675516/job/50058485671) apply issue.