### PR TITLE
Archive - SCP

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -116,12 +116,12 @@ resource "aws_organizations_policy_attachment" "mp_s3_block_public_access" {
   target_id = aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id
 }
 
-########################################
-# DenyCloudTrailDeleteStopUpdatePolicy #
-########################################
-resource "aws_organizations_policy" "deny_cloudtrail_delete_stop_update" {
-  name        = "DenyCloudTrailDeleteStopUpdatePolicy"
-  description = "Denies changes to CloudTrail (DeleteTrail, StopLogging, UpdateTrail) while allowing ModernisationPlatformAccess role for infrastructure automation"
+###################################################
+# DenyCloudTrailDeleteStopUpdatePolicy Sprinkler  #
+###################################################
+resource "aws_organizations_policy" "deny_cloudtrail_delete_stop_update_sprinkler" {
+  name        = "DenyCloudTrailDeleteStopUpdatePolicySprinkler"
+  description = "Denies changes to CloudTrail (DeleteTrail, StopLogging, UpdateTrail) for modernisation-platform-sprinkler while allowing ModernisationPlatformAccess role for infrastructure automation"
   type        = "SERVICE_CONTROL_POLICY"
 
   tags = {
@@ -130,10 +130,10 @@ resource "aws_organizations_policy" "deny_cloudtrail_delete_stop_update" {
     source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
   }
 
-  content = data.aws_iam_policy_document.deny_cloudtrail_delete_stop_update.json
+  content = data.aws_iam_policy_document.deny_cloudtrail_delete_stop_update_sprinkler.json
 }
 
-data "aws_iam_policy_document" "deny_cloudtrail_delete_stop_update" {
+data "aws_iam_policy_document" "deny_cloudtrail_delete_stop_update_sprinkler" {
   statement {
     effect = "Deny"
     actions = [
@@ -152,7 +152,7 @@ data "aws_iam_policy_document" "deny_cloudtrail_delete_stop_update" {
   }
 }
 
-data "aws_organizations_organizational_units" "modernisation_platform_member_children" {
+data "aws_organizations_organizational_units" "modernisation_platform_member_children_sprinkler" {
   parent_id = [
     for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children :
     child.id
@@ -162,11 +162,11 @@ data "aws_organizations_organizational_units" "modernisation_platform_member_chi
 
 resource "aws_organizations_policy_attachment" "deny_cloudtrail_delete_stop_update_sprinkler" {
   for_each = toset([
-    for child in data.aws_organizations_organizational_units.modernisation_platform_member_children.children :
+    for child in data.aws_organizations_organizational_units.modernisation_platform_member_children_sprinkler.children :
     child.id
     if child.name == "modernisation-platform-sprinkler"
   ])
 
-  policy_id = aws_organizations_policy.deny_cloudtrail_delete_stop_update.id
+  policy_id = aws_organizations_policy.deny_cloudtrail_delete_stop_update_sprinkler.id
   target_id = each.value
 }

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -115,3 +115,58 @@ resource "aws_organizations_policy_attachment" "mp_s3_block_public_access" {
   policy_id = aws_organizations_policy.mp_s3_block_public_access.id
   target_id = aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id
 }
+
+########################################
+# DenyCloudTrailDeleteStopUpdatePolicy #
+########################################
+resource "aws_organizations_policy" "deny_cloudtrail_delete_stop_update" {
+  name        = "DenyCloudTrailDeleteStopUpdatePolicy"
+  description = "Denies changes to CloudTrail (DeleteTrail, StopLogging, UpdateTrail) while allowing ModernisationPlatformAccess role for infrastructure automation"
+  type        = "SERVICE_CONTROL_POLICY"
+
+  tags = {
+    business-unit = "Security"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
+  }
+
+  content = data.aws_iam_policy_document.deny_cloudtrail_delete_stop_update.json
+}
+
+data "aws_iam_policy_document" "deny_cloudtrail_delete_stop_update" {
+  statement {
+    effect = "Deny"
+    actions = [
+      "cloudtrail:UpdateTrail",
+      "cloudtrail:DeleteTrail",
+      "cloudtrail:StopLogging"
+    ]
+    resources = ["*"]
+
+    # Exclusion of ModernisationPlatformAccess role for Terraform infrastructure automation
+    condition {
+      test     = "StringNotLike"
+      variable = "aws:PrincipalARN"
+      values   = ["arn:aws:iam::*:role/ModernisationPlatformAccess"]
+    }
+  }
+}
+
+data "aws_organizations_organizational_units" "modernisation_platform_member_children" {
+  parent_id = [
+    for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children :
+    child.id
+    if child.name == "Modernisation Platform Member"
+  ][0]
+}
+
+resource "aws_organizations_policy_attachment" "deny_cloudtrail_delete_stop_update_sprinkler" {
+  for_each = toset([
+    for child in data.aws_organizations_organizational_units.modernisation_platform_member_children.children :
+    child.id
+    if child.name == "modernisation-platform-sprinkler"
+  ])
+
+  policy_id = aws_organizations_policy.deny_cloudtrail_delete_stop_update.id
+  target_id = each.value
+}

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -126,7 +126,7 @@ resource "aws_organizations_policy_attachment" "mp_s3_block_public_access" {
 ###################################################
 resource "aws_organizations_policy" "deny_cloudtrail_delete_stop_update_sprinkler" {
   name        = "DenyCloudTrailDeleteStopUpdatePolicySprinkler"
-  description = "Denies changes to CloudTrail (DeleteTrail, StopLogging, UpdateTrail) for modernisation-platform-sprinkler while allowing ModernisationPlatformAccess role for infrastructure automation"
+  description = "Denies DeleteTrail, StopLogging, and UpdateTrail on the 'cloudtrail' trail, except that UpdateTrail is permitted for the ModernisationPlatformAccess role, within modernisation-platform-sprinkler"
   type        = "SERVICE_CONTROL_POLICY"
 
   tags = {
@@ -140,11 +140,22 @@ resource "aws_organizations_policy" "deny_cloudtrail_delete_stop_update_sprinkle
 
 data "aws_iam_policy_document" "deny_cloudtrail_delete_stop_update_sprinkler" {
   statement {
+    sid    = "DenyDeleteTrailAndStopLogging"
     effect = "Deny"
     actions = [
-      "cloudtrail:UpdateTrail",
       "cloudtrail:DeleteTrail",
       "cloudtrail:StopLogging"
+    ]
+    resources = [
+      "arn:aws:cloudtrail:*:*:trail/cloudtrail"
+    ]
+  }
+
+  statement {
+    sid    = "DenyUpdateTrailExceptModernisationPlatformAccess"
+    effect = "Deny"
+    actions = [
+      "cloudtrail:UpdateTrail"
     ]
     resources = [
       "arn:aws:cloudtrail:*:*:trail/cloudtrail"

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -141,7 +141,9 @@ data "aws_iam_policy_document" "deny_cloudtrail_delete_stop_update_sprinkler" {
       "cloudtrail:DeleteTrail",
       "cloudtrail:StopLogging"
     ]
-    resources = ["*"]
+    resources = [
+      "arn:aws:cloudtrail:*:*:trail/cloudtrail"
+    ]
 
     # Exclusion of ModernisationPlatformAccess role for Terraform infrastructure automation
     condition {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=155970301&issue=ministryofjustice%7Cmodernisation-platform-security%7C97

This PR introduces a defensive Service Control Policy (SCP) to prevent CloudTrail actions such as DeleteTrail, StopLogging, and UpdateTrail for Sprinkler.

The objective is to apply this control across the Modernisation Platform OU. However, as an initial step, this change scopes the policy to modernisation-platform-sprinkler to test behaviour and assess any potential impact. A follow-up change will be raised once the impact has been assessed.

## ♻️ What's changed

- Introduced a new SCP resource
- Created a IAM policy document for this SCP.
- Scoped the deny statement so it only targets the CloudTrail trail named cloudtrail, rather than all resources.
- Ensures exclusion for the `ModernisationPlatformAccess` role for update trail.
- Introduced targeting logic to dynamically locate the Modernisation Platform Member OU filter and attach the policy only to the modernisation-platform-sprinkler OU

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes