### PR TITLE
Add permissions to be able to launch cloudshell and run AWS CLI commands

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -912,6 +912,8 @@ data "aws_iam_policy_document" "network_automation_support_operator" {
       "cloudshell:GetEnvironmentStatus",
       "cloudshell:DescribeEnvironments",
       "cloudshell:DeleteEnvironment",
+      "cloudshell:CreateEnvironment",
+      "cloudshell:PutCredentials",
 
       "secretsmanager:CreateSecret",
       "secretsmanager:GetSecretValue",


### PR DESCRIPTION
Add permissions to be able to launch cloudshell and run AWS CLI commands for network_automation_support_operator role

<!-- markdownlint-disable MD041 -->

## 👀 Purpose

The cloudshell permissions were missing some permissions sets. createenvironments is required to be able to start a cloudshell session

## ♻️ What's changed

No functional changes. Just minor permissions fix.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
