### PR TITLE
Remove `modernisation-platform-logs-cloudtrail-logging` buckets from core S3 bucket protection SCP

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -188,9 +188,6 @@ locals {
     "arn:aws:s3:::modernisation-platform-logs-cloudtrail",
     "arn:aws:s3:::modernisation-platform-logs-cloudtrail-replication",
 
-    "arn:aws:s3:::modernisation-platform-logs-cloudtrail-logging",
-    "arn:aws:s3:::modernisation-platform-logs-cloudtrail-logging-replication",
-
     "arn:aws:s3:::modernisation-platform-logs-config",
     "arn:aws:s3:::modernisation-platform-logs-config-replication",
 


### PR DESCRIPTION
## Summary

Removes the following S3 bucket ARNs from the `mp_protect_core_s3_buckets` SCP:

- `arn:aws:s3:::modernisation-platform-logs-cloudtrail-logging`
- `arn:aws:s3:::modernisation-platform-logs-cloudtrail-logging-replication`

## Reason

S3 server access logging has been disabled for CloudTrail buckets, making these logging destination buckets redundant. As part of removing these buckets, they are no longer required in the core S3 protection SCP. 