### PR TITLE
Expand tagging SCP for Cloud Platform resources

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -468,6 +468,30 @@ resource "aws_organizations_policy_attachment" "deny_all_actions_by_users" {
 }
 
 # Enforce presence of mandatory tags
+locals {
+  iam_actions_for_tagging_scp = [
+      "athena:CreateWorkGroup",
+      "athena:CreateCapacityReservation",
+      "athena:CreateDataCatalog",
+      "s3:CreateBucket",
+      "s3:CreateAccessPoint",
+      "kms:CreateKey",
+      "lambda:CreateFunction",
+      "lambda:CreateCapacityProvider",
+      "lambda:CreateCodeSigningConfig",
+      "lambda:CreateEventSourceMapping",
+      "iam:CreateRole",
+      "ecr:CreateRepository",
+      "secretsmanager:CreateSecret",
+      "logs:CreateLogGroup",
+      "elasticache:CreateReplicationGroup",
+      "ec2:Create*",
+      "eks:Create*",
+      "rds:Create*",
+      "elasticloadbalancing:Create*"
+    ]
+}
+
 resource "aws_organizations_policy" "enforce_mandatory_tags" {
   name        = "Enforce mandatory tags"
   description = "Enforces the presence of mandatory resource tags"
@@ -485,21 +509,7 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
   statement {
     sid    = "DenyMissingBusinessUnit"
     effect = "Deny"
-
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
-
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -512,21 +522,7 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
   statement {
     sid    = "DenyInvalidBusinessUnit"
     effect = "Deny"
-
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
-
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -550,21 +546,7 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
   statement {
     sid    = "DenyMissingServiceArea"
     effect = "Deny"
-
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
-
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -577,21 +559,7 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
   statement {
     sid    = "DenyMissingApplication"
     effect = "Deny"
-
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
-
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -604,21 +572,7 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
   statement {
     sid    = "DenyMissingIsProduction"
     effect = "Deny"
-
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
-
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -631,21 +585,7 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
   statement {
     sid    = "DenyInvalidIsProduction"
     effect = "Deny"
-
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
-
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -658,21 +598,7 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
   statement {
     sid    = "DenyMissingOwner"
     effect = "Deny"
-
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
-
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {


### PR DESCRIPTION
- De-duplicates list of IAM actions used for tagging scp policies using locals.
- Expands SCP to cover core AWS resources used on Cloud Platform.