### PR TITLE
🔥 Remove Unused `blocked_encryption_types` Option (Fixes Drift)

### DIFF
--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -53,8 +53,6 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
     content {
       bucket_key_enabled = try(rule.value.bucket_key_enabled, false)
 
-      blocked_encryption_types = try(rule.value.blocked_encryption_types, [])
-
       dynamic "apply_server_side_encryption_by_default" {
         for_each = try([rule.value.apply_server_side_encryption_by_default], [])
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

- Fixing the drift - relates to #1487 
- The drift stems from a provider bug https://github.com/hashicorp/terraform-provider-aws/issues/47320
- We don't actually use this value anywhere we call the module, so removing it which fixes it displaying in the plans and will make things a bit easier when we migrate away from this module ♻️ 

## ♻️ What's changed

- Remove Unused blocked_encryption_types Option in S3 Module

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

- Plan shows no changes in the S3 buckets 🥳 
