### PR TITLE
Allow LAA read-only to update LZ backup vault policy

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -1036,6 +1036,16 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
     ]
   }
   statement {
+    sid    = "AllowLZDefaultVaultAccessPolicyUpdate"
+    effect = "Allow"
+    actions = [
+      "backup:PutBackupVaultAccessPolicy"
+    ]
+    resources = [
+      "arn:aws:backup:eu-west-2:${aws_organizations_account.laa_production.id}:backup-vault:Default"
+    ]
+  }
+  statement {
     sid    = "AllowKMSKeyUseForSnapshotCopy"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

Allow LAAReadOnly to update the LZ Default backup vault access policy so EFS recovery points can be copied from LAA Prod to the ECP backup vault

## ♻️ What's changed

Added `backup:PutBackupVaultAccessPolicy` to the LAAReadOnly permission set

This is scoped only to the LAA Prod Default backup vault:

`arn:aws:backup:eu-west-2:${aws_organizations_account.laa_production.id}:backup-vault:Default`

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window
- [x] No.

## 📓 Notes

This is needed because the AWS Backup console attempts to update the LZ Default vault access policy during the cross-account copy setup
