### PR TITLE
Change tagging SCP policy coupling

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -511,9 +511,9 @@ locals {
 }
 
 # policies
-resource "aws_organizations_policy" "enforce_business_unit_and_is_production_tags" {
-  name        = "Enforce business unit and is-production tags"
-  description = "Enforces the presence of mandatory business unit and is-production tags"
+resource "aws_organizations_policy" "enforce_business_unit_tag" {
+  name        = "Enforce business unit tag"
+  description = "Enforces the presence of mandatory business unit tag"
   type        = "SERVICE_CONTROL_POLICY"
   tags = {
     business-unit = "Platforms"
@@ -521,7 +521,20 @@ resource "aws_organizations_policy" "enforce_business_unit_and_is_production_tag
     source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
   }
 
-  content = data.aws_iam_policy_document.enforce_business_unit_and_is_production_tags.json
+  content = data.aws_iam_policy_document.enforce_business_unit_tag.json
+}
+
+resource "aws_organizations_policy" "enforce_is_production_tag" {
+  name        = "Enforce is production tag"
+  description = "Enforces the presence of mandatory is production tag"
+  type        = "SERVICE_CONTROL_POLICY"
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
+  }
+
+  content = data.aws_iam_policy_document.enforce_is_production_tag.json
 }
 
 resource "aws_organizations_policy" "enforce_service_area_tag" {
@@ -537,9 +550,9 @@ resource "aws_organizations_policy" "enforce_service_area_tag" {
   content = data.aws_iam_policy_document.enforce_service_area_tag.json
 }
 
-resource "aws_organizations_policy" "enforce_application_tag" {
-  name        = "Enforce application tag"
-  description = "Enforces the presence of mandatory application tag"
+resource "aws_organizations_policy" "enforce_application_and_owner_tags" {
+  name        = "Enforce application and owner tags"
+  description = "Enforces the presence of mandatory application and owner tags"
   type        = "SERVICE_CONTROL_POLICY"
   tags = {
     business-unit = "Platforms"
@@ -547,24 +560,11 @@ resource "aws_organizations_policy" "enforce_application_tag" {
     source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
   }
 
-  content = data.aws_iam_policy_document.enforce_application_tag.json
-}
-
-resource "aws_organizations_policy" "enforce_owner_tag" {
-  name        = "Enforce owner tag"
-  description = "Enforces the presence of mandatory owner tag"
-  type        = "SERVICE_CONTROL_POLICY"
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
-  }
-
-  content = data.aws_iam_policy_document.enforce_owner_tag.json
+  content = data.aws_iam_policy_document.enforce_application_and_owner_tags.json
 }
 
 # policy documents
-data "aws_iam_policy_document" "enforce_business_unit_and_is_production_tags" {
+data "aws_iam_policy_document" "enforce_business_unit_tag" {
   statement {
     sid       = "DenyMissingBusinessUnit"
     effect    = "Deny"
@@ -601,7 +601,9 @@ data "aws_iam_policy_document" "enforce_business_unit_and_is_production_tags" {
       ]
     }
   }
+}
 
+data "aws_iam_policy_document" "enforce_is_production_tag" {
   statement {
     sid       = "DenyMissingIsProduction"
     effect    = "Deny"
@@ -644,7 +646,7 @@ data "aws_iam_policy_document" "enforce_service_area_tag" {
   }
 }
 
-data "aws_iam_policy_document" "enforce_application_tag" {
+data "aws_iam_policy_document" "enforce_application_and_owner_tags" {
   statement {
     sid       = "DenyMissingApplication"
     effect    = "Deny"
@@ -657,9 +659,7 @@ data "aws_iam_policy_document" "enforce_application_tag" {
       values   = ["true"]
     }
   }
-}
 
-data "aws_iam_policy_document" "enforce_owner_tag" {
   statement {
     sid       = "DenyMissingOwner"
     effect    = "Deny"
@@ -675,13 +675,23 @@ data "aws_iam_policy_document" "enforce_owner_tag" {
 }
 
 # Policy attachments - attach to COAT OU
-resource "aws_organizations_policy_attachment" "enforce_business_unit_and_is_production_tags" {
+resource "aws_organizations_policy_attachment" "enforce_business_unit_tag" {
   for_each = toset([
     for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
     if child.name == "modernisation-platform-coat"
   ])
 
-  policy_id = aws_organizations_policy.enforce_business_unit_and_is_production_tags.id
+  policy_id = aws_organizations_policy.enforce_business_unit_tag.id
+  target_id = each.value
+}
+
+resource "aws_organizations_policy_attachment" "enforce_is_production_tag" {
+  for_each = toset([
+    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
+    if child.name == "modernisation-platform-coat"
+  ])
+
+  policy_id = aws_organizations_policy.enforce_is_production_tag.id
   target_id = each.value
 }
 
@@ -695,22 +705,12 @@ resource "aws_organizations_policy_attachment" "enforce_service_area_tag" {
   target_id = each.value
 }
 
-resource "aws_organizations_policy_attachment" "enforce_application_tag" {
+resource "aws_organizations_policy_attachment" "enforce_application_and_owner_tags" {
   for_each = toset([
     for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
     if child.name == "modernisation-platform-coat"
   ])
 
-  policy_id = aws_organizations_policy.enforce_application_tag.id
-  target_id = each.value
-}
-
-resource "aws_organizations_policy_attachment" "enforce_owner_tag" {
-  for_each = toset([
-    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
-    if child.name == "modernisation-platform-coat"
-  ])
-
-  policy_id = aws_organizations_policy.enforce_owner_tag.id
+  policy_id = aws_organizations_policy.enforce_application_and_owner_tags.id
   target_id = each.value
 }


### PR DESCRIPTION
Running into the IAM policy limit issue again: https://github.com/ministryofjustice/aws-root-account/actions/runs/24672262919/job/72146129236#step:8:5370

Executing risk mitigation strategy outlined: https://github.com/ministryofjustice/aws-root-account/pull/1488

Switching the coupling to simpler tags decreases average policy size, allowing this issue to be remedied.

