### PR TITLE
#12518 - Typo in added tag. Should be service-area, not service_area

### DIFF
--- a/organisation-security/terraform/cloudformation-cortex.tf
+++ b/organisation-security/terraform/cloudformation-cortex.tf
@@ -14,7 +14,7 @@ resource "random_uuid" "cortex_xdr_stack_set" {}
 resource "aws_ssm_parameter" "cortex_xdr_uuids" {
   description = "Map of random UUID values used to secure external access for IAM role assumption"
   name        = "cortex_xdr_uuids"
-  tags        = merge(local.tags_organisation_management, { service_area = "Hosting" })
+  tags        = merge(local.tags_organisation_management, { service-area = "Hosting" })
   type        = "SecureString"
   value = jsonencode({
     xdr_stack_set = random_uuid.cortex_xdr_stack_set.result
@@ -39,7 +39,7 @@ resource "aws_cloudformation_stack_set" "cortex_xdr_stack_set" {
   }
   permission_model = "SERVICE_MANAGED"
   template_body    = data.aws_s3_object.cortex_xdr_templates["cortex-xdr-subordinate-account.template"].body
-  tags             = merge(local.tags_organisation_management, { service_area = "Hosting" })
+  tags             = merge(local.tags_organisation_management, { service-area = "Hosting" })
 }
 
 resource "aws_cloudformation_stack_set_instance" "cortex_xdr_stack_set" {


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->

## 👀 Purpose

See Modernisation Platform Issue https://github.com/ministryofjustice/modernisation-platform/issues/12518

## ♻️ What's changed

Fixes typo in one of the new tags added to Cortex Xsiam cloudformation stackset. Should be service-area rather than service_area.

## 🔊 Does this PR affect multiple parties?

- [x] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [ ] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
