### PR TITLE
Add S3 KMS/AES256 encryption enforcement SCP (sprinkler OU trial)

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -494,11 +494,14 @@ data "aws_iam_policy_document" "enforce_s3_kms_encryption" {
 }
 
 # Scoped to sprinkler sub-OU only for testing.
+# "modernisation-platform-sprinkler" is nested under "Modernisation Platform
+# Member", not a direct child of the Modernisation Platform OU, so this must
+# use mp_member_children (not platforms_and_architecture_modernisation_platform_children).
 # Do NOT attach to the parent Modernisation Platform OU — SCP inheritance would
 # block Terraform state s3:PutObject calls in all other member accounts.
 resource "aws_organizations_policy_attachment" "enforce_s3_kms_encryption_pilot" {
   for_each = toset([
-    for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children : child.id
+    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
     if child.name == "modernisation-platform-sprinkler"
   ])
 

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -437,3 +437,71 @@ resource "aws_organizations_policy_attachment" "mp_protect_security_services_pil
   policy_id = aws_organizations_policy.mp_protect_security_services_pilot.id
   target_id = each.value
 }
+
+##############################
+# Enforce S3 KMS encryption  #
+##############################
+
+# Enforces KMS-based encryption for S3 object writes and explicitly blocks
+# setting bucket default encryption to SSE-S3 (AES256).
+#
+# The PutObject deny below blocks explicit SSE-S3 (AES256) writes while
+# allowing requests that omit the encryption header and rely on bucket
+# default encryption. Bucket-level downgrade/removal is still denied below.
+
+resource "aws_organizations_policy" "enforce_s3_kms_encryption" {
+  name        = "Enforce S3 KMS encryption"
+  description = "Denies explicit SSE-S3 object writes and setting bucket default encryption to SSE-S3"
+  type        = "SERVICE_CONTROL_POLICY"
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-policy-service-control-modernisation-platform.tf"])
+  }
+
+  content = data.aws_iam_policy_document.enforce_s3_kms_encryption.json
+}
+
+data "aws_iam_policy_document" "enforce_s3_kms_encryption" {
+  # Deny only explicit SSE-S3 object writes. Requests with no SSE header are
+  # allowed so that bucket default KMS encryption can apply.
+  statement {
+    sid       = "DenyS3PutObjectSSES3"
+    effect    = "Deny"
+    actions   = ["s3:PutObject"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = ["AES256"]
+    }
+  }
+
+  # Deny setting bucket default encryption to SSE-S3.
+  statement {
+    sid       = "DenyS3SetBucketDefaultEncryptionToSSES3"
+    effect    = "Deny"
+    actions   = ["s3:PutEncryptionConfiguration"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = ["AES256"]
+    }
+  }
+}
+
+# Scoped to sprinkler sub-OU only for testing.
+# Do NOT attach to the parent Modernisation Platform OU — SCP inheritance would
+# block Terraform state s3:PutObject calls in all other member accounts.
+resource "aws_organizations_policy_attachment" "enforce_s3_kms_encryption_pilot" {
+  for_each = toset([
+    for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children : child.id
+    if child.name == "modernisation-platform-sprinkler"
+  ])
+
+  policy_id = aws_organizations_policy.enforce_s3_kms_encryption.id
+  target_id = each.value
+}


### PR DESCRIPTION
## Summary
Adds a new Service Control Policy, `enforce_s3_kms_encryption`, to enforce S3 encryption standards.

## What the new SCP does
- Denies `s3:PutObject` requests that explicitly set `x-amz-server-side-encryption: AES256` (blocks explicit SSE-S3 writes; requests omitting the header are still allowed so bucket default KMS encryption can apply).
- Denies `s3:PutEncryptionConfiguration` calls that set bucket default encryption to `AES256`.

## Scope
Attached only to the `modernisation-platform-sprinkler` sub-OU as a trial, **not** the parent Modernisation Platform OU, to avoid unintended blast radius (e.g. Terraform state `PutObject` calls in other member accounts).

## Testing
Validated behaviour via local IAM policy equivalents and a CLI test script prior to opening this PR.