### PR TITLE
Update sso-admin-account-assignments.tf

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -226,6 +226,30 @@ locals {
       ]
     },
     {
+      github_team        = "organisation-security-auditor",
+      permission_set_arn = aws_ssoadmin_permission_set.security_audit.arn,
+      account_ids = [
+        aws_organizations_organization.default.master_account_id,
+        aws_organizations_account.organisation_security.id,
+        aws_organizations_account.cloud_platform.id
+      ]
+    },
+    {
+      github_team        = "organisation-security-auditor",
+      permission_set_arn = aws_ssoadmin_permission_set.view_only_access.arn,
+      account_ids = [
+        aws_organizations_account.organisation_security.id,
+        aws_organizations_account.cloud_platform.id
+      ]
+    },
+    {
+      github_team        = "organisation-security-auditor",
+      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
+      account_ids = [
+        aws_organizations_account.organisation_security.id,
+      ]
+    },
+    {
       github_team        = "modernisation-platform-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
       account_ids = [

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -202,7 +202,7 @@ locals {
       ]
     },
     {
-      github_team        = "organisation-security-auditor",
+      github_team        = "azure-aws-sso-jdsoc",
       permission_set_arn = aws_ssoadmin_permission_set.security_audit.arn,
       account_ids = [
         aws_organizations_organization.default.master_account_id,
@@ -211,7 +211,7 @@ locals {
       ]
     },
     {
-      github_team        = "organisation-security-auditor",
+      github_team        = "azure-aws-sso-jdsoc",
       permission_set_arn = aws_ssoadmin_permission_set.view_only_access.arn,
       account_ids = [
         aws_organizations_account.organisation_security.id,
@@ -219,7 +219,7 @@ locals {
       ]
     },
     {
-      github_team        = "organisation-security-auditor",
+      github_team        = "azure-aws-sso-jdsoc",
       permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
       account_ids = [
         aws_organizations_account.organisation_security.id,


### PR DESCRIPTION
As per https://mojdt.slack.com/archives/C06P4KA0V0A/p1777539497843599 updating to Entra management.

<!-- markdownlint-disable MD041 -->

## 👀 Purpose

Move managemed of SOC access to Entra

## ♻️ What's changed

Replaced access granted to `organisation-security-auditor` to the EntraID group provided by jdsoc.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [X] No.

## 📓 Notes

Link to the related conversation on top.
