### PR TITLE
Add Slack alerting for Modernisation Platform SCP changes

### DIFF
--- a/management-account/terraform/alerting-modernisation-platform-scp.tf
+++ b/management-account/terraform/alerting-modernisation-platform-scp.tf
@@ -1,0 +1,101 @@
+###############################################################
+# Alerting: Modernisation Platform SCP changes
+###############################################################
+
+resource "aws_sns_topic" "modernisation_platform_scp_change_alerts" {
+  name = "modernisation-platform-scp-change-alerts"
+
+  tags = {
+    business-unit = "Platforms"
+    component     = "SNS_TOPIC"
+    source-code   = join("", [local.github_repository, "/terraform/alerting-modernisation-platform-scp.tf"])
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "modernisation_platform_scp_change_alerts" {
+  name        = "modernisation-platform-scp-change-alerts"
+  description = "Alerts on AWS Organizations changes to Modernisation Platform SCPs."
+
+  event_pattern = jsonencode({
+    "detail-type" : ["AWS API Call via CloudTrail"],
+    "source" : ["aws.organizations"],
+    "detail" : {
+      "eventSource" : ["organizations.amazonaws.com"],
+      "eventName" : [
+        "UpdatePolicy",
+        "AttachPolicy",
+        "DetachPolicy",
+        "DeletePolicy"
+      ],
+      "requestParameters" : {
+        "policyId" : [
+          aws_organizations_policy.rds_guardrails.id,
+          aws_organizations_policy.mp_deny_cloudtrail_delete_stop_update.id,
+          aws_organizations_policy.mp_protect_core_s3_buckets.id,
+          aws_organizations_policy.modernisation_platform_member_ou_scp.id
+        ]
+      }
+    }
+  })
+
+  tags = {
+    business-unit = "Platforms"
+    component     = "EVENTBRIDGE_RULE"
+    source-code   = join("", [local.github_repository, "/terraform/alerting-modernisation-platform-scp.tf"])
+  }
+}
+
+resource "aws_cloudwatch_event_target" "modernisation_platform_scp_change_alerts" {
+  rule = aws_cloudwatch_event_rule.modernisation_platform_scp_change_alerts.name
+  arn  = aws_sns_topic.modernisation_platform_scp_change_alerts.arn
+}
+
+data "aws_iam_policy_document" "modernisation_platform_scp_change_alerts_topic_policy" {
+  statement {
+    sid    = "AllowEventBridgePublish"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions   = ["sns:Publish"]
+    resources = [aws_sns_topic.modernisation_platform_scp_change_alerts.arn]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_cloudwatch_event_rule.modernisation_platform_scp_change_alerts.arn]
+    }
+  }
+
+  statement {
+    sid    = "AllowAccountAdmin"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    actions   = ["sns:*"]
+    resources = [aws_sns_topic.modernisation_platform_scp_change_alerts.arn]
+  }
+}
+
+resource "aws_sns_topic_policy" "modernisation_platform_scp_change_alerts" {
+  arn    = aws_sns_topic.modernisation_platform_scp_change_alerts.arn
+  policy = data.aws_iam_policy_document.modernisation_platform_scp_change_alerts_topic_policy.json
+}
+
+module "modernisation_platform_scp_slack_notifications" {
+  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=0ec33c7bfde5649af3c23d0834ea85c849edf3ac" # v3.0.0
+
+  application_name = "modernisation-platform-scp-alerts"
+  slack_channel_id = "C02PFCG8M1R"
+  sns_topic_arns = [
+    aws_sns_topic.modernisation_platform_scp_change_alerts.arn
+  ]
+  tags = {}
+}

--- a/management-account/terraform/alerting-modernisation-platform-scp.tf
+++ b/management-account/terraform/alerting-modernisation-platform-scp.tf
@@ -3,6 +3,8 @@
 ###############################################################
 
 resource "aws_sns_topic" "modernisation_platform_scp_change_alerts" {
+  provider = aws.us-east-1
+
   name = "modernisation-platform-scp-change-alerts"
 
   tags = {
@@ -13,6 +15,8 @@ resource "aws_sns_topic" "modernisation_platform_scp_change_alerts" {
 }
 
 resource "aws_cloudwatch_event_rule" "modernisation_platform_scp_change_alerts" {
+  provider = aws.us-east-1
+
   name        = "modernisation-platform-scp-change-alerts"
   description = "Alerts on AWS Organizations changes to Modernisation Platform SCPs."
 
@@ -46,6 +50,8 @@ resource "aws_cloudwatch_event_rule" "modernisation_platform_scp_change_alerts" 
 }
 
 resource "aws_cloudwatch_event_target" "modernisation_platform_scp_change_alerts" {
+  provider = aws.us-east-1
+
   rule = aws_cloudwatch_event_rule.modernisation_platform_scp_change_alerts.name
   arn  = aws_sns_topic.modernisation_platform_scp_change_alerts.arn
 }
@@ -85,12 +91,18 @@ data "aws_iam_policy_document" "modernisation_platform_scp_change_alerts_topic_p
 }
 
 resource "aws_sns_topic_policy" "modernisation_platform_scp_change_alerts" {
+  provider = aws.us-east-1
+
   arn    = aws_sns_topic.modernisation_platform_scp_change_alerts.arn
   policy = data.aws_iam_policy_document.modernisation_platform_scp_change_alerts_topic_policy.json
 }
 
 module "modernisation_platform_scp_slack_notifications" {
   source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=0ec33c7bfde5649af3c23d0834ea85c849edf3ac" # v3.0.0
+
+  providers = {
+    aws = aws.us-east-1
+  }
 
   application_name = "modernisation-platform-scp-alerts"
   slack_channel_id = "C02PFCG8M1R"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

{ Add content here - what are you trying to achieve with this PR? What originating issue sparked this pull request? }
https://github.com/ministryofjustice/modernisation-platform/issues/12230

## ♻️ What's changed

{ Add content here - what functional changes are you introducing? Are you adding new resources? Changing existing resources? }

Added Slack alerting for changes to Modernisation Platform SCPs.
Added an EventBridge rule to detect UpdatePolicy, AttachPolicy, DetachPolicy, and DeletePolicy actions for the Modernisation Platform SCP policy IDs.
Created an SNS topic to receive matched events and wired it to Slack via the existing modernisation-platform-terraform-aws-chatbot module (reusing the same Slack channel ID already used for SCIM monitoring).

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [ ] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
