### PR TITLE
Protect critical security services with Modernisation Platform SCPs

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -281,7 +281,7 @@ resource "aws_organizations_policy_attachment" "mp_protect_core_s3_buckets" {
 
 data "aws_iam_policy_document" "mp_protect_secure_baselines" {
   statement {
-    sid    = "DenyDeleteSecureBaselinesResources"
+    sid    = "DenyDestructiveChangesToSecureBaselinesResources"
     effect = "Deny"
     actions = [
       "accessanalyzer:Delete*",
@@ -329,11 +329,87 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
       ])
     }
   }
+
+  # Allow trusted platform automation to update baseline configuration while denying other principals
+  statement {
+    sid    = "DenyModificationOfSecureBaselinesResources"
+    effect = "Deny"
+    actions = [
+      "config:PutConfigurationRecorder",
+      "guardduty:UpdateDetector"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/component"
+      values   = ["secure-baselines"]
+    }
+
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/ModernisationPlatformAccess",
+        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
+      ]
+    }
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:PrincipalAccount"
+      values = flatten([
+        local.modernisation_platform_accounts.testing_test
+      ])
+    }
+  }
+
+  # Prevent removal or replacement of the tag used to identify protected resources
+  statement {
+    sid    = "DenyChangingSecureBaselinesComponentTag"
+    effect = "Deny"
+    actions = [
+      "config:TagResource",
+      "config:UntagResource",
+      "guardduty:TagResource",
+      "guardduty:UntagResource"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/component"
+      values   = ["secure-baselines"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "aws:TagKeys"
+      values   = ["component"]
+    }
+
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/ModernisationPlatformAccess",
+        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
+      ]
+    }
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:PrincipalAccount"
+      values = flatten([
+        local.modernisation_platform_accounts.testing_test
+      ])
+    }
+  }
 }
 
 resource "aws_organizations_policy" "mp_protect_secure_baselines" {
   name        = "Modernisation Platform Protect Secure Baselines"
-  description = "Deny deletion or disabling of secure-baselines tagged resources in Modernisation Platform accounts, except AWSReservedSSO_AdministratorAccess roles."
+  description = "Deny destructive changes to secure-baselines tagged resources and restrict configuration or tag modifications to trusted platform automation and AWSReservedSSO_AdministratorAccess roles."
   type        = "SERVICE_CONTROL_POLICY"
 
   tags = {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

Implement additional SCP protections for critical security and logging services in Modernisation Platform accounts.

This addresses [[modernisation-platform-security#116](https://github.com/ministryofjustice/modernisation-platform-security/issues/116)](https://github.com/ministryofjustice/modernisation-platform-security/issues/116).

## ♻️ What's changed

- Prevents untrusted principals from modifying AWS Config configuration recorders.
- Prevents untrusted principals from modifying or disabling GuardDuty detectors.
- Prevents the `component=secure-baselines` tag from being replaced or removed from protected AWS Config and GuardDuty resources.
- Preserves access for trusted `ModernisationPlatformAccess` automation and AWS SSO Administrator roles.
- Retains the existing `testing-test` account exception.
- Updates the SCP statement name and description to reflect the expanded protection.

No new AWS resources are created. The existing Modernisation Platform secure-baselines SCP is updated.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

The policy remains attached to the Modernisation Platform OU.

Validation completed:

- `terraform fmt -check`
- `git diff --check`
- `terraform validate -no-color`

The change should be validated in the `testing-test` account before removing the existing test-account exception or proceeding with broader enforcement.
