### PR TITLE
Remove `organizations:DetachPolicy` action

### DIFF
--- a/modules/github-oidc-provider/main.tf
+++ b/modules/github-oidc-provider/main.tf
@@ -173,7 +173,6 @@ data "aws_iam_policy_document" "extra_permissions_apply" {
       "organizations:DescribeAccount",
       "organizations:DescribeCreateAccountStatus",
       "organizations:DescribeOrganization",
-      "organizations:DetachPolicy",
       "organizations:DisablePolicyType",
       "organizations:EnablePolicyType",
       "organizations:EnableAWSServiceAccess",


### PR DESCRIPTION
Removed `organizations:DetachPolicy` from the policy actions list to make it harder for a rogue PR or malicious action to edit SCPs. 