### PR TITLE
Enable Zurich for Bedrock Cross-Region Inference

### DIFF
--- a/management-account/terraform/config.tf
+++ b/management-account/terraform/config.tf
@@ -45,6 +45,17 @@ module "config_eu_central_1" {
   snapshot_delivery_frequency = "One_Hour"
 }
 
+module "config_eu_central_2" {
+  source = "../../modules/config"
+  providers = {
+    aws = aws.eu-central-2
+  }
+
+  iam_role_arn                = module.config_eu_west_2.iam_role_arn
+  s3_bucket_name              = module.config_log_bucket.bucket_name
+  snapshot_delivery_frequency = "One_Hour"
+}
+
 ########################
 # Config in US regions #
 ########################

--- a/management-account/terraform/guardduty.tf
+++ b/management-account/terraform/guardduty.tf
@@ -221,6 +221,21 @@ module "guardduty_eu_central_1" {
   })
 }
 
+module "guardduty_eu_central_2" {
+  source = "../../modules/guardduty-root"
+
+  providers = {
+    aws.root_account            = aws.eu-central-2
+    aws.delegated_administrator = aws.organisation-security-eu-central-2
+  }
+
+  root_tags = local.root_account
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+}
+
 module "guardduty_eu_west_1" {
   source = "../../modules/guardduty-root"
 

--- a/management-account/terraform/ipam.tf
+++ b/management-account/terraform/ipam.tf
@@ -23,3 +23,8 @@ resource "aws_vpc_ipam_organization_admin_account" "eu_central_1" {
   provider                   = aws.eu-central-1
   delegated_admin_account_id = aws_organizations_account.organisation_security.id
 }
+
+resource "aws_vpc_ipam_organization_admin_account" "eu_central_2" {
+  provider                   = aws.eu-central-2
+  delegated_admin_account_id = aws_organizations_account.organisation_security.id
+}

--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -73,6 +73,10 @@ locals {
     ]
   }
 
+  # Flat list of all modernisation platform account IDs
+  modernisation_platform_account_ids = flatten(values(local.modernisation_platform_accounts))
+
+
   root_account = merge(local.tags_business_units.platforms, {
     application   = "AWS root account"
     is-production = true
@@ -147,4 +151,8 @@ locals {
       "arn:aws:s3:::${location}/*"
     ]
   ])
