### PR TITLE
Remove LAA Production

### DIFF
--- a/management-account/terraform/budgets.tf
+++ b/management-account/terraform/budgets.tf
@@ -95,7 +95,6 @@ resource "aws_budgets_budget" "laa" {
     values = [
       aws_organizations_account.laa_cloudtrail.id,
       aws_organizations_account.laa_development.id,
-      aws_organizations_account.laa_production.id,
       aws_organizations_account.laa_shared_services.id,
       aws_organizations_account.laa_staging.id,
       aws_organizations_account.laa_test.id,

--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -35,12 +35,12 @@ locals {
     active_only : {
       for account in aws_organizations_organization.default.accounts :
       account.name => account.id
-      if account.status == "ACTIVE"
+      if account.status == "ACTIVE" && account.name != "LAA Production"
     },
     active_only_account_ids : [
       for account in aws_organizations_organization.default.accounts :
       account.id
-      if account.status == "ACTIVE"
+      if account.status == "ACTIVE" && account.name != "LAA Production"
     ],
   }
 

--- a/management-account/terraform/organizations-accounts-laa.tf
+++ b/management-account/terraform/organizations-accounts-laa.tf
@@ -40,25 +40,6 @@ resource "aws_organizations_account" "laa_development" {
   }
 }
 
-resource "aws_organizations_account" "laa_production" {
-  name                       = "LAA Production"
-  email                      = replace(local.aws_account_email_addresses_template, "{email}", "LAA+Production")
-  iam_user_access_to_billing = "ALLOW"
-  parent_id                  = aws_organizations_organizational_unit.disabled_accounts.id
-  close_on_deletion          = true
-
-  tags = local.tags_laa
-
-  lifecycle {
-    ignore_changes = [
-      email,
-      iam_user_access_to_billing,
-      name,
-      role_name,
-    ]
-  }
-}
-
 resource "aws_organizations_account" "laa_shared_services" {
   name                       = "LAA Shared services"
   email                      = replace(local.aws_account_email_addresses_template, "{email}", "LAA+Shared+services")

--- a/management-account/terraform/organizations-policy-service-control.tf
+++ b/management-account/terraform/organizations-policy-service-control.tf
@@ -460,9 +460,3 @@ data "aws_iam_policy_document" "deny_all_actions_by_users" {
     }
   }
 }
-
-# Attach policy to laa production
-resource "aws_organizations_policy_attachment" "deny_all_actions_by_users" {
-  policy_id = aws_organizations_policy.deny_all_actions_by_users.id
-  target_id = aws_organizations_account.laa_production.id
-}

--- a/management-account/terraform/sso-admin-account-assignments.tf
+++ b/management-account/terraform/sso-admin-account-assignments.tf
@@ -479,20 +479,6 @@ locals {
       ]
     },
     {
-      github_team        = "laa-lz-read-only",
-      permission_set_arn = aws_ssoadmin_permission_set.laa_read_only.arn,
-      account_ids = [
-        aws_organizations_account.laa_production.id
-      ]
-    },
-    {
-      github_team        = "laa-lz-admin",
-      permission_set_arn = aws_ssoadmin_permission_set.administrator_access.arn,
-      account_ids = [
-        aws_organizations_account.laa_production.id
-      ]
-    },
-    {
       github_team        = "modernisation-platform",
       permission_set_arn = aws_ssoadmin_permission_set.security_audit.arn,
       account_ids = [
@@ -532,13 +518,6 @@ locals {
       permission_set_arn = aws_ssoadmin_permission_set.aws_sso_admin.arn,
       account_ids = [
         aws_organizations_organization.default.master_account_id
-      ]
-    },
-    {
-      github_team        = "azure-aws-sso-laa-readers",
-      permission_set_arn = aws_ssoadmin_permission_set.laa_lz_s3_read_access.arn,
-      account_ids = [
-        aws_organizations_account.laa_production.id,
       ]
     },
     {

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -1035,7 +1035,7 @@ data "aws_iam_policy_document" "laa_lz_s3_read_access" {
       "kms:DescribeKey"
     ]
     resources = [
-      "arn:aws:kms:eu-west-2:${aws_organizations_account.laa_production.id}:alias/s3"
+      "arn:aws:kms:eu-west-2:*:alias/s3"
     ]
   }
 }
@@ -1106,7 +1106,7 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
     actions = [
       "iam:PassRole"
     ]
-    resources = ["arn:aws:iam::${aws_organizations_account.laa_production.id}:role/service-role/AWSBackupDefaultServiceRole"]
+    resources = ["arn:aws:iam::*:role/service-role/AWSBackupDefaultServiceRole"]
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"
@@ -1120,7 +1120,7 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
       "rds:DeleteDBSnapshot"
     ]
     resources = [
-      "arn:aws:rds:eu-west-2:${aws_organizations_account.laa_production.id}:snapshot:lz-prod-rds-*-final-backup"
+      "arn:aws:rds:eu-west-2:*:snapshot:lz-prod-rds-*-final-backup"
     ]
   }
   statement {
@@ -1130,7 +1130,7 @@ data "aws_iam_policy_document" "laa_read_only_additional" {
       "backup:PutBackupVaultAccessPolicy"
     ]
     resources = [
-      "arn:aws:backup:eu-west-2:${aws_organizations_account.laa_production.id}:backup-vault:Default"
+      "arn:aws:backup:eu-west-2:*:backup-vault:Default"
     ]
   }
   statement {


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

## 👀 Purpose

This account has now been migrated to the ECP organisation.

## ♻️ What's changed

Removed LAA Production from code.

Policies and permission sets left for the moment in case they are used elsewhere or needed for the remaining LAA accounts.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

Further work should be done to remove the policies and permission sets relating to LAA LZ accounts once all the accounts have been closed.
