### PR TITLE
Add MP secure-baselines SCP protection actions

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -273,3 +273,71 @@ resource "aws_organizations_policy_attachment" "mp_protect_core_s3_buckets" {
   policy_id = aws_organizations_policy.mp_protect_core_s3_buckets.id
   target_id = aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id
 }
+
+
+###############################################################
+# Protect baseline resources from deletion
+# Modernisation Platform OU scope
+###############################################################
+
+data "aws_iam_policy_document" "mp_protect_secure_baselines" {
+  statement {
+    sid    = "DenyDeleteSecureBaselinesResources"
+    effect = "Deny"
+    actions = [
+      "accessanalyzer:Delete*",
+      "backup:Delete*",
+      "cloudtrail:Delete*",
+      "cloudtrail:StopLogging",
+      "cloudwatch:Delete*",
+      "cloudwatch:DisableAlarmActions",
+      "events:Delete*",
+      "events:Remove*",
+      "guardduty:Delete*",
+      "kms:Delete*",
+      "kms:DisableKey",
+      "logs:Delete*",
+      "s3:Delete*",
+      "s3:PutBucketPolicy",
+      "sns:Delete*",
+      "securityhub:DisableSecurityHub",
+      "config:Delete*",
+      "config:StopConfigurationRecorder"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/component"
+      values   = ["secure-baselines"]
+    }
+
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "mp_protect_secure_baselines" {
+  name        = "Modernisation Platform Protect Secure Baselines"
+  description = "Deny deletion or disabling of secure-baselines tagged resources in Modernisation Platform accounts, except AWSReservedSSO_AdministratorAccess roles."
+  type        = "SERVICE_CONTROL_POLICY"
+
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-policy-service-control-modernisation-platform.tf"])
+  }
+
+  content = data.aws_iam_policy_document.mp_protect_secure_baselines.json
+}
+
+# Attach the SCP to the Modernisation Platform OU only
+resource "aws_organizations_policy_attachment" "mp_protect_secure_baselines" {
+  policy_id = aws_organizations_policy.mp_protect_secure_baselines.id
+  target_id = aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id
+}

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -296,6 +296,8 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
       "guardduty:Delete*",
       "kms:Delete*",
       "kms:DisableKey",
+      "kms:ScheduleKeyDeletion",
+      "kms:CancelKeyDeletion",
       "logs:Delete*",
       "s3:Delete*",
       "s3:PutBucketPolicy",


### PR DESCRIPTION
This change adds a minimal set of SCP actions to protect resources tagged with `component = secure-baselines` from being deleted, disabled. The policy blocks deletion or disabling of key baseline security and monitoring services. The policy is restricted to the` MP OU `and exempts the `AdministratorAccess` SSO role [#12217](https://github.com/ministryofjustice/modernisation-platform/issues/12217)