### PR TITLE
Fix Sprinkler pilot SCP attachment

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -430,7 +430,7 @@ resource "aws_organizations_policy" "mp_protect_security_services_pilot" {
 # Attach the pilot SCP to the Sprinkler OU only for testing before wider MP OU enforcement
 resource "aws_organizations_policy_attachment" "mp_protect_security_services_pilot" {
   for_each = toset([
-    for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children : child.id
+    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
     if child.name == "modernisation-platform-sprinkler"
   ])
 


### PR DESCRIPTION
## 👀 Purpose

The pilot SCP created in PR #1576 was intended to apply to the `modernisation-platform-sprinkler` OU. However, the attachment logic searched the direct children of the `Modernisation Platform` OU, while Sprinkler is a child of the `Modernisation Platform Member` OU. Consequently, the pilot SCP was created but not attached to Sprinkler.

## ♻️ What's changed

Updated the pilot SCP attachment to search the existing `mp_member_children` data source for the `modernisation-platform-sprinkler` OU.

This ensures the `Modernisation Platform Protect Security Services Pilot` SCP is attached to the correct OU and inherited by the `sprinkler-development` account.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes