### PR TITLE
✨ Let member accounts manage Transfer Web App access

### DIFF
--- a/management-account/terraform/guardduty.tf
+++ b/management-account/terraform/guardduty.tf
@@ -292,7 +292,7 @@ module "guardduty_eu_north_1" {
   root_tags = local.root_account
   administrator_tags = merge(
     local.tags_organisation_management, {
-      component = "Security"
+      component    = "Security"
       service-area = "Hosting"
   })
 }
@@ -311,7 +311,7 @@ module "guardduty_sa_east_1" {
   root_tags = local.root_account
   administrator_tags = merge(
     local.tags_organisation_management, {
-      component = "Security"
+      component    = "Security"
       service-area = "Hosting"
   })
 }

--- a/management-account/terraform/iam-policies.tf
+++ b/management-account/terraform/iam-policies.tf
@@ -152,6 +152,38 @@ data "aws_iam_policy_document" "sso_administrator_policy" {
   }
 }
 
+####################################################
+# ModernisationPlatformSSOApplicationAssignment    #
+####################################################
+resource "aws_iam_policy" "modernisation_platform_sso_application_assignment" {
+  name        = "ModernisationPlatformSSOApplicationAssignment"
+  description = "A policy to allow Modernisation Platform accounts to manage their SSO application assignments"
+  path        = "/"
+  policy      = data.aws_iam_policy_document.modernisation_platform_sso_application_assignment_permissions.json
+  tags        = {}
+}
+
+data "aws_iam_policy_document" "modernisation_platform_sso_application_assignment_permissions" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "sso:CreateApplicationAssignment",
+      "sso:DeleteApplicationAssignment",
+      "sso:DescribeApplicationAssignment"
+    ]
+    #tfsec:ignore:aws-iam-no-policy-wildcards
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      values   = ["&{aws:PrincipalTag/ApplicationAccount}"]
+      variable = "sso:ApplicationAccount"
+    }
+  }
+}
+
 #########################################
 # TerraformOrganisationManagementPolicy #
 #########################################

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -204,6 +204,89 @@ resource "aws_iam_role_policy_attachment" "modernisation_platform_ssodirectory_r
   policy_arn = aws_iam_policy.modernisation_platform_sso_readonly_additional.arn
 }
 
