### PR TITLE
Protect critical security services with Modernisation Platform SCPs Test

### DIFF
--- a/management-account/terraform/alerting-modernisation-platform-scp.tf
+++ b/management-account/terraform/alerting-modernisation-platform-scp.tf
@@ -37,7 +37,8 @@ resource "aws_cloudwatch_event_rule" "modernisation_platform_scp_change_alerts" 
           aws_organizations_policy.mp_deny_cloudtrail_delete_stop_update.id,
           aws_organizations_policy.mp_protect_core_s3_buckets.id,
           aws_organizations_policy.modernisation_platform_member_ou_scp.id,
-          aws_organizations_policy.mp_protect_secure_baselines.id
+          aws_organizations_policy.mp_protect_secure_baselines.id,
+          aws_organizations_policy.mp_protect_security_services_pilot.id
         ]
       }
     }

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -350,3 +350,93 @@ resource "aws_organizations_policy_attachment" "mp_protect_secure_baselines" {
   policy_id = aws_organizations_policy.mp_protect_secure_baselines.id
   target_id = aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id
 }
+
+###############################################################
+# Protect critical security services from modification
+# Sprinkler OU scope for testing
+###############################################################
+
+data "aws_iam_policy_document" "mp_protect_security_services_pilot" {
+  statement {
+    sid    = "DenyModificationOfSecureBaselinesResources"
+    effect = "Deny"
+    actions = [
+      "config:PutConfigurationRecorder",
+      "guardduty:UpdateDetector"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/component"
+      values   = ["secure-baselines"]
+    }
+
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/ModernisationPlatformAccess",
+        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
+      ]
+    }
+  }
+
+  statement {
+    sid    = "DenyChangingSecureBaselinesComponentTag"
+    effect = "Deny"
+    actions = [
+      "config:TagResource",
+      "config:UntagResource",
+      "guardduty:TagResource",
+      "guardduty:UntagResource"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/component"
+      values   = ["secure-baselines"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "aws:TagKeys"
+      values   = ["component"]
+    }
+
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/ModernisationPlatformAccess",
+        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "mp_protect_security_services_pilot" {
+  name        = "Modernisation Platform Protect Security Services Pilot"
+  description = "Pilot protection against modification of secure-baselines AWS Config and GuardDuty resources in the Sprinkler OU."
+  type        = "SERVICE_CONTROL_POLICY"
+
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-policy-service-control-modernisation-platform.tf"])
+  }
+
+  content = data.aws_iam_policy_document.mp_protect_security_services_pilot.json
+}
+
+# Attach the pilot SCP to the Sprinkler OU only for testing before wider MP OU enforcement
+resource "aws_organizations_policy_attachment" "mp_protect_security_services_pilot" {
+  for_each = toset([
+    for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children : child.id
+    if child.name == "modernisation-platform-sprinkler"
+  ])
+
+  policy_id = aws_organizations_policy.mp_protect_security_services_pilot.id
+  target_id = each.value
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

[ministryofjustice/modernisation-platform-security#116](https://github.com/ministryofjustice/modernisation-platform-security/issues/116)

This PR introduces a pilot Service Control Policy (SCP) to prevent untrusted principals from modifying critical AWS Config and GuardDuty resources managed by secure baselines.

Existing Modernisation Platform SCPs already protect critical services—including CloudTrail, Security Hub, AWS Config, GuardDuty, CloudWatch, EventBridge, KMS, CloudWatch Logs, S3, SNS, Backup and IAM Access Analyzer—from destructive actions such as deletion or disabling.

This PR addresses two modification paths not covered by those existing controls:

- `guardduty:UpdateDetector`, which can disable or weaken a GuardDuty detector.
- `config:PutConfigurationRecorder`, which can reduce or alter the resources recorded by AWS Config.

The objective is to apply these additional controls across the Modernisation Platform OU. As an initial step, this PR scopes the policy to `modernisation-platform-sprinkler` to test its behaviour and assess potential impact.

## ♻️ What's changed

- Introduced a temporary pilot SCP for critical security services.
- Created an IAM policy document that:
  - Prevents untrusted principals from modifying AWS Config configuration recorders.
  - Prevents untrusted principals from modifying or disabling GuardDuty detectors.
  - Prevents the `component=secure-baselines` tag from being replaced or removed from protected AWS Config and GuardDuty resources.
- Preserved access for the `ModernisationPlatformAccess` automation role and AWS SSO Administrator roles.
- Attached the pilot SCP only to the `modernisation-platform-sprinkler` OU.
- Added the pilot SCP to the existing Modernisation Platform SCP-change alerting.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

This is an incremental addition to the existing Modernisation Platform security SCPs, rather than a replacement for the current protections.

After the controls have been validated in Sprinkler, a follow-up PR will:

- Remove the temporary pilot SCP.
- Incorporate the validated statements into the existing Modernisation Platform secure-baselines SCP.
- Extend enforcement to the wider Modernisation Platform OU.