### PR TITLE
Exclude `testing-test` from secure baselines SCP for terratest

### DIFF
--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -71,6 +71,11 @@ locals {
       account_id
       if account_name == "sprinkler-development"
     ]
+    testing_test = [
+      for account_name, account_id in local.accounts.active_only :
+      account_id
+      if account_name == "testing-test"
+    ]
   }
 
   root_account = merge(local.tags_business_units.platforms, {

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -320,6 +320,14 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
         "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
       ]
     }
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:PrincipalAccount"
+      values = flatten([
+        local.modernisation_platform_accounts.testing_test
+      ])
+    }
   }
 }
 


### PR DESCRIPTION
Terratest runs in the `testing-test` account and needs to create and delete baseline-related resources as part of test setup and teardown. At the moment, the secure baselines SCP denies deletion or disabling of `secure-baselines` tagged resources, which causes terratest cleanup to fail.
https://github.com/ministryofjustice/modernisation-platform-terraform-baselines/actions/runs/25919592203/job/76190113290#step:9:6644

This change is intended to support automated test execution in `testing-test` where resource deletion is required.