### PR TITLE
Add role for container platform to manage SSO

### DIFF
--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -309,3 +309,84 @@ resource "aws_iam_role_policy_attachment" "analytical_platform_identity_center" 
   role       = aws_iam_role.analytical_platform_identity_center.name
   policy_arn = aws_iam_policy.analytical_platform_identity_center.arn
 }
+
+#########################################
+# ContainerPlatformSSOAdministrator #
+#########################################
+resource "aws_iam_role" "container_platform_sso_administrator" {
+  name               = "ContainerPlatformSSOAdministrator"
+  assume_role_policy = data.aws_iam_policy_document.container_platform_sso_administrator.json
+}
+
+data "aws_iam_policy_document" "container_platform_sso_administrator" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.accounts.active_only["cloud-platform-live"]}:root",
+      ]
+    }
+  }
+}
+
+# Role policy attachments
+
+resource "aws_iam_role_policy_attachment" "container_platform_sso_administrator_custom" {
+  role       = aws_iam_role.container_platform_sso_administrator.name
+  policy_arn = aws_iam_policy.sso_administrator_policy.arn
+}
+
+#########################################
+# ContainerPlatformSSOReadOnly #
+#########################################
+resource "aws_iam_role" "container_platform_sso_readonly" {
+  name               = "ContainerPlatformSSOReadOnly"
+  assume_role_policy = data.aws_iam_policy_document.container_platform_sso_readonly.json
+}
+
+resource "aws_iam_policy" "container_platform_sso_readonly_additional" {
+  name   = "ContainerPlatformSSOReadOnlyAdditional"
+  policy = data.aws_iam_policy_document.container_platform_sso_readonly_additional.json
+}
+
+data "aws_iam_policy_document" "container_platform_sso_readonly" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${local.accounts.active_only["cloud-platform-live"]}:root",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "container_platform_sso_readonly_additional" {
+  statement {
+    effect  = "Allow"
+    actions = ["identitystore:Get*"]
+
+    resources = ["arn:aws:identitystore::${data.aws_caller_identity.current.account_id}:identitystore/*"]
+  }
+}
+
+# Role policy attachments
+resource "aws_iam_role_policy_attachment" "container_platform_sso_readonly" {
+  role       = aws_iam_role.container_platform_sso_readonly.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSSSOReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "container_platform_ssodirectory_readonly" {
+  role       = aws_iam_role.container_platform_sso_readonly.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSSSODirectoryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "container_platform_ssodirectory_readonly_additional" {
+  role       = aws_iam_role.container_platform_sso_readonly.name
+  policy_arn = aws_iam_policy.container_platform_sso_readonly_additional.arn
+}


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

## 👀 Purpose

Container platform needs access to mangage SSO, including creation, deletion, management of permission sets, account assignments and group assignments.

Also created readonly role so that when this runs on a pipeline the plan on PR can use this role.

Not reusing the similar MP role to keep separation of responsibilites and for security in case a role is compromised.

## ♻️ What's changed

Adding 2 new roles and attaching required policies

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
