### PR TITLE
Allow deletion of LAA final backup DB snapshots

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -1024,6 +1024,16 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
     }
   }
   statement {
+    sid    = "AllowDeleteLAAFinalBackupDBSnapshots"
+    effect = "Allow"
+    actions = [
+      "rds:DeleteDBSnapshot"
+    ]
+    resources = [
+      "arn:aws:rds:eu-west-2:${aws_organizations_account.laa_production.id}:snapshot:lz-prod-rds-*-final-backup"
+    ]
+  }
+  statement {
     sid    = "AllowKMSKeyUseForSnapshotCopy"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

Allow LAAReadOnly users to delete temporary final-backup RDS snapshots created as part of the LZ Prod backup work.

This was raised after an access denied error when trying to delete the `lz-prod-rds-bacway-final-backup` DB snapshot.

## ♻️ What's changed

The permission is limited to LAA Production RDS snapshots matching:

`arn:aws:rds:eu-west-2:${aws_organizations_account.laa_production.id}:snapshot:lz-prod-rds-*-final-backup`

No new resources are created.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

This is intentionally scoped to final-backup snapshots only, rather than allowing deletion of all RDS snapshots
