### PR TITLE
Tagging SCP Module and Staging Setup

### DIFF
--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -602,7 +602,7 @@ module "mandatory_tags_group_1_scp_staging_coat" {
 
   iam_actions = local.iam_actions_for_tagging_scp_staging
   tags_to_enforce = local.mandatory_tags_group_1
-  organisational_unit_ids = local.coat_ou_id
+  organisational_unit_ids = [local.coat_ou_id]
 }
 
 module "mandatory_tags_group_2_scp_staging_coat" {
@@ -610,7 +610,7 @@ module "mandatory_tags_group_2_scp_staging_coat" {
 
   iam_actions = local.iam_actions_for_tagging_scp_staging
   tags_to_enforce = local.mandatory_tags_group_2
-  organisational_unit_ids = local.coat_ou_id
+  organisational_unit_ids = [local.coat_ou_id]
 }
 
 module "mandatory_tags_group_3_scp_staging_coat" {
@@ -618,5 +618,5 @@ module "mandatory_tags_group_3_scp_staging_coat" {
 
   iam_actions = local.iam_actions_for_tagging_scp_staging
   tags_to_enforce = local.mandatory_tags_group_3
-  organisational_unit_ids = local.coat_ou_id
+  organisational_unit_ids = [local.coat_ou_id]
 }

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -527,26 +527,10 @@ locals {
     "logs:CreateLogGroup",
     "elasticache:CreateReplicationGroup",
 
-    "rds:CreateBlueGreenDeployment",
-    "rds:CreateCustomDBEngineVersion",
-    "rds:CreateDBCluster",
-    "rds:CreateDBClusterEndpoint",
-    "rds:CreateDBClusterParameterGroup",
-    "rds:CreateDBClusterSnapshot",
-    "rds:CreateDBInstance",
-    "rds:CreateDBInstanceReadReplica",
-    "rds:CreateDBParameterGroup",
-    "rds:CreateDBProxy",
-    "rds:CreateDBProxyEndpoint",
-    "rds:CreateDBSecurityGroup",
-    "rds:CreateDBShardGroup",
-    "rds:CreateDBSnapshot",
-    "rds:CreateDBSubnetGroup",
-    "rds:CreateEventSubscription",
-    "rds:CreateGlobalCluster",
-    "rds:CreateIntegration",
-    "rds:CreateOptionGroup",
-    "rds:CreateTenantDatabase"
+    "rds:Create*",
+    "ec2:Create*",
+    "eks:Create*",
+    "elasticloadbalancing:Create*"
   ]
 
   iam_actions_for_tagging_scp_prod = [

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -509,7 +509,7 @@ locals {
     }
   ]
 
-  iam_actions_for_tagging_scp_staging = [
+  iam_actions_for_tagging_scps_staging_coat = [
     "athena:CreateWorkGroup",
     "athena:CreateCapacityReservation",
     "athena:CreateDataCatalog",
@@ -533,7 +533,7 @@ locals {
     "elasticloadbalancing:Create*"
   ]
 
-  iam_actions_for_tagging_scp_prod = [
+  iam_actions_for_tagging_scps_prod = [
     "athena:CreateWorkGroup",
     "athena:CreateCapacityReservation",
     "athena:CreateDataCatalog",

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -521,7 +521,6 @@ locals {
     "lambda:CreateCodeSigningConfig",
     "lambda:CreateEventSourceMapping",
     "iam:CreateRole",
-
     "ecr:CreateRepository",
     "secretsmanager:CreateSecret",
     "logs:CreateLogGroup",
@@ -543,7 +542,6 @@ locals {
     "lambda:CreateCodeSigningConfig",
     "lambda:CreateEventSourceMapping",
     "iam:CreateRole",
-
     "ecr:CreateRepository",
     "secretsmanager:CreateSecret",
     "logs:CreateLogGroup",

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -489,22 +489,22 @@ locals {
 
   mandatory_tags_group_2 = [
     {
-      tag = "is-production"
+      tag          = "is-production"
       valid_values = ["true", "false"]
     }
   ]
 
   mandatory_tags_group_3 = [
     {
-      tag = "service-area"
+      tag          = "service-area"
       valid_values = []
     },
     {
-      tag = "owner"
+      tag          = "owner"
       valid_values = []
     },
     {
-      tag = "application"
+      tag          = "application"
       valid_values = []
     }
   ]
@@ -600,23 +600,23 @@ locals {
 module "mandatory_tags_group_1_scp_staging_coat" {
   source = "../../modules/tagging-scp"
 
-  iam_actions = local.iam_actions_for_tagging_scp_staging
-  tags_to_enforce = local.mandatory_tags_group_1
+  iam_actions             = local.iam_actions_for_tagging_scp_staging
+  tags_to_enforce         = local.mandatory_tags_group_1
   organisational_unit_ids = [local.coat_ou_id]
 }
 
 module "mandatory_tags_group_2_scp_staging_coat" {
   source = "../../modules/tagging-scp"
 
-  iam_actions = local.iam_actions_for_tagging_scp_staging
-  tags_to_enforce = local.mandatory_tags_group_2
+  iam_actions             = local.iam_actions_for_tagging_scp_staging
+  tags_to_enforce         = local.mandatory_tags_group_2
   organisational_unit_ids = [local.coat_ou_id]
 }
 
 module "mandatory_tags_group_3_scp_staging_coat" {
   source = "../../modules/tagging-scp"
 
-  iam_actions = local.iam_actions_for_tagging_scp_staging
-  tags_to_enforce = local.mandatory_tags_group_3
+  iam_actions             = local.iam_actions_for_tagging_scp_staging
+  tags_to_enforce         = local.mandatory_tags_group_3
   organisational_unit_ids = [local.coat_ou_id]
 }

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -469,8 +469,7 @@ resource "aws_organizations_policy_attachment" "deny_all_actions_by_users" {
 
 # Enforce presence of mandatory tags
 locals {
-  iam_actions_for_tagging_scp = [
-    # COAT
+  iam_actions_for_tagging_scp_staging = [
     "athena:CreateWorkGroup",
     "athena:CreateCapacityReservation",
     "athena:CreateDataCatalog",
@@ -483,13 +482,51 @@ locals {
     "lambda:CreateEventSourceMapping",
     "iam:CreateRole",
 
-    # Cloud Platform
     "ecr:CreateRepository",
     "secretsmanager:CreateSecret",
     "logs:CreateLogGroup",
     "elasticache:CreateReplicationGroup",
 
-    # Cloud Platform - RDS
+    "rds:CreateBlueGreenDeployment",
+    "rds:CreateCustomDBEngineVersion",
+    "rds:CreateDBCluster",
+    "rds:CreateDBClusterEndpoint",
+    "rds:CreateDBClusterParameterGroup",
+    "rds:CreateDBClusterSnapshot",
+    "rds:CreateDBInstance",
+    "rds:CreateDBInstanceReadReplica",
+    "rds:CreateDBParameterGroup",
+    "rds:CreateDBProxy",
+    "rds:CreateDBProxyEndpoint",
+    "rds:CreateDBSecurityGroup",
+    "rds:CreateDBShardGroup",
+    "rds:CreateDBSnapshot",
+    "rds:CreateDBSubnetGroup",
+    "rds:CreateEventSubscription",
+    "rds:CreateGlobalCluster",
+    "rds:CreateIntegration",
+    "rds:CreateOptionGroup",
+    "rds:CreateTenantDatabase"
+  ]
+
+  iam_actions_for_tagging_scp_prod = [
+    "athena:CreateWorkGroup",
+    "athena:CreateCapacityReservation",
+    "athena:CreateDataCatalog",
+    "s3:CreateBucket",
+    "s3:CreateAccessPoint",
+    "kms:CreateKey",
+    "lambda:CreateFunction",
+    "lambda:CreateCapacityProvider",
+    "lambda:CreateCodeSigningConfig",
+    "lambda:CreateEventSourceMapping",
+    "iam:CreateRole",
+
+    "ecr:CreateRepository",
+    "secretsmanager:CreateSecret",
+    "logs:CreateLogGroup",
+    "elasticache:CreateReplicationGroup",
+
     "rds:CreateBlueGreenDeployment",
     "rds:CreateCustomDBEngineVersion",
     "rds:CreateDBCluster",

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -469,6 +469,46 @@ resource "aws_organizations_policy_attachment" "deny_all_actions_by_users" {
 
 # Enforce presence of mandatory tags
 locals {
+  mandatory_tags_group_1 = [
+    {
+      tag = "business-unit"
+      valid_values = [
+        "Central Digital",
+        "CICA",
+        "HMCTS",
+        "HMPPS",
+        "LAA",
+        "OPG",
+        "OCTO",
+        "Technology Services",
+        "YJB",
+        "Platforms"
+      ]
+    }
+  ]
+
+  mandatory_tags_group_2 = [
+    {
+      tag = "is-production"
+      valid_values = ["true", "false"]
+    }
+  ]
+
+  mandatory_tags_group_3 = [
+    {
+      tag = "service-area"
+      valid_values = []
+    },
+    {
+      tag = "owner"
+      valid_values = []
+    },
+    {
+      tag = "application"
+      valid_values = []
+    }
+  ]
+
   iam_actions_for_tagging_scp_staging = [
     "athena:CreateWorkGroup",
     "athena:CreateCapacityReservation",
@@ -555,167 +595,28 @@ locals {
   ])
 }
 
-# policies
-resource "aws_organizations_policy" "enforce_business_unit_tag" {
-  name        = "Enforce business unit tag"
-  description = "Enforces the presence of mandatory business unit tag"
-  type        = "SERVICE_CONTROL_POLICY"
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
-  }
+# Create mandatory tagging SCPs for staging, attached to COAT OU - using internal tagging-scp module
 
-  content = data.aws_iam_policy_document.enforce_business_unit_tag.json
+module "mandatory_tags_group_1_scp_staging_coat" {
+  source = "../../modules/tagging-scp"
+
+  iam_actions = local.iam_actions_for_tagging_scp_staging
+  tags_to_enforce = local.mandatory_tags_group_1
+  organisational_unit_ids = local.coat_ou_id
 }
 
-resource "aws_organizations_policy" "enforce_is_production_tag" {
-  name        = "Enforce is production tag"
-  description = "Enforces the presence of mandatory is production tag"
-  type        = "SERVICE_CONTROL_POLICY"
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
-  }
+module "mandatory_tags_group_2_scp_staging_coat" {
+  source = "../../modules/tagging-scp"
 
-  content = data.aws_iam_policy_document.enforce_is_production_tag.json
+  iam_actions = local.iam_actions_for_tagging_scp_staging
+  tags_to_enforce = local.mandatory_tags_group_2
+  organisational_unit_ids = local.coat_ou_id
 }
 
-resource "aws_organizations_policy" "enforce_application_owner_service_area_tags" {
-  name        = "Enforce application, owner, and service area tags"
-  description = "Enforces the presence of mandatory application, owner, and service area tags"
-  type        = "SERVICE_CONTROL_POLICY"
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = join("", [local.github_repository, "/terraform/organizations-service-control-policies.tf"])
-  }
+module "mandatory_tags_group_3_scp_staging_coat" {
+  source = "../../modules/tagging-scp"
 
-  content = data.aws_iam_policy_document.enforce_application_owner_service_area_tags.json
-}
-
-# policy documents
-data "aws_iam_policy_document" "enforce_business_unit_tag" {
-  statement {
-    sid       = "DenyMissingBusinessUnit"
-    effect    = "Deny"
-    actions   = local.iam_actions_for_tagging_scp
-    resources = ["*"]
-
-    condition {
-      test     = "Null"
-      variable = "aws:RequestTag/business-unit"
-      values   = ["true"]
-    }
-  }
-
-  statement {
-    sid       = "DenyInvalidBusinessUnit"
-    effect    = "Deny"
-    actions   = local.iam_actions_for_tagging_scp
-    resources = ["*"]
-
-    condition {
-      test     = "StringNotEquals"
-      variable = "aws:RequestTag/business-unit"
-      values = [
-        "Central Digital",
-        "CICA",
-        "HMCTS",
-        "HMPPS",
-        "LAA",
-        "OPG",
-        "OCTO",
-        "Technology Services",
-        "YJB",
-        "Platforms"
-      ]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "enforce_is_production_tag" {
-  statement {
-    sid       = "DenyMissingIsProduction"
-    effect    = "Deny"
-    actions   = local.iam_actions_for_tagging_scp
-    resources = ["*"]
-
-    condition {
-      test     = "Null"
-      variable = "aws:RequestTag/is-production"
-      values   = ["true"]
-    }
-  }
-
-  statement {
-    sid       = "DenyInvalidIsProduction"
-    effect    = "Deny"
-    actions   = local.iam_actions_for_tagging_scp
-    resources = ["*"]
-
-    condition {
-      test     = "StringNotEquals"
-      variable = "aws:RequestTag/is-production"
-      values   = ["true", "false"]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "enforce_application_owner_service_area_tags" {
-  statement {
-    sid       = "DenyMissingApplication"
-    effect    = "Deny"
-    actions   = local.iam_actions_for_tagging_scp
-    resources = ["*"]
-
-    condition {
-      test     = "Null"
-      variable = "aws:RequestTag/application"
-      values   = ["true"]
-    }
-  }
-
-  statement {
-    sid       = "DenyMissingOwner"
-    effect    = "Deny"
-    actions   = local.iam_actions_for_tagging_scp
-    resources = ["*"]
-
-    condition {
-      test     = "Null"
-      variable = "aws:RequestTag/owner"
-      values   = ["true"]
-    }
-  }
-
-  statement {
-    sid       = "DenyMissingServiceArea"
-    effect    = "Deny"
-    actions   = local.iam_actions_for_tagging_scp
-    resources = ["*"]
-
-    condition {
-      test     = "Null"
-      variable = "aws:RequestTag/service-area"
-      values   = ["true"]
-    }
-  }
-}
-
-# Policy attachments - attach to COAT OU
-resource "aws_organizations_policy_attachment" "enforce_business_unit_tag_coat" {
-  policy_id = aws_organizations_policy.enforce_business_unit_tag.id
-  target_id = local.coat_ou_id
-}
-
-resource "aws_organizations_policy_attachment" "enforce_is_production_tag_coat" {
-  policy_id = aws_organizations_policy.enforce_is_production_tag.id
-  target_id = local.coat_ou_id
-}
-
-resource "aws_organizations_policy_attachment" "enforce_application_and_owner_tags_coat" {
-  policy_id = aws_organizations_policy.enforce_application_owner_service_area_tags.id
-  target_id = local.coat_ou_id
+  iam_actions = local.iam_actions_for_tagging_scp_staging
+  tags_to_enforce = local.mandatory_tags_group_3
+  organisational_unit_ids = local.coat_ou_id
 }

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -579,7 +579,7 @@ locals {
 module "mandatory_tags_group_1_scp_staging_coat" {
   source = "../../modules/tagging-scp"
 
-  iam_actions             = local.iam_actions_for_tagging_scp_staging
+  iam_actions             = local.iam_actions_for_tagging_scps_staging_coat
   tags_to_enforce         = local.mandatory_tags_group_1
   organisational_unit_ids = [local.coat_ou_id]
 }
@@ -587,7 +587,7 @@ module "mandatory_tags_group_1_scp_staging_coat" {
 module "mandatory_tags_group_2_scp_staging_coat" {
   source = "../../modules/tagging-scp"
 
-  iam_actions             = local.iam_actions_for_tagging_scp_staging
+  iam_actions             = local.iam_actions_for_tagging_scps_staging_coat
   tags_to_enforce         = local.mandatory_tags_group_2
   organisational_unit_ids = [local.coat_ou_id]
 }
@@ -595,7 +595,7 @@ module "mandatory_tags_group_2_scp_staging_coat" {
 module "mandatory_tags_group_3_scp_staging_coat" {
   source = "../../modules/tagging-scp"
 
-  iam_actions             = local.iam_actions_for_tagging_scp_staging
+  iam_actions             = local.iam_actions_for_tagging_scps_staging_coat
   tags_to_enforce         = local.mandatory_tags_group_3
   organisational_unit_ids = [local.coat_ou_id]
 }

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -487,6 +487,7 @@ locals {
     "ecr:CreateRepository",
     "secretsmanager:CreateSecret",
     "logs:CreateLogGroup",
+    "elasticache:CreateReplicationGroup",
 
     # Cloud Platform - RDS
     "rds:CreateBlueGreenDeployment",

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -553,8 +553,6 @@ locals {
     "athena:CreateWorkGroup",
     "athena:CreateCapacityReservation",
     "athena:CreateDataCatalog",
-    "s3:CreateBucket",
-    "s3:CreateAccessPoint",
     "kms:CreateKey",
     "lambda:CreateFunction",
     "lambda:CreateCapacityProvider",
@@ -565,7 +563,6 @@ locals {
     "ecr:CreateRepository",
     "secretsmanager:CreateSecret",
     "logs:CreateLogGroup",
-    "elasticache:CreateReplicationGroup",
 
     "rds:CreateBlueGreenDeployment",
     "rds:CreateCustomDBEngineVersion",

--- a/modules/tagging-scp/main.tf
+++ b/modules/tagging-scp/main.tf
@@ -17,15 +17,17 @@ data "aws_iam_policy_document" "default" {
   dynamic "statement" {
     for_each = var.tags_to_enforce
 
-    sid       = "DenyMissing${statement.value.tag}"
-    effect    = "Deny"
-    actions   = var.iam_actions
-    resources = [var.resources]
+    content {
+      sid       = "DenyMissing${statement.value.tag}"
+      effect    = "Deny"
+      actions   = var.iam_actions
+      resources = [var.resources]
 
-    condition {
-      test     = "Null"
-      variable = "aws:RequestTag/${statement.value.tag}"
-      values   = ["true"]
+      condition {
+        test     = "Null"
+        variable = "aws:RequestTag/${statement.value.tag}"
+        values   = ["true"]
+      }
     }
   }
 
@@ -39,15 +41,17 @@ data "aws_iam_policy_document" "default" {
       if length(valid_values) > 0
     }
 
-    sid       = "DenyInvalid${statement.value.tag}"
-    effect    = "Deny"
-    actions   = var.iam_actions
-    resources = [var.resources]
+    content {
+      sid       = "DenyInvalid${statement.value.tag}"
+      effect    = "Deny"
+      actions   = var.iam_actions
+      resources = [var.resources]
 
-    condition {
-      test     = "StringNotEquals"
-      variable = "aws:RequestTag/${statement.value.tag}"
-      values = statement.value.valid_values
+      condition {
+        test     = "StringNotEquals"
+        variable = "aws:RequestTag/${statement.value.tag}"
+        values = statement.value.valid_values
+      }
     }
   }
 }

--- a/modules/tagging-scp/main.tf
+++ b/modules/tagging-scp/main.tf
@@ -1,7 +1,11 @@
+locals {
+  tag_names = [for tag in var.tags_to_enforce : tag.tag]
+}
+
 # Policies
 resource "aws_organizations_policy" "default" {
-  name        = "Enforce ${join(", ", var.tags_to_enforce)} tag"
-  description = "Enforces the presence of mandatory ${join(", ", var.tags_to_enforce)} tag"
+  name        = "Enforce ${join(", ", local.tag_names)} tag"
+  description = "Enforces the presence of mandatory ${join(", ", local.tag_names)} tag"
   type        = "SERVICE_CONTROL_POLICY"
   tags = {
     business-unit = "Platforms"

--- a/modules/tagging-scp/main.tf
+++ b/modules/tagging-scp/main.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "default" {
     for_each = var.tags_to_enforce
 
     content {
-      sid       = "DenyMissing${statement.value.tag}"
+      sid       = "DenyMissing${join("", [for part in split("-", statement.value.tag) : title(part)])}"
       effect    = "Deny"
       actions   = var.iam_actions
       resources = var.resources
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "default" {
     }
 
     content {
-      sid       = "DenyInvalid${statement.key}"
+      sid       = "DenyInvalid${join("", [for part in split("-", statement.key) : title(part)])}"
       effect    = "Deny"
       actions   = var.iam_actions
       resources = var.resources

--- a/modules/tagging-scp/main.tf
+++ b/modules/tagging-scp/main.tf
@@ -1,0 +1,61 @@
+# Policies
+resource "aws_organizations_policy" "default" {
+  name        = "Enforce ${join(", ", var.tags_to_enforce)} tag"
+  description = "Enforces the presence of mandatory ${join(", ", var.tags_to_enforce)} tag"
+  type        = "SERVICE_CONTROL_POLICY"
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [var.github_repository, "/terraform/organizations-service-control-policies.tf"])
+  }
+
+  content = data.aws_iam_policy_document.default.json
+}
+
+# Policy Documents
+data "aws_iam_policy_document" "default" {
+  dynamic "statement" {
+    for_each = var.tags_to_enforce
+
+    sid       = "DenyMissing${statement.value.tag}"
+    effect    = "Deny"
+    actions   = var.iam_actions
+    resources = [var.resources]
+
+    condition {
+      test     = "Null"
+      variable = "aws:RequestTag/${statement.value.tag}"
+      values   = ["true"]
+    }
+  }
+
+  dynamic "statement" {
+    for_each   = {
+      for tag, valid_values in var.tags_to_enforce :
+      tag => {
+        tag          = tag
+        valid_values = valid_values
+      }
+      if length(valid_values) > 0
+    }
+
+    sid       = "DenyInvalid${statement.value.tag}"
+    effect    = "Deny"
+    actions   = var.iam_actions
+    resources = [var.resources]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:RequestTag/${statement.value.tag}"
+      values = statement.value.valid_values
+    }
+  }
+}
+
+# Policy Attachments
+resource "aws_organizations_policy_attachment" "default" {
+  for_each = toset(var.organisational_unit_ids)
+
+  policy_id = aws_organizations_policy.default.id
+  target_id = each.value
+}

--- a/modules/tagging-scp/main.tf
+++ b/modules/tagging-scp/main.tf
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "default" {
   }
 
   dynamic "statement" {
-    for_each   = {
+    for_each = {
       for item in var.tags_to_enforce :
       item.tag => item.valid_values
       if length(item.valid_values) > 0
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "default" {
       condition {
         test     = "StringNotEquals"
         variable = "aws:RequestTag/${statement.key}"
-        values = statement.value
+        values   = statement.value
       }
     }
   }

--- a/modules/tagging-scp/main.tf
+++ b/modules/tagging-scp/main.tf
@@ -25,7 +25,7 @@ data "aws_iam_policy_document" "default" {
       sid       = "DenyMissing${statement.value.tag}"
       effect    = "Deny"
       actions   = var.iam_actions
-      resources = [var.resources]
+      resources = var.resources
 
       condition {
         test     = "Null"
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "default" {
       sid       = "DenyInvalid${statement.value.tag}"
       effect    = "Deny"
       actions   = var.iam_actions
-      resources = [var.resources]
+      resources = var.resources
 
       condition {
         test     = "StringNotEquals"

--- a/modules/tagging-scp/main.tf
+++ b/modules/tagging-scp/main.tf
@@ -37,24 +37,21 @@ data "aws_iam_policy_document" "default" {
 
   dynamic "statement" {
     for_each   = {
-      for tag, valid_values in var.tags_to_enforce :
-      tag => {
-        tag          = tag
-        valid_values = valid_values
-      }
-      if length(valid_values) > 0
+      for item in var.tags_to_enforce :
+      item.tag => item.valid_values
+      if length(item.valid_values) > 0
     }
 
     content {
-      sid       = "DenyInvalid${statement.value.tag}"
+      sid       = "DenyInvalid${statement.key}"
       effect    = "Deny"
       actions   = var.iam_actions
       resources = var.resources
 
       condition {
         test     = "StringNotEquals"
-        variable = "aws:RequestTag/${statement.value.tag}"
-        values = statement.value.valid_values
+        variable = "aws:RequestTag/${statement.key}"
+        values = statement.value
       }
     }
   }

--- a/modules/tagging-scp/outputs.tf
+++ b/modules/tagging-scp/outputs.tf
@@ -1,0 +1,3 @@
+output "scp_id" {
+  value = aws_organizations_policy.default.id
+}

--- a/modules/tagging-scp/variables.tf
+++ b/modules/tagging-scp/variables.tf
@@ -10,8 +10,8 @@ variable "resources" {
 
 variable "tags_to_enforce" {
   type = list(object({
-    tag                 = string
-    valid_values        = list(string)
+    tag          = string
+    valid_values = list(string)
   }))
   default = []
 }

--- a/modules/tagging-scp/variables.tf
+++ b/modules/tagging-scp/variables.tf
@@ -1,0 +1,32 @@
+variable "iam_actions" {
+  type    = list(string)
+  default = []
+}
+
+variable "resources" {
+  type    = list(string)
+  default = ["*"]
+}
+
+variable "enforce_value" {
+  type    = bool
+  default = false
+}
+
+variable "tags_to_enforce" {
+  type = list(object({
+    tag                 = string
+    valid_values        = list(string)
+  }))
+  default = []
+}
+
+variable "organisational_unit_ids" {
+  type    = list(string)
+  default = []
+}
+
+variable "github_repository" {
+  type    = string
+  default = "github.com/ministryofjustice/aws-root-account/blob/main"
+}

--- a/modules/tagging-scp/variables.tf
+++ b/modules/tagging-scp/variables.tf
@@ -8,11 +8,6 @@ variable "resources" {
   default = ["*"]
 }
 
-variable "enforce_value" {
-  type    = bool
-  default = false
-}
-
 variable "tags_to_enforce" {
   type = list(object({
     tag                 = string

--- a/modules/tagging-scp/versions.tf
+++ b/modules/tagging-scp/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}


### PR DESCRIPTION
**Why**

Modularise tagging SCPs to:
- Reduce code duplication
- Allow for multi-environment/platform setup - separate staging SCPs attached to COAT OU to allow for adequate SCP testing and phased rollout.

**What**

- Creates internal tagging scp module
- Refactors tagging SCP code with attachments to COAT OU to use this module
- Adds actions for services we want to test to staging/COAT SCPs (https://github.com/orgs/ministryofjustice/projects/52/views/4?pane=issue&itemId=179351294&issue=ministryofjustice%7Ccloud-optimisation-and-accountability%7C759).
- Removes problematic actions (https://github.com/orgs/ministryofjustice/projects/52/views/4?pane=issue&itemId=186066937&issue=ministryofjustice%7Ccloud-optimisation-and-accountability%7C786) from provisional actions list for "prod" SCPs.