+########################################################
+# ModernisationPlatformSSOApplicationAssignment        #
+########################################################
+/*
+provider "aws" {
+  alias = "sso-application-assignment"
+
+  assume_role {
+    role_arn = "arn:aws:iam::<management-account-id>:role/ModernisationPlatformSSOApplicationAssignment"
+    tags = {
+      ApplicationAccount = data.aws_caller_identity.original_session.account_id
+    }
+  }
+}
+*/
+resource "aws_iam_role" "modernisation_platform_sso_application_assignment" {
+  name               = "ModernisationPlatformSSOApplicationAssignment"
+  assume_role_policy = data.aws_iam_policy_document.modernisation_platform_sso_application_assignment.json
+}
+
+data "aws_iam_policy_document" "modernisation_platform_sso_application_assignment" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      values   = ["${data.aws_organizations_organization.root.id}/*/${aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id}/*"]
+      variable = "aws:PrincipalOrgPaths"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["&{aws:PrincipalAccount}"]
+      variable = "aws:RequestTag/ApplicationAccount"
+    }
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      values   = ["ApplicationAccount"]
+      variable = "aws:TagKeys"
+    }
+  }
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:TagSession"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      values   = ["${data.aws_organizations_organization.root.id}/*/${aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id}/*"]
+      variable = "aws:PrincipalOrgPaths"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = ["&{aws:PrincipalAccount}"]
+      variable = "aws:RequestTag/ApplicationAccount"
+    }
+
+    condition {
+      test     = "ForAllValues:StringEquals"
+      values   = ["ApplicationAccount"]
+      variable = "aws:TagKeys"
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "modernisation_platform_sso_application_assignment" {
+  role       = aws_iam_role.modernisation_platform_sso_application_assignment.name
+  policy_arn = aws_iam_policy.modernisation_platform_sso_application_assignment.arn
+}
+
 ##########################################
 # ModernisationPlatformGithubActionsRole #
 ##########################################

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -242,6 +242,12 @@ data "aws_iam_policy_document" "modernisation_platform_sso_application_assignmen
 
     condition {
       test     = "StringEquals"
+      values   = [local.modernisation_platform_accounts.integration_hub_file_transfer_development_id]
+      variable = "aws:PrincipalAccount"
+    }
+
+    condition {
+      test     = "StringEquals"
       values   = ["&{aws:PrincipalAccount}"]
       variable = "aws:RequestTag/ApplicationAccount"
     }
@@ -266,6 +272,12 @@ data "aws_iam_policy_document" "modernisation_platform_sso_application_assignmen
       test     = "ForAnyValue:StringLike"
       values   = ["${data.aws_organizations_organization.root.id}/*/${aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id}/*"]
       variable = "aws:PrincipalOrgPaths"
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = [local.modernisation_platform_accounts.integration_hub_file_transfer_development_id]
+      variable = "aws:PrincipalAccount"
     }
 
     condition {

--- a/management-account/terraform/iam-roles.tf
+++ b/management-account/terraform/iam-roles.tf
@@ -207,18 +207,18 @@ resource "aws_iam_role_policy_attachment" "modernisation_platform_ssodirectory_r
 ########################################################
 # ModernisationPlatformSSOApplicationAssignment        #
 ########################################################
-/*
-provider "aws" {
-  alias = "sso-application-assignment"
 
-  assume_role {
-    role_arn = "arn:aws:iam::<management-account-id>:role/ModernisationPlatformSSOApplicationAssignment"
-    tags = {
-      ApplicationAccount = data.aws_caller_identity.original_session.account_id
-    }
-  }
-}
-*/
+# provider "aws" {
+#   alias = "sso-application-assignment"
+#
+#   assume_role {
+#     role_arn = "arn:aws:iam::<management-account-id>:role/ModernisationPlatformSSOApplicationAssignment"
+#     tags = {
+#       ApplicationAccount = data.aws_caller_identity.original_session.account_id
+#     }
+#   }
+# }
+
 resource "aws_iam_role" "modernisation_platform_sso_application_assignment" {
   name               = "ModernisationPlatformSSOApplicationAssignment"
   assume_role_policy = data.aws_iam_policy_document.modernisation_platform_sso_application_assignment.json

--- a/management-account/terraform/locals.tf
+++ b/management-account/terraform/locals.tf
@@ -46,6 +46,7 @@ locals {
 
   # Modernisation Platform account IDs
   modernisation_platform_accounts = {
+    integration_hub_file_transfer_development_id = local.accounts.active_only["integration-hub-file-transfer-development"]
     core_logging_id = [
       for account_name, account_id in local.accounts.active_only :
       account_id


### PR DESCRIPTION
:copilot: _This pull request body was generated by GitHub Copilot_

## 👀 Purpose

In order to provision AWS Transfer Family Web Apps in Modernisation Platform member accounts, a programmatic way to manage group memberships is required. 📁

The first example is `integration-hub-file-transfer`, introduced in [modernisation-platform-environments#17944](https://github.com/ministryofjustice/modernisation-platform-environments/pull/17944). Assigning IAM Identity Center groups to these applications by hand would leave a manual production step that becomes harder to manage with every new web app. This PR creates the possibility for a safe Terraform route instead. 🧑‍💻

## ♻️ What's changed

- Adds the `ModernisationPlatformSSOApplicationAssignment` role for Modernisation Platform member accounts.
- Grants only the create, describe and delete application-assignment actions needed to add or remove Identity Center groups.
- Restricts each session to applications associated with the calling member account, so one account cannot change another account's assignments. 🔐
- Requires an `ApplicationAccount` session tag that must match the caller's AWS account ID.
- Includes a small provider example showing how the environments repository can populate that tag from its existing `original_session` caller identity.

Once consumed by an environment, teams can manage who can reach their Transfer Family Web App in Terraform, alongside the S3 Access Grants that give those groups the right file access. No more clickops. ✨

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

A follow-up change in `modernisation-platform-environments` will add the aliased provider and allow its GitHub Actions roles to call `sts:AssumeRole` and `sts:TagSession` on this role.

Locally checked with `terraform fmt -check`, `git diff --check` and editor diagnostics. `terraform validate` was not run because this checkout is not initialised; CI can perform the repository's full checks without using local AWS credentials. 🧪

Signed-off-by: dms1981 <10881569+dms1981@users.noreply.github.com>