### PR TITLE
🔧 Correct Terraform Drift

### DIFF
--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -51,7 +51,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
     for_each = try(flatten([var.server_side_encryption_configuration["rule"]]), [])
 
     content {
-      bucket_key_enabled = try(rule.value.bucket_key_enabled, null)
+      bucket_key_enabled = try(rule.value.bucket_key_enabled, false)
+
+      blocked_encryption_types = try(rule.value.blocked_encryption_types, [])
 
       dynamic "apply_server_side_encryption_by_default" {
         for_each = try([rule.value.apply_server_side_encryption_by_default], [])


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

- To try and correct the following persistent Terraform drift:
```
      - rule {
          - blocked_encryption_types = [
              - "NONE",
            ] -> null
          - bucket_key_enabled       = false -> null

          - apply_server_side_encryption_by_default {
              - kms_master_key_id = "arn:aws:kms:eu-west-2:REDACTED:key/70d5523d-99d3-47ff-aa3a-70144c831fad" -> null
              - sse_algorithm     = "aws:kms" -> null
            }
        }
      + rule {
          + blocked_encryption_types = []

          + apply_server_side_encryption_by_default {
              + kms_master_key_id = "arn:aws:kms:eu-west-2:REDACTED:key/70d5523d-99d3-47ff-aa3a-70144c831fad"
              + sse_algorithm     = "aws:kms"
            }
        }
```

## ♻️ What's changed

- Add an explicit value for `blocked_encryption_types` (which I think is the main problem) and also for `bucket_key_enabled` in the S3 Module. This change will update all buckets using this module in both accounts.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

- I believe the issue here is that we're not specifying values explicitly, terraform plan see's a change, terraform apply either doesn't make that change or just doesn't update the state - then the next plan has the same drift changes. Specifying these values to align should at least update the state to get rid of the drift 🔥 
