### PR TITLE
Adds policy to enforce use of MFA by IAM users & applies this policy to user groups.

### DIFF
--- a/management-account/terraform/iam-groups.tf
+++ b/management-account/terraform/iam-groups.tf
@@ -31,6 +31,11 @@ resource "aws_iam_group_policy_attachment" "aws_organisations_admin_custom" {
   policy_arn = aws_iam_policy.aws_organisations_admin.arn
 }
 
+resource "aws_iam_group_policy_attachment" "aws_organisations_admin_enforce_mfa" {
+  group      = aws_iam_group.aws_organisations_admin.name
+  policy_arn = aws_iam_policy.enforce_mfa_use_policy.arn
+}
+
 ################################
 # AWSOrganisationsListReadOnly #
 ################################
@@ -59,6 +64,11 @@ resource "aws_iam_group_policy_attachment" "billing_full_access" {
   policy_arn = aws_iam_policy.billing_full_access.arn
 }
 
+resource "aws_iam_group_policy_attachment" "billing_enforce_mfa" {
+  group      = aws_iam_group.billing_full_access.name
+  policy_arn = aws_iam_policy.enforce_mfa_use_policy.arn
+}
+
 #########################
 # IAMUserChangePassword #
 #########################
@@ -85,4 +95,9 @@ resource "aws_iam_group" "modernisation_platform_organisation_management" {
 resource "aws_iam_group_policy_attachment" "modernisation_platform_organisation_management" {
   group      = aws_iam_group.modernisation_platform_organisation_management.name
   policy_arn = aws_iam_policy.terraform_organisation_management_policy.arn
+}
+
+resource "aws_iam_group_policy_attachment" "modernisation_platform_organisation_enforce_mfa" {
+  group      = aws_iam_group.modernisation_platform_organisation_management.name
+  policy_arn = aws_iam_policy.enforce_mfa_use_policy.arn
 }

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -278,3 +278,126 @@ data "aws_iam_policy_document" "terraform_organisation_management_policy" {
     }
   }
 }
+
+################################
+# Enforce MFA Use by IAM Users #
+################################
+resource "aws_iam_policy" "enforce_mfa_use_policy" {
+  name        = "enforce-mfa-by-users"
+  description = "A policy that enforces the use of MFA by IAM Users"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.enforce_mfa_use_policy.json
+  tags        = {}
+}
+
+# AWS IAM Policy Document for Force MFA, as taken from:
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html
+data "aws_iam_policy_document" "enforce_mfa_use_policy" {
+  version = "2012-10-17"
+
+  statement {
+    sid    = "AllowViewAccountInfo"
+    effect = "Allow"
+    actions = [
+      "iam:GetAccountPasswordPolicy",
+      "iam:GetAccountSummary",
+      "iam:ListVirtualMFADevices"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "AllowManageOwnPasswords"
+    effect = "Allow"
+    actions = [
+      "iam:ChangePassword",
+      "iam:GetUser"
+    ]
+    resources = ["arn:aws:iam::*:user/$${aws:username}"]
+  }
+  statement {
+    sid    = "AllowManageOwnAccessKeys"
+    effect = "Allow"
+    actions = [
+      "iam:CreateAccessKey",
+      "iam:DeleteAccessKey",
+      "iam:ListAccessKeys",
+      "iam:UpdateAccessKey"
+    ]
+    resources = ["arn:aws:iam::*:user/$${aws:username}"]
+  }
+  statement {
+    sid    = "AllowManageOwnSigningCertificates"
+    effect = "Allow"
+    actions = [
+      "iam:DeleteSigningCertificate",
+      "iam:ListSigningCertificates",
+      "iam:UpdateSigningCertificate",
+      "iam:UploadSigningCertificate"
+    ]
+    resources = ["arn:aws:iam::*:user/$${aws:username}"]
+  }
+  statement {
+    sid    = "AllowManageOwnSSHPublicKeys"
+    effect = "Allow"
+    actions = [
+      "iam:DeleteSSHPublicKey",
+      "iam:GetSSHPublicKey",
+      "iam:ListSSHPublicKeys",
+      "iam:UpdateSSHPublicKey",
+      "iam:UploadSSHPublicKey"
+    ]
+    resources = ["arn:aws:iam::*:user/$${aws:username}"]
+  }
+  statement {
+    sid    = "AllowManageOwnGitCredentials"
+    effect = "Allow"
+    actions = [
+      "iam:CreateServiceSpecificCredential",
+      "iam:DeleteServiceSpecificCredential",
+      "iam:ListServiceSpecificCredentials",
+      "iam:ResetServiceSpecificCredential",
+      "iam:UpdateServiceSpecificCredential"
+    ]
+    resources = ["arn:aws:iam::*:user/$${aws:username}"]
+  }
+  statement {
+    sid    = "AllowManageOwnVirtualMFADevice"
+    effect = "Allow"
+    actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:DeleteVirtualMFADevice"
+    ]
+    resources = ["arn:aws:iam::*:mfa/$${aws:username}"]
+  }
+  statement {
+    sid    = "AllowManageOwnUserMFA"
+    effect = "Allow"
+    actions = [
+      "iam:DeactivateMFADevice",
+      "iam:EnableMFADevice",
+      "iam:ListMFADevices",
+      "iam:ResyncMFADevice"
+    ]
+    resources = ["arn:aws:iam::*:user/$${aws:username}"]
+  }
+  statement {
+    sid    = "DenyAllExceptListedIfNoMFA"
+    effect = "Deny"
+    not_actions = [
+      "iam:CreateVirtualMFADevice",
+      "iam:EnableMFADevice",
+      "iam:GetUser",
+      "iam:ListMFADevices",
+      "iam:ListVirtualMFADevices",
+      "iam:ResyncMFADevice",
+      "sts:GetSessionToken",
+      "iam:ChangePassword"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "BoolIfExists"
+      variable = "aws:MultiFactorAuthPresent"
+      values   = ["false"]
+    }
+  }
+}


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

## 👀 Purpose

Enforces the use of MFA by IAM user accounts. See Modernisation Platform ticket id https://github.com/ministryofjustice/modernisation-platform-security/issues/91

## ♻️ What's changed

- Adds a new policy with permissions to enforce authorisation-time MFA whilst allowing for user sign-on and MFA token setting. This policy is based directly on that used by the Modernisation Platform team for its superadmin IAM user accounts. (see https://github.com/ministryofjustice/modernisation-platform-terraform-iam-superadmins/blob/main/main.tf#L131)
- Assigns this policy to the groups AWSOrganisationsAdmin, BillingFullAccess and ModernisationPlatformOrganisationManagement
- Does not assign MFA permissions to AWSOrganisationsListReadOnly as this is used by XsoarIntegration and could break integration between the cortex-xsiam platform and access to log data.


## 🔊 Does this PR affect multiple parties?

- [x] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [ ] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
