### PR TITLE
fix alerting and resuse chatbot config

### DIFF
--- a/management-account/terraform/alerting-modernisation-platform-scp.tf
+++ b/management-account/terraform/alerting-modernisation-platform-scp.tf
@@ -21,18 +21,18 @@ resource "aws_cloudwatch_event_rule" "modernisation_platform_scp_change_alerts" 
   description = "Alerts on AWS Organizations changes to Modernisation Platform SCPs."
 
   event_pattern = jsonencode({
-    "detail-type" : ["AWS API Call via CloudTrail"],
-    "source" : ["aws.organizations"],
-    "detail" : {
-      "eventSource" : ["organizations.amazonaws.com"],
-      "eventName" : [
+    "detail-type" = ["AWS API Call via CloudTrail"]
+    "source"      = ["aws.organizations"]
+    "detail" = {
+      "eventSource" = ["organizations.amazonaws.com"]
+      "eventName" = [
         "UpdatePolicy",
         "AttachPolicy",
         "DetachPolicy",
         "DeletePolicy"
-      ],
-      "requestParameters" : {
-        "policyId" : [
+      ]
+      "requestParameters" = {
+        "policyId" = [
           aws_organizations_policy.rds_guardrails.id,
           aws_organizations_policy.mp_deny_cloudtrail_delete_stop_update.id,
           aws_organizations_policy.mp_protect_core_s3_buckets.id,
@@ -66,27 +66,21 @@ data "aws_iam_policy_document" "modernisation_platform_scp_change_alerts_topic_p
       identifiers = ["events.amazonaws.com"]
     }
 
-    actions   = ["sns:Publish"]
-    resources = [aws_sns_topic.modernisation_platform_scp_change_alerts.arn]
+    actions = [
+      "sns:Publish"
+    ]
+
+    resources = [
+      aws_sns_topic.modernisation_platform_scp_change_alerts.arn
+    ]
 
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
-      values   = [aws_cloudwatch_event_rule.modernisation_platform_scp_change_alerts.arn]
+      values = [
+        aws_cloudwatch_event_rule.modernisation_platform_scp_change_alerts.arn
+      ]
     }
-  }
-
-  statement {
-    sid    = "AllowAccountAdmin"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
-    }
-
-    actions   = ["sns:*"]
-    resources = [aws_sns_topic.modernisation_platform_scp_change_alerts.arn]
   }
 }
 
@@ -95,19 +89,4 @@ resource "aws_sns_topic_policy" "modernisation_platform_scp_change_alerts" {
 
   arn    = aws_sns_topic.modernisation_platform_scp_change_alerts.arn
   policy = data.aws_iam_policy_document.modernisation_platform_scp_change_alerts_topic_policy.json
-}
-
-module "modernisation_platform_scp_slack_notifications" {
-  source = "github.com/ministryofjustice/modernisation-platform-terraform-aws-chatbot?ref=0ec33c7bfde5649af3c23d0834ea85c849edf3ac" # v3.0.0
-
-  providers = {
-    aws = aws.us-east-1
-  }
-
-  application_name = "modernisation-platform-scp-alerts"
-  slack_channel_id = "C02PFCG8M1R"
-  sns_topic_arns = [
-    aws_sns_topic.modernisation_platform_scp_change_alerts.arn
-  ]
-  tags = {}
 }

--- a/management-account/terraform/sso-scim.tf
+++ b/management-account/terraform/sso-scim.tf
@@ -34,7 +34,8 @@ module "scim_slack_notifications" {
   slack_channel_id = "C02PFCG8M1R"
   sns_topic_arns = [
     module.entraid_scim.sns_topic_arn,
-    module.scim.sns_topic_arn
+    module.scim.sns_topic_arn,
+    aws_sns_topic.modernisation_platform_scp_change_alerts.arn
   ]
   tags = {}
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

{ Add content here - what are you trying to achieve with this PR? What originating issue sparked this pull request? }

This change makes Modernisation Platform SCP change alerting publish to an SNS topic in us-east-1 (where Organizations CloudTrail events appear), and reuses the existing Slack Chatbot configuration (SCIM monitoring) to deliver alerts to the already-configured Slack channel. 

## ♻️ What's changed

{ Add content here - what functional changes are you introducing? Are you adding new resources? Changing existing resources? }

│ Error: setting SNS Topic (arn:aws:sns:us-east-1:***:modernisation-platform-scp-change-alerts) attribute (Policy): operation error SNS: SetTopicAttributes, https response error StatusCode: 400, RequestID: 8787979b-5587-5d6a-9f50-f5e0e22966f2, InvalidParameter: Invalid parameter: Policy statement action out of service scope!
│ Error: creating AWS Chatbot Slack Channel Configuration

Avoids AWS Chatbot failing with “Slack channel already configured” by not attempting to create a second Slack channel configuration in the same account.
Avoids SNS policy errors  sns:* and keeps the topic policy scoped to EventBridge.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [ ] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
