### PR TITLE
STB-4328: S3 permission change to allow cloudwatch log export

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -982,7 +982,10 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
       "s3:PutObject",
     ]
     #tfsec:ignore:aws-iam-no-policy-wildcards
-    resources = ["*"]
+    not_resources = [
+      "arn:aws:s3:::laa-prod-cloudwatch-logs-backup",
+      "arn:aws:s3:::laa-prod-cloudwatch-logs-backup/*"
+    ]
   }
   statement {
     sid    = "AllowSnapshotCopy"
@@ -1025,7 +1028,9 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
     actions = [
       "logs:CreateExportTask",
       "logs:DescribeExportTasks",
-      "logs:CancelExportTask"
+      "logs:CancelExportTask",
+      "logs:DescribeLogStreams",
+      "logs:DescribeLogGroups"
     ]
     resources = ["*"]
   }
@@ -1041,5 +1046,15 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
       variable = "iam:PassedToService"
       values   = ["backup.amazonaws.com"]
     }
+  }
+  statement {
+    sid    = "AllowS3PutToCloudWatchBucket"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject"
+  ]
+    resources = [
+      "arn:aws:s3:::laa-prod-cloudwatch-logs-backup/*"
+    ]
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

CloudWatch logs export task was giving permission errors. I believe the s3 deny rule was causing this. This is for LZ Prod back up work (STB-4060)

## ♻️ What's changed

Scoped the existing deny rule to exclude the S3 bucket in the destination account and added a new statement granting s3:PutObject on that bucket only.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [ X] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