+
+  non_default_enabled_regions = [
+    "eu-central-2"
+  ]
 }

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -195,6 +195,7 @@ data "aws_iam_policy_document" "deny_non_eu_non_us_east_1_operations" {
       variable = "aws:RequestedRegion"
       values = [
         "eu-central-1", # Europe (Frankfurt)
+        "eu-central-2", # Europe (Zurich)
         "eu-north-1",   # Europe (Stockholm)
         "eu-south-1",   # Europe (Milan)
         "eu-south-2",   # Europe (Spain)

--- a/management-account/terraform/outputs.tf
+++ b/management-account/terraform/outputs.tf
@@ -13,6 +13,7 @@ output "guardduty_administrator_detector_ids" {
     "ap_southeast_2" = module.guardduty_ap_southeast_2.administrator_detector_id
     "ca_central_1"   = module.guardduty_ca_central_1.administrator_detector_id
     "eu_central_1"   = module.guardduty_eu_central_1.administrator_detector_id
+    "eu_central_2"   = module.guardduty_eu_central_2.administrator_detector_id
     "eu_west_1"      = module.guardduty_eu_west_1.administrator_detector_id
     "eu_west_2"      = module.guardduty_eu_west_2.administrator_detector_id
     "eu_west_3"      = module.guardduty_eu_west_3.administrator_detector_id

--- a/management-account/terraform/providers-organisation-security.tf
+++ b/management-account/terraform/providers-organisation-security.tf
@@ -122,6 +122,16 @@ provider "aws" {
   }
 }
 
+# eu-central-2
+provider "aws" {
+  region = "eu-central-2"
+  alias  = "organisation-security-eu-central-2"
+
+  assume_role {
+    role_arn = can(regex("GitHubActionsPlan", data.aws_caller_identity.current.arn)) ? "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/ReadOnly" : "arn:aws:iam::${aws_organizations_account.organisation_security.id}:role/OrganizationAccountAccessRole"
+  }
+}
+
 # eu-west-1
 provider "aws" {
   region = "eu-west-1"

--- a/management-account/terraform/providers.tf
+++ b/management-account/terraform/providers.tf
@@ -94,6 +94,11 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "eu-central-2"
+  region = "eu-central-2"
+}
+
+provider "aws" {
   alias  = "eu-west-1"
   region = "eu-west-1"
 }

--- a/management-account/terraform/regions.tf
+++ b/management-account/terraform/regions.tf
@@ -1,0 +1,33 @@
+
+
+# Enable non-default regions for modernisation platform accounts
+
+resource "aws_account_region" "modernisation_platform_accounts" {
+  for_each = {
+    for combo in setproduct(local.non_default_enabled_regions, local.modernisation_platform_account_ids) :
+    "${combo[0]}-${combo[1]}" => {
+      region     = combo[0]
+      account_id = combo[1]
+    }
+  }
+  account_id  = each.value.account_id
+  region_name = each.value.region
+  enabled     = true
+}
+
+# Enable non-default regions for management account
+
+resource "aws_account_region" "management_account" {
+  for_each    = toset(local.non_default_enabled_regions)
+  region_name = each.value
+  enabled     = true
+}
+
+# Enable non-default regions for organisation security account
+
+resource "aws_account_region" "organisation_security_account" {
+  for_each    = toset(local.non_default_enabled_regions)
+  account_id  = aws_organizations_account.organisation_security.id
+  region_name = each.value
+  enabled     = true
+}

--- a/management-account/terraform/securityhub.tf
+++ b/management-account/terraform/securityhub.tf
@@ -37,6 +37,15 @@ module "securityhub_eu_central_1" {
   admin_account = aws_organizations_account.organisation_security.id
 }
 
+module "securityhub_eu_central_2" {
+  source = "../../modules/securityhub"
+  providers = {
+    aws = aws.eu-central-2
+  }
+
+  admin_account = aws_organizations_account.organisation_security.id
+}
+
 ##############################
 # Security Hub in US regions #
 ##############################

--- a/organisation-security/terraform/guardduty.tf
+++ b/organisation-security/terraform/guardduty.tf
@@ -386,6 +386,35 @@ module "guardduty_eu_central_1" {
   ]
 }
 
+module "guardduty_eu_central_2" {
+  source = "../../modules/guardduty-org-sec"
+
+  providers = { aws.delegated_administrator = aws.eu-central-2 }
+
+  administrator_detector_id = local.guardduty_administrator_detector_ids.eu_central_2
+
+  # Utilise ThreatIntelSet
+  enable_threatintelset = false
+  threatintelset_key    = aws_s3_object.guardduty_threatintelset.key
+  threatintelset_bucket = aws_s3_object.guardduty_threatintelset.bucket
+
+  # Automatically enable GuardDuty for eu-central-2
+  auto_enable = true
+
+  destination_arn = module.guardduty_publishing_destination_s3_bucket.bucket.arn
+  kms_key_arn     = aws_kms_key.guardduty.arn
+
+
+  administrator_tags = merge(
+    local.tags_organisation_management, {
+      component = "Security"
+  })
+
+  depends_on = [
+    module.guardduty_publishing_destination_s3_bucket
+  ]
+}
+
 module "guardduty_eu_west_1" {
   source = "../../modules/guardduty-org-sec"
 

--- a/organisation-security/terraform/ipam.tf
+++ b/organisation-security/terraform/ipam.tf
@@ -7,7 +7,8 @@ locals {
     "eu-west-1",
     "eu-west-2",
     "eu-west-3",
-    "eu-central-1"
+    "eu-central-1",
+    "eu-central-2"
   ]
 }
 

--- a/organisation-security/terraform/providers.tf
+++ b/organisation-security/terraform/providers.tf
@@ -88,6 +88,11 @@ provider "aws" {
 }
 
 provider "aws" {
+  alias  = "eu-central-2"
+  region = "eu-central-2"
+}
+
+provider "aws" {
   alias  = "eu-west-1"
   region = "eu-west-1"
 }

--- a/organisation-security/terraform/securityhub.tf
+++ b/organisation-security/terraform/securityhub.tf
@@ -39,6 +39,15 @@ module "securityhub_eu_central_1" {
   is_delegated_administrator = true
 }
 
+module "securityhub_eu_central_2" {
+  source = "../../modules/securityhub"
+  providers = {
+    aws = aws.eu-central-2
+  }
+
+  is_delegated_administrator = true
+}
+
 ##############################
 # Security Hub in US regions #
 ##############################


### PR DESCRIPTION
This enabled the Zurich region to allow the use of the Sonnet 4.5 model which routes cross-region inference requests to `eu-central-2` instead of `eu-central-1` for what I am sure is an exceptionally good reason and not a typo in code.