### PR TITLE
Add LAA read-only permissions for RDS and EFS backups

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -1049,19 +1049,6 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
     resources = ["*"]
   }
   statement {
-    sid    = "AllowPassAWSBackupServiceRole"
-    effect = "Allow"
-    actions = [
-      "iam:PassRole"
-    ]
-    resources = ["arn:aws:iam::${aws_organizations_account.laa_production.id}:role/service-role/AWSBackupDefaultServiceRole"]
-    condition {
-      test     = "StringEquals"
-      variable = "iam:PassedToService"
-      values   = ["backup.amazonaws.com"]
-    }
-  }
-  statement {
     sid    = "AllowS3PutToCloudWatchBucket"
     effect = "Allow"
     actions = [

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -1036,7 +1036,7 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
     ]
     resources = ["arn:aws:kms:*:*:key/*"]
   }
-    statement {
+  statement {
     sid    = "AllowCloudWatchLogsExport"
     effect = "Allow"
     actions = [
@@ -1066,7 +1066,7 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
     effect = "Allow"
     actions = [
       "s3:PutObject"
-  ]
+    ]
     resources = [
       "arn:aws:s3:::laa-prod-cloudwatch-logs-backup/*"
     ]

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -1002,6 +1002,7 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
       "rds:CreateDBSnapshot",
       "rds:CopyDBSnapshot",
       "rds:ModifyDBSnapshotAttribute",
+      "rds:AddTagsToResource",
       "elasticfilesystem:Backup",
       "backup:ListRecoveryPoints",
       "backup:StartBackupJob",

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -1010,6 +1010,19 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
     resources = ["*"]
   }
   statement {
+    sid    = "AllowPassAWSBackupServiceRole"
+    effect = "Allow"
+    actions = [
+      "iam:PassRole"
+    ]
+    resources = ["arn:aws:iam::${aws_organizations_account.laa_production.id}:role/service-role/AWSBackupDefaultServiceRole"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["backup.amazonaws.com"]
+    }
+  }
+  statement {
     sid    = "AllowKMSKeyUseForSnapshotCopy"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

Allow the LAAReadOnly permission set to create and manage the RDS/EFS backup actions needed for LZ Prod backup work.

This was raised after access denied errors when creating RDS snapshots and starting EFS backup jobs.

## ♻️ What's changed

Updated the LAAReadOnly additional inline policy to allow: rds:AddTagsToResource

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

