### PR TITLE
Remove elasticache from tagging SCP

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -487,7 +487,6 @@ locals {
     "ecr:CreateRepository",
     "secretsmanager:CreateSecret",
     "logs:CreateLogGroup",
-    "elasticache:CreateReplicationGroup",
 
     # Cloud Platform - RDS
     "rds:CreateBlueGreenDeployment",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

{ Add content here - what are you trying to achieve with this PR? What originating issue sparked this pull request? }

PR to remove elasticache creation from tagging enforcement SCP. There are some untaggable resources in this group and we should do further testing to refine what should be included. Removing to enable further investigation.

## ♻️ What's changed

{ Add content here - what functional changes are you introducing? Are you adding new resources? Changing existing resources? }

Remove `"elasticache:CreateReplicationGroup",`

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
