### PR TITLE
Bump moj-terraform-scim-entra-id to latest version

### DIFF
--- a/management-account/terraform/sso-scim.tf
+++ b/management-account/terraform/sso-scim.tf
@@ -17,7 +17,7 @@ module "scim" {
 
 module "entraid_scim" {
   # tflint-ignore: terraform_module_pinned_source
-  source              = "github.com/ministryofjustice/moj-terraform-scim-entra-id?ref=2b5085cb19c8c909c688e43f873013a2eb3d390f" # v2.0.1
+  source              = "github.com/ministryofjustice/moj-terraform-scim-entra-id?ref=d9411f9273c381a615d4017ffbde239ea37076d5" # v3.0.0
   azure_tenant_id     = sensitive(local.azure.tenant_id)
   azure_client_id     = sensitive(local.azure.client_id)
   azure_client_secret = sensitive(local.azure.client_secret)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

👀 **Purpose**
Upgrade the Entra ID SCIM module to the latest release so this stack stays aligned with upstream platform/runtime changes, specifically Terraform AWS Provider v6 compatibility and Python 3.13 support in the module implementation.

This PR was prompted by dependency maintenance on the SCIM integration path and keeping root account automation current with supported module/runtime versions.

♻️ **What's changed**
- Updated the Entra ID SCIM module source reference in `sso-scim.tf` from `v2.0.1` to `v3.0.0`.
- No direct functional logic changes were made in this repository beyond the pinned module version update.
- Any functional/resource deltas will come from the upstream module release (including its move to AWS provider v6 and Python 3.13).

🔊 **Does this PR affect multiple parties?**
- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [X] No.

📓 **Notes**
- Scope of change in this repo is intentionally minimal: module version bump only.
- Review focus should be on Terraform plan output to confirm there are no unexpected infra changes from the upstream module upgrade.
- This change is expected to improve compatibility with current provider/runtime baselines rather than introduce new root-account features.