### PR TITLE
Allow LAA read-only users to start backup copy jobs

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -1008,6 +1008,7 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
       "elasticfilesystem:Backup",
       "backup:ListRecoveryPoints",
       "backup:StartBackupJob",
+      "backup:StartCopyJob",
       "backup:CopyRecoveryPoint"
     ]
     resources = ["*"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

Allow LAAReadOnly users to start AWS Backup copy jobs so EFS recovery points can be copied from LAA Prod to the ECP backup vault.

## ♻️ What's changed

Added `backup:StartCopyJob` to the LAAReadOnly additional policy

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

