### PR TITLE
Introduce defensive CloudTrail SCP for MP OU

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -164,7 +164,7 @@ data "aws_iam_policy_document" "mp_deny_cloudtrail_delete_stop_update" {
     # Exclusion of ModernisationPlatformAccess role for Terraform infrastructure automation
     condition {
       test     = "StringNotLike"
-      variable = "aws:PrincipalArn"
+      variable = "aws:PrincipalARN"
       values   = ["arn:aws:iam::*:role/ModernisationPlatformAccess"]
     }
   }

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -126,7 +126,7 @@ resource "aws_organizations_policy_attachment" "mp_s3_block_public_access" {
 ###############################################################
 resource "aws_organizations_policy" "mp_deny_cloudtrail_delete_stop_update" {
   name        = "Modernisation Platform Deny CloudTrail Delete Stop Update"
-  description = "Denies DeleteTrail, StopLogging, and UpdateTrail on the 'cloudtrail' trail for accounts in the Modernisation Platform Member OU, except that UpdateTrail is permitted for the ModernisationPlatformAccess role."
+  description = "Denies DeleteTrail, StopLogging, and UpdateTrail on the 'cloudtrail' trail for accounts in the Modernisation Platform OU, except that UpdateTrail is permitted for the ModernisationPlatformAccess role."
   type        = "SERVICE_CONTROL_POLICY"
 
   tags = {
@@ -164,19 +164,14 @@ data "aws_iam_policy_document" "mp_deny_cloudtrail_delete_stop_update" {
     # Exclusion of ModernisationPlatformAccess role for Terraform infrastructure automation
     condition {
       test     = "StringNotLike"
-      variable = "aws:PrincipalARN"
+      variable = "aws:PrincipalArn"
       values   = ["arn:aws:iam::*:role/ModernisationPlatformAccess"]
     }
   }
 }
 
-# Attach the SCP to the Modernisation Platform Member OU only
+# Attach the SCP to the Modernisation Platform OU only
 resource "aws_organizations_policy_attachment" "mp_deny_cloudtrail_delete_stop_update" {
-  for_each = toset([
-    for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children : child.id
-    if child.name == "Modernisation Platform Member"
-  ])
-
   policy_id = aws_organizations_policy.mp_deny_cloudtrail_delete_stop_update.id
-  target_id = each.value
+  target_id = aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id
 }

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -121,24 +121,24 @@ resource "aws_organizations_policy_attachment" "mp_s3_block_public_access" {
   target_id = each.value
 }
 
-###################################################
-# DenyCloudTrailDeleteStopUpdatePolicy Sprinkler  #
-###################################################
-resource "aws_organizations_policy" "deny_cloudtrail_delete_stop_update_sprinkler" {
-  name        = "DenyCloudTrailDeleteStopUpdatePolicySprinkler"
-  description = "Denies DeleteTrail, StopLogging, and UpdateTrail on the 'cloudtrail' trail, except that UpdateTrail is permitted for the ModernisationPlatformAccess role, within modernisation-platform-sprinkler"
+###############################################################
+# Deny CloudTrail Delete/Stop/Update - MP OU scope
+###############################################################
+resource "aws_organizations_policy" "mp_deny_cloudtrail_delete_stop_update" {
+  name        = "Modernisation Platform Deny CloudTrail Delete Stop Update"
+  description = "Denies DeleteTrail, StopLogging, and UpdateTrail on the 'cloudtrail' trail for accounts in the Modernisation Platform Member OU, except that UpdateTrail is permitted for the ModernisationPlatformAccess role."
   type        = "SERVICE_CONTROL_POLICY"
 
   tags = {
     business-unit = "Security"
     component     = "SERVICE_CONTROL_POLICY"
-    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
+    source-code   = join("", [local.github_repository, "/terraform/organizations-policy-service-control-modernisation-platform.tf"])
   }
 
-  content = data.aws_iam_policy_document.deny_cloudtrail_delete_stop_update_sprinkler.json
+  content = data.aws_iam_policy_document.mp_deny_cloudtrail_delete_stop_update.json
 }
 
-data "aws_iam_policy_document" "deny_cloudtrail_delete_stop_update_sprinkler" {
+data "aws_iam_policy_document" "mp_deny_cloudtrail_delete_stop_update" {
   statement {
     sid    = "DenyDeleteTrailAndStopLogging"
     effect = "Deny"
@@ -164,27 +164,19 @@ data "aws_iam_policy_document" "deny_cloudtrail_delete_stop_update_sprinkler" {
     # Exclusion of ModernisationPlatformAccess role for Terraform infrastructure automation
     condition {
       test     = "StringNotLike"
-      variable = "aws:PrincipalARN"
+      variable = "aws:PrincipalArn"
       values   = ["arn:aws:iam::*:role/ModernisationPlatformAccess"]
     }
   }
 }
 
-data "aws_organizations_organizational_units" "modernisation_platform_member_children_sprinkler" {
-  parent_id = [
-    for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children :
-    child.id
-    if child.name == "Modernisation Platform Member"
-  ][0]
-}
-
-resource "aws_organizations_policy_attachment" "deny_cloudtrail_delete_stop_update_sprinkler" {
+# Attach the SCP to the Modernisation Platform Member OU only
+resource "aws_organizations_policy_attachment" "mp_deny_cloudtrail_delete_stop_update" {
   for_each = toset([
-    for child in data.aws_organizations_organizational_units.modernisation_platform_member_children_sprinkler.children :
-    child.id
-    if child.name == "modernisation-platform-sprinkler"
+    for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children : child.id
+    if child.name == "Modernisation Platform Member"
   ])
 
-  policy_id = aws_organizations_policy.deny_cloudtrail_delete_stop_update_sprinkler.id
+  policy_id = aws_organizations_policy.mp_deny_cloudtrail_delete_stop_update.id
   target_id = each.value
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=155970301&issue=ministryofjustice%7Cmodernisation-platform-security%7C97

This PR introduces a defensive Service Control Policy (SCP) to prevent CloudTrail actions such as `DeleteTrail`, `StopLogging`, and `UpdateTrail` within the Modernisation Platform Member OU.

This control was initially tested against `modernisation-platform-sprinkler` to validate behaviour and assess any potential impact. Following successful [testing](https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=155970301&issue=ministryofjustice%7Cmodernisation-platform-security%7C97), this change applies the control at the wider Modernisation Platform Member OU level.

## ♻️ What's changed

- Introduced a new SCP resource for the Modernisation Platform Member OU.
- Created an IAM policy document for this SCP.
- Scoped the policy so it only targets the CloudTrail trail named `cloudtrail`, rather than all resources.
- Split the deny logic so that:
  - `DeleteTrail` and `StopLogging` are denied for all principals
  - `UpdateTrail` is denied for all principals except the `ModernisationPlatformAccess` role
- Updated the attachment logic so the policy applies to the `Modernisation Platform Member` OU.
- Simplified the targeting logic by attaching directly to the Modernisation Platform Member OU rather than a specific child OU.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
