### PR TITLE
correct PrincipalArn condition + remove invalid S3 action

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -163,7 +163,7 @@ data "aws_iam_policy_document" "mp_deny_cloudtrail_delete_stop_update" {
 
     # Exclusion of ModernisationPlatformAccess role for Terraform infrastructure automation
     condition {
-      test     = "StringNotLike"
+      test     = "ArnNotLike"
       variable = "aws:PrincipalArn"
       values   = ["arn:aws:iam::*:role/ModernisationPlatformAccess"]
     }
@@ -239,7 +239,7 @@ data "aws_iam_policy_document" "mp_protect_core_s3_buckets" {
 
     # Exclusion of automation roles for Terraform infrastructure automation
     condition {
-      test     = "StringNotLike"
+      test     = "ArnNotLike"
       variable = "aws:PrincipalArn"
       values = [
         "arn:aws:iam::*:role/ModernisationPlatformAccess",
@@ -262,8 +262,7 @@ data "aws_iam_policy_document" "mp_protect_core_s3_buckets" {
     sid    = "DenyLifecycleChangesOnCoreBuckets"
     effect = "Deny"
     actions = [
-      "s3:PutLifecycleConfiguration",
-      "s3:DeleteLifecycleConfiguration"
+      "s3:PutLifecycleConfiguration"
     ]
     resources = local.mp_protected_core_s3_buckets
   }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

{ Add content here - what are you trying to achieve with this PR? What originating issue sparked this pull request? }

Fixes SCP policy validation errors by using the correct condition operator type for aws:PrincipalArn and removing an invalid S3 action from the core bucket protection controls.


## ♻️ What's changed

{ Add content here - what functional changes are you introducing? Are you adding new resources? Changing existing resources? }

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [ ] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
