### PR TITLE
Adding permissions to MP team for Justice Engineering account

### DIFF
--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -560,6 +560,7 @@ locals {
         aws_organizations_account.modernisation_platform.id,
         aws_organizations_organization.default.master_account_id,
         aws_organizations_account.organisation_security.id,
+        aws_organizations_account.justice_engineering_ai_services.id,
       ]
     },
     {
@@ -567,6 +568,7 @@ locals {
       permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
       account_ids = [
         aws_organizations_account.modernisation_platform.id,
+        aws_organizations_account.justice_engineering_ai_services.id,
       ]
     },
     {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

This is so that MP team can access Justice Engineering AI Services account using EntraID for SSO.

## ♻️ What's changed

New permissions are added for Modernisation Platform Team.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.
