### PR TITLE
New team for techops operator permission

### DIFF
--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -76,6 +76,17 @@ locals {
       account_id
       if account_name == "testing-test"
     ]
+    moj_network_operations_centre_preproduction_id = [
+      for account_name, account_id in local.accounts.active_only :
+      account_id
+      if account_name == "moj-network-operations-centre-preproduction"
+    ]
+
+    moj_network_operations_centre_production_id = [
+      for account_name, account_id in local.accounts.active_only :
+      account_id
+      if account_name == "moj-network-operations-centre-production"
+    ]
   }
 
   root_account = merge(local.tags_business_units.platforms, {
@@ -152,18 +163,4 @@ locals {
       "arn:aws:s3:::${location}/*"
     ]
   ])
-
-  organizations_organization = data.terraform_remote_state.management_account.outputs.organizations_organization
-
-  moj_network_operations_centre_preproduction_account_id = coalesce([
-    for account in local.organizations_organization.accounts :
-    account.id
-    if account.name == "moj-network-operations-centre-preproduction"
-  ]...)
-
-  moj_network_operations_centre_production_account_id = coalesce([
-    for account in local.organizations_organization.accounts :
-    account.id
-    if account.name == "moj-network-operations-centre-production"
-  ]...)
 }

--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -152,4 +152,18 @@ locals {
       "arn:aws:s3:::${location}/*"
     ]
   ])
+
+  organizations_organization = data.terraform_remote_state.management_account.outputs.organizations_organization
+
+  moj_network_operations_centre_preproduction_account_id = coalesce([
+    for account in local.organizations_organization.accounts :
+    account.id
+    if account.name == "moj-network-operations-centre-preproduction"
+  ]...)
+
+  moj_network_operations_centre_production_account_id = coalesce([
+    for account in local.organizations_organization.accounts :
+    account.id
+    if account.name == "moj-network-operations-centre-production"
+  ]...)
 }

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -345,6 +345,31 @@ locals {
       ]
     },
     {
+      github_team        = "moj-official-techops-operator",
+      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
+      account_ids = [
+        aws_organizations_account.moj_official_development.id,
+        aws_organizations_account.workplace_tech_proof_of_concept_development.id,
+        aws_organizations_account.network_architecture.id
+      ]
+    },
+    {
+      github_team        = "moj-official-techops-operator",
+      permission_set_arn = aws_ssoadmin_permission_set.techops_operator.arn,
+      account_ids = [
+        aws_organizations_account.moj_official_development.id,
+        aws_organizations_account.moj_official_preproduction.id,
+        aws_organizations_account.moj_official_production.id,
+        aws_organizations_account.moj_official_public_key_infrastructure_dev.id,
+        aws_organizations_account.moj_official_public_key_infrastructure.id,
+        aws_organizations_account.moj_official_shared_services.id,
+        aws_organizations_account.workplace_tech_proof_of_concept_development.id,
+        aws_organizations_account.network_architecture.id,
+        local.moj_network_operations_centre_preproduction_account_id,
+        local.moj_network_operations_centre_production_account_id
+      ]
+    },
+    {
       github_team        = "eucs-idam-maintainers",
       permission_set_arn = aws_ssoadmin_permission_set.techops_operator.arn,
       account_ids = [

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -345,7 +345,7 @@ locals {
       ]
     },
     {
-      github_team        = "moj-official-techops-operator",
+      github_team        = "moj-official-techops-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [
         aws_organizations_account.moj_official_development.id,
@@ -354,7 +354,7 @@ locals {
       ]
     },
     {
-      github_team        = "moj-official-techops-operator",
+      github_team        = "moj-official-techops-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.techops_operator.arn,
       account_ids = [
         aws_organizations_account.moj_official_development.id,

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -356,7 +356,7 @@ locals {
     {
       github_team        = "moj-official-techops-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.techops_operator.arn,
-      account_ids = [
+      account_ids = flatten([
         aws_organizations_account.moj_official_development.id,
         aws_organizations_account.moj_official_preproduction.id,
         aws_organizations_account.moj_official_production.id,
@@ -365,9 +365,16 @@ locals {
         aws_organizations_account.moj_official_shared_services.id,
         aws_organizations_account.workplace_tech_proof_of_concept_development.id,
         aws_organizations_account.network_architecture.id,
-        local.moj_network_operations_centre_preproduction_account_id,
-        local.moj_network_operations_centre_production_account_id
-      ]
+        local.modernisation_platform_accounts.moj_network_operations_centre_preproduction_id,
+        local.modernisation_platform_accounts.moj_network_operations_centre_production_id,
+      ])
+    },
+    {
+      github_team        = "moj-official-techops",
+      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
+      account_ids = flatten([
+        local.modernisation_platform_accounts.core_network_services_id,
+      ])
     },
     {
       github_team        = "eucs-idam-maintainers",
@@ -392,13 +399,6 @@ locals {
       account_ids = [
         aws_organizations_account.moj_official_shared_services.id,
       ]
-    },
-    {
-      github_team        = "moj-official-techops",
-      permission_set_arn = aws_ssoadmin_permission_set.read_only_access.arn,
-      account_ids = flatten([
-        local.modernisation_platform_accounts.core_network_services_id,
-      ])
     },
     {
       github_team        = "cloud-ops-alz-admins",

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -439,13 +439,6 @@ locals {
       ]
     },
     {
-      github_team        = "moj-official-sharedservices-noc",
-      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
-      account_ids = [
-        aws_organizations_account.moj_official_shared_services.id,
-      ]
-    },
-    {
       github_team        = "modernisation-platform-engineers",
       permission_set_arn = aws_ssoadmin_permission_set.aws_sso_read_only.arn,
       account_ids = [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose
The `moj-official-techops` team currently has Administrator access to the NOC pre-production and production accounts, as defined in the Modernisation Platform account configuration:

https://github.com/ministryofjustice/modernisation-platform/blob/a52d8c7855fcd51c9140ef2865cf1c9f8b788859/environments/moj-network-operations-centre.json#L8

The purpose of this PR is to reduce the level of access granted to NOC accounts. A dedicated team assignment has been created to provide the `techops_operator` permission set instead of Administrator access.


## ♻️ What's changed

Added a new GitHub team assignment for `moj-official-techops-engineers` with the `techops_operator` permission set.

Removed the unused team assignment `moj-official-sharedservices-noc`.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
