### PR TITLE
Add 'organizations:DeletePolicy' action to GitHub Actions policy

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -170,6 +170,7 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
       "organizations:CreateAccount",
       "organizations:CreateOrganizationalUnit",
       "organizations:CreatePolicy",
+      "organizations:DeletePolicy",
       "organizations:DescribeAccount",
       "organizations:DescribeCreateAccountStatus",
       "organizations:DescribeOrganization",


### PR DESCRIPTION
Fixes issue trying to delete an SCP policy created in a subsequent PR...
https://github.com/ministryofjustice/aws-root-account/actions/runs/18013144299/job/51250975440#step:9:3069

This PR adds the 'organizations:DeletePolicy' action to the GitHub Actions role to add permissions to remove a policy.