### PR TITLE
Scp/modernisation platform s3 scp

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -494,11 +494,14 @@ data "aws_iam_policy_document" "enforce_s3_kms_encryption" {
 }
 
 # Scoped to sprinkler sub-OU only for testing.
+# "modernisation-platform-sprinkler" is nested under "Modernisation Platform
+# Member", not a direct child of the Modernisation Platform OU, so this must
+# use mp_member_children (not platforms_and_architecture_modernisation_platform_children).
 # Do NOT attach to the parent Modernisation Platform OU — SCP inheritance would
 # block Terraform state s3:PutObject calls in all other member accounts.
 resource "aws_organizations_policy_attachment" "enforce_s3_kms_encryption_pilot" {
   for_each = toset([
-    for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children : child.id
+    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
     if child.name == "modernisation-platform-sprinkler"
   ])
 

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -437,3 +437,71 @@ resource "aws_organizations_policy_attachment" "mp_protect_security_services_pil
   policy_id = aws_organizations_policy.mp_protect_security_services_pilot.id
   target_id = each.value
 }
+
+##############################
+# Enforce S3 KMS encryption  #
+##############################
+
+# Enforces KMS-based encryption for S3 object writes and explicitly blocks
+# setting bucket default encryption to SSE-S3 (AES256).
+#
+# The PutObject deny below blocks explicit SSE-S3 (AES256) writes while
+# allowing requests that omit the encryption header and rely on bucket
+# default encryption. Bucket-level downgrade/removal is still denied below.
+
+resource "aws_organizations_policy" "enforce_s3_kms_encryption" {
+  name        = "Enforce S3 KMS encryption"
+  description = "Denies explicit SSE-S3 object writes and setting bucket default encryption to SSE-S3"
+  type        = "SERVICE_CONTROL_POLICY"
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-policy-service-control-modernisation-platform.tf"])
+  }
+
+  content = data.aws_iam_policy_document.enforce_s3_kms_encryption.json
+}
+
+data "aws_iam_policy_document" "enforce_s3_kms_encryption" {
+  # Deny only explicit SSE-S3 object writes. Requests with no SSE header are
+  # allowed so that bucket default KMS encryption can apply.
+  statement {
+    sid       = "DenyS3PutObjectSSES3"
+    effect    = "Deny"
+    actions   = ["s3:PutObject"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = ["AES256"]
+    }
+  }
+
+  # Deny setting bucket default encryption to SSE-S3.
+  statement {
+    sid       = "DenyS3SetBucketDefaultEncryptionToSSES3"
+    effect    = "Deny"
+    actions   = ["s3:PutEncryptionConfiguration"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = ["AES256"]
+    }
+  }
+}
+
+# Scoped to sprinkler sub-OU only for testing.
+# Do NOT attach to the parent Modernisation Platform OU — SCP inheritance would
+# block Terraform state s3:PutObject calls in all other member accounts.
+resource "aws_organizations_policy_attachment" "enforce_s3_kms_encryption_pilot" {
+  for_each = toset([
+    for child in data.aws_organizations_organizational_units.platforms_and_architecture_modernisation_platform_children.children : child.id
+    if child.name == "modernisation-platform-sprinkler"
+  ])
+
+  policy_id = aws_organizations_policy.enforce_s3_kms_encryption.id
+  target_id = each.value
+}

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -463,21 +463,6 @@ resource "aws_organizations_policy" "enforce_s3_kms_encryption" {
 }
 
 data "aws_iam_policy_document" "enforce_s3_kms_encryption" {
-  # Deny only explicit SSE-S3 object writes. Requests with no SSE header are
-  # allowed so that bucket default KMS encryption can apply.
-  statement {
-    sid       = "DenyS3PutObjectSSES3"
-    effect    = "Deny"
-    actions   = ["s3:PutObject"]
-    resources = ["*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "s3:x-amz-server-side-encryption"
-      values   = ["AES256"]
-    }
-  }
-
   # Deny setting bucket default encryption to SSE-S3.
   statement {
     sid       = "DenyS3SetBucketDefaultEncryptionToSSES3"

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -442,8 +442,8 @@ resource "aws_organizations_policy_attachment" "mp_protect_security_services_pil
 # Enforce S3 KMS encryption  #
 ##############################
 
-# Enforces KMS-based encryption for S3 object writes and explicitly blocks
-# setting bucket default encryption to SSE-S3 (AES256).
+# Denies attempts to set bucket default encryption to SSE-S3 (AES256).
+# This is a low blast-radius pilot scoped via the attachment below.
 #
 # The PutObject deny below blocks explicit SSE-S3 (AES256) writes while
 # allowing requests that omit the encryption header and rely on bucket


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

As a modernisation platform engineer
I need to increase security on s3 buckets
So that user can downgrade the security of S3

## ♻️ What's changed

We need a production-safe first step to tighten S3 encryption controls using SCPs, aligned with ADR 0043-enforce-s3-kms-encryption-with-scp-guardrails.

During earlier testing and rollout attempts, broad SCP attachment created unintended impact across the Modernisation Platform OU. We therefore want a low blast-radius control that is targeted, testable, and reversible.

Key findings from testing and AWS behaviour:

Since Nov 2023, S3 applies default encryption to all buckets.
Calling DeleteBucketEncryption does not create an unencrypted bucket; it reverts to SSE-S3 (AES256).
The relevant IAM action for bucket default encryption updates is s3:PutEncryptionConfiguration.
s3:PutBucketEncryption and s3:DeleteBucketEncryption are not valid IAM action names for policy statements.
A deny on s3:PutEncryptionConfiguration does not by itself block unrelated actions like s3:ListBucket or s3:PutObject (unless those are separately denied).
For this issue, the intended first control is:

Deny s3:PutEncryptionConfiguration when the request attempts to set bucket default encryption to AES256.
## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [ x ] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
