### PR TITLE
Add audit-log cursor for periodic GitHub sync

### DIFF
--- a/management-account/terraform/secrets-manager.tf
+++ b/management-account/terraform/secrets-manager.tf
@@ -80,6 +80,16 @@ data "aws_secretsmanager_secret_version" "github_app_private_key" {
   secret_id = aws_secretsmanager_secret.github_app_private_key.id
 }
 
+# GitHub App Private Key for the periodic GitHub team -> IAM Identity Center sync (v2 poller).
+# The value (PEM) is populated out-of-band when the GitHub App is created; no
+# secret_version is managed here, mirroring github_app_private_key above. The
+# consuming data source + module wiring are added once the value exists and the
+# moj-terraform-github-periodic-sync module has a tagged release.
+resource "aws_secretsmanager_secret" "github_periodic_sync_private_key" {
+  name        = "github_periodic_sync_private_key"
+  description = "GitHub App private key for the periodic GitHub team to IAM Identity Center sync"
+}
+
 # OIDC: Azure EntraID client ID and secrets
 resource "aws_secretsmanager_secret" "azure_entraid_oidc" {
   name        = "azure_entraid_oidc"


### PR DESCRIPTION
## What

Declares the `github_periodic_sync_private_key` Secrets Manager secret for the new audit-log-driven GitHub team → AWS IAM Identity Center periodic sync (v2 poller).

## Why first / scope

The poller authenticates as a GitHub App; its private key must live in a code-managed Secrets Manager secret before anything can populate or consume it. This PR adds **only the secret resource** (mirroring `github_app_private_key`).

- No `secret_version` is managed here — the PEM is written out-of-band when the GitHub App is created.
- The consuming `data` source + the module wiring (the periodic-sync module call) follow in a later PR, once the value exists and `ministryofjustice/moj-terraform-github-periodic-sync` has a tagged release.

## Validation

- `terraform fmt -check` passes.