### PR TITLE
Split mandatory tagging SCP into separate SCP per tag

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -563,9 +563,9 @@ resource "aws_organizations_policy" "enforce_owner_tag" {
 # policy documents
 data "aws_iam_policy_document" "enforce_business_unit_tag" {
   statement {
-    sid    = "DenyMissingBusinessUnit"
-    effect = "Deny"
-    actions = local.iam_actions_for_tagging_scp
+    sid       = "DenyMissingBusinessUnit"
+    effect    = "Deny"
+    actions   = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -576,9 +576,9 @@ data "aws_iam_policy_document" "enforce_business_unit_tag" {
   }
 
   statement {
-    sid    = "DenyInvalidBusinessUnit"
-    effect = "Deny"
-    actions = local.iam_actions_for_tagging_scp
+    sid       = "DenyInvalidBusinessUnit"
+    effect    = "Deny"
+    actions   = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -602,9 +602,9 @@ data "aws_iam_policy_document" "enforce_business_unit_tag" {
 
 data "aws_iam_policy_document" "enforce_service_area_tag" {
   statement {
-    sid    = "DenyMissingServiceArea"
-    effect = "Deny"
-    actions = local.iam_actions_for_tagging_scp
+    sid       = "DenyMissingServiceArea"
+    effect    = "Deny"
+    actions   = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -617,9 +617,9 @@ data "aws_iam_policy_document" "enforce_service_area_tag" {
 
 data "aws_iam_policy_document" "enforce_application_tag" {
   statement {
-    sid    = "DenyMissingApplication"
-    effect = "Deny"
-    actions = local.iam_actions_for_tagging_scp
+    sid       = "DenyMissingApplication"
+    effect    = "Deny"
+    actions   = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -632,9 +632,9 @@ data "aws_iam_policy_document" "enforce_application_tag" {
 
 data "aws_iam_policy_document" "enforce_is_production_tag" {
   statement {
-    sid    = "DenyMissingIsProduction"
-    effect = "Deny"
-    actions = local.iam_actions_for_tagging_scp
+    sid       = "DenyMissingIsProduction"
+    effect    = "Deny"
+    actions   = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -645,9 +645,9 @@ data "aws_iam_policy_document" "enforce_is_production_tag" {
   }
 
   statement {
-    sid    = "DenyInvalidIsProduction"
-    effect = "Deny"
-    actions = local.iam_actions_for_tagging_scp
+    sid       = "DenyInvalidIsProduction"
+    effect    = "Deny"
+    actions   = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -660,9 +660,9 @@ data "aws_iam_policy_document" "enforce_is_production_tag" {
 
 data "aws_iam_policy_document" "enforce_owner_tag" {
   statement {
-    sid    = "DenyMissingOwner"
-    effect = "Deny"
-    actions = local.iam_actions_for_tagging_scp
+    sid       = "DenyMissingOwner"
+    effect    = "Deny"
+    actions   = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -468,9 +468,36 @@ resource "aws_organizations_policy_attachment" "deny_all_actions_by_users" {
 }
 
 # Enforce presence of mandatory tags
-resource "aws_organizations_policy" "enforce_mandatory_tags" {
-  name        = "Enforce mandatory tags"
-  description = "Enforces the presence of mandatory resource tags"
+locals {
+  iam_actions_for_tagging_scp = [
+    "athena:CreateWorkGroup",
+    "athena:CreateCapacityReservation",
+    "athena:CreateDataCatalog",
+    "s3:CreateBucket",
+    "s3:CreateAccessPoint",
+    "kms:CreateKey",
+    "lambda:CreateFunction",
+    "lambda:CreateCapacityProvider",
+    "lambda:CreateCodeSigningConfig",
+    "lambda:CreateEventSourceMapping",
+    "iam:CreateRole",
+
+    "ecr:CreateRepository",
+    "secretsmanager:CreateSecret",
+    "logs:CreateLogGroup",
+    "elasticache:CreateReplicationGroup",
+
+    "ec2:Create*",
+    "eks:Create*",
+    "rds:Create*",
+    "elasticloadbalancing:Create*"
+  ]
+}
+
+# policies
+resource "aws_organizations_policy" "enforce_business_unit_tag" {
+  name        = "Enforce business unit tag"
+  description = "Enforces the presence of mandatory business unit tag"
   type        = "SERVICE_CONTROL_POLICY"
   tags = {
     business-unit = "Platforms"
@@ -478,26 +505,67 @@ resource "aws_organizations_policy" "enforce_mandatory_tags" {
     source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
   }
 
-  content = data.aws_iam_policy_document.enforce_mandatory_tags.json
+  content = data.aws_iam_policy_document.enforce_business_unit_tag.json
 }
 
-data "aws_iam_policy_document" "enforce_mandatory_tags" {
+resource "aws_organizations_policy" "enforce_service_area_tag" {
+  name        = "Enforce service area tag"
+  description = "Enforces the presence of service area tag"
+  type        = "SERVICE_CONTROL_POLICY"
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
+  }
+
+  content = data.aws_iam_policy_document.enforce_service_area_tag.json
+}
+
+resource "aws_organizations_policy" "enforce_application_tag" {
+  name        = "Enforce application tag"
+  description = "Enforces the presence of mandatory application tag"
+  type        = "SERVICE_CONTROL_POLICY"
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
+  }
+
+  content = data.aws_iam_policy_document.enforce_application_tag.json
+}
+
+resource "aws_organizations_policy" "enforce_is_production_tag" {
+  name        = "Enforce is production tag"
+  description = "Enforces the presence of mandatory is production tag"
+  type        = "SERVICE_CONTROL_POLICY"
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
+  }
+
+  content = data.aws_iam_policy_document.enforce_is_production_tag.json
+}
+
+resource "aws_organizations_policy" "enforce_owner_tag" {
+  name        = "Enforce owner tag"
+  description = "Enforces the presence of mandatory owner tag"
+  type        = "SERVICE_CONTROL_POLICY"
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
+  }
+
+  content = data.aws_iam_policy_document.enforce_owner_tag.json
+}
+
+# policy documents
+data "aws_iam_policy_document" "enforce_business_unit_tag" {
   statement {
     sid    = "DenyMissingBusinessUnit"
     effect = "Deny"
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -510,19 +578,7 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
   statement {
     sid    = "DenyInvalidBusinessUnit"
     effect = "Deny"
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -542,23 +598,13 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
       ]
     }
   }
+}
 
+data "aws_iam_policy_document" "enforce_service_area_tag" {
   statement {
     sid    = "DenyMissingServiceArea"
     effect = "Deny"
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -567,23 +613,13 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
       values   = ["true"]
     }
   }
+}
 
+data "aws_iam_policy_document" "enforce_application_tag" {
   statement {
     sid    = "DenyMissingApplication"
     effect = "Deny"
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -592,23 +628,13 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
       values   = ["true"]
     }
   }
+}
 
+data "aws_iam_policy_document" "enforce_is_production_tag" {
   statement {
     sid    = "DenyMissingIsProduction"
     effect = "Deny"
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -621,19 +647,7 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
   statement {
     sid    = "DenyInvalidIsProduction"
     effect = "Deny"
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -642,23 +656,13 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
       values   = ["true", "false"]
     }
   }
+}
 
+data "aws_iam_policy_document" "enforce_owner_tag" {
   statement {
     sid    = "DenyMissingOwner"
     effect = "Deny"
-    actions = [
-      "athena:CreateWorkGroup",
-      "athena:CreateCapacityReservation",
-      "athena:CreateDataCatalog",
-      "s3:CreateBucket",
-      "s3:CreateAccessPoint",
-      "kms:CreateKey",
-      "lambda:CreateFunction",
-      "lambda:CreateCapacityProvider",
-      "lambda:CreateCodeSigningConfig",
-      "lambda:CreateEventSourceMapping",
-      "iam:CreateRole"
-    ]
+    actions = local.iam_actions_for_tagging_scp
     resources = ["*"]
 
     condition {
@@ -669,13 +673,53 @@ data "aws_iam_policy_document" "enforce_mandatory_tags" {
   }
 }
 
-# Attach policy to coat-development
-resource "aws_organizations_policy_attachment" "enforce_mandatory_tags" {
+# Policy attachments - attach to COAT OU
+resource "aws_organizations_policy_attachment" "enforce_business_unit_tag" {
   for_each = toset([
     for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
     if child.name == "modernisation-platform-coat"
   ])
 
-  policy_id = aws_organizations_policy.enforce_mandatory_tags.id
+  policy_id = aws_organizations_policy.enforce_business_unit_tag.id
+  target_id = each.value
+}
+
+resource "aws_organizations_policy_attachment" "enforce_service_area_tag" {
+  for_each = toset([
+    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
+    if child.name == "modernisation-platform-coat"
+  ])
+
+  policy_id = aws_organizations_policy.enforce_service_area_tag.id
+  target_id = each.value
+}
+
+resource "aws_organizations_policy_attachment" "enforce_application_tag" {
+  for_each = toset([
+    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
+    if child.name == "modernisation-platform-coat"
+  ])
+
+  policy_id = aws_organizations_policy.enforce_application_tag.id
+  target_id = each.value
+}
+
+resource "aws_organizations_policy_attachment" "enforce_is_production_tag" {
+  for_each = toset([
+    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
+    if child.name == "modernisation-platform-coat"
+  ])
+
+  policy_id = aws_organizations_policy.enforce_is_production_tag.id
+  target_id = each.value
+}
+
+resource "aws_organizations_policy_attachment" "enforce_owner_tag" {
+  for_each = toset([
+    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
+    if child.name == "modernisation-platform-coat"
+  ])
+
+  policy_id = aws_organizations_policy.enforce_owner_tag.id
   target_id = each.value
 }


### PR DESCRIPTION
Having 1 SCP to enforce all mandatory tags led to hitting policy size limits as the SCP scope was growing - https://github.com/ministryofjustice/aws-root-account/actions/runs/24349652850/job/71100150756#step:8:3442

- This PR separates the mandatory tags SCP into 5 separate SCPs, 1 to enforce each mandatory tag, to avoid policy size issues going forward.
- This PR defines the IAM actions enforced by the tagging SCPs in locals, to reduce code duplication.
- Ticket: https://github.com/orgs/ministryofjustice/projects/52/views/4?pane=issue&itemId=175698186&issue=ministryofjustice%7Ccloud-optimisation-and-accountability%7C751