### PR TITLE
SP-3982 -  add fsbp config 1 suppression for inactive regions in OPG #minor

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -126,7 +126,7 @@ resource "aws_securityhub_automation_rule" "suppress_mp_tf_state_bucket_cross_ac
   count = (
     var.is_delegated_administrator &&
     data.aws_region.current.region == "eu-west-2"
-    ) ? 1 : 0
+  ) ? 1 : 0
 
   rule_name   = "suppress-mp-tf-state-bucket-s3-6"
   rule_order  = 1
@@ -165,6 +165,72 @@ resource "aws_securityhub_automation_rule" "suppress_mp_tf_state_bucket_cross_ac
 
       note {
         text       = "Approved exception: Terraform backend requires controlled cross-account access."
+        updated_by = "terraform"
+      }
+    }
+  }
+}
+
+############################################
+# OPG Config.1 inactive-region suppression #
+############################################
+
+# Member accounts can't own automation rules
+# Supress Config.1 findings in non-active regions for OPG accounts and only create in home region
+resource "aws_securityhub_automation_rule" "suppress_opg_config_1_inactive_regions" {
+  count = (
+    var.is_delegated_administrator &&
+    data.aws_region.current.region == "eu-west-2" &&
+    length(var.opg_config_1_suppress_account_ids) > 0
+  ) ? 1 : 0
+
+  rule_name   = "suppress-opg-config-1-inactive-regions"
+  rule_order  = 1
+  description = "Suppress Config.1 findings in non-active regions."
+
+  criteria {
+    product_name {
+      comparison = "EQUALS"
+      value      = "Security Hub"
+    }
+
+    generator_id {
+      comparison = "CONTAINS"
+      value      = "Config.1"
+    }
+
+    workflow_status {
+      comparison = "EQUALS"
+      value      = "NEW"
+    }
+
+    dynamic "resource_region" {
+      for_each = ["eu-west-1", "eu-west-2", "us-east-1"]
+      content {
+        comparison = "NOT_EQUALS"
+        value      = resource_region.value
+      }
+    }
+
+    dynamic "aws_account_id" {
+      for_each = var.opg_config_1_suppress_account_ids
+      content {
+        comparison = "EQUALS"
+        value      = aws_account_id.value
+      }
+    }
+  }
+
+  actions {
+    type = "FINDING_FIELDS_UPDATE"
+
+    finding_fields_update {
+      workflow {
+        status = "SUPPRESSED"
+      }
+
+      note {
+        text       = "Suppressed: not an active region for this account."
         updated_by = "terraform"
       }
     }

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -212,8 +212,9 @@ resource "aws_securityhub_automation_rule" "suppress_opg_config_1_inactive_regio
       }
     }
 
+    # TODO: restore var.opg_config_1_suppress_account_ids once testing is complete
     dynamic "aws_account_id" {
-      for_each = var.opg_config_1_suppress_account_ids
+      for_each = ["288342028542", "492687888235"]
       content {
         comparison = "EQUALS"
         value      = aws_account_id.value

--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -176,7 +176,7 @@ resource "aws_securityhub_automation_rule" "suppress_mp_tf_state_bucket_cross_ac
 ############################################
 
 # Member accounts can't own automation rules
-# Supress Config.1 findings in non-active regions for OPG accounts and only create in home region
+# Suppress Config.1 findings in non-active regions for OPG accounts and only create in home region
 resource "aws_securityhub_automation_rule" "suppress_opg_config_1_inactive_regions" {
   count = (
     var.is_delegated_administrator &&
@@ -185,7 +185,7 @@ resource "aws_securityhub_automation_rule" "suppress_opg_config_1_inactive_regio
   ) ? 1 : 0
 
   rule_name   = "suppress-opg-config-1-inactive-regions"
-  rule_order  = 1
+  rule_order  = 2
   description = "Suppress Config.1 findings in non-active regions."
 
   criteria {
@@ -194,8 +194,8 @@ resource "aws_securityhub_automation_rule" "suppress_opg_config_1_inactive_regio
       value      = "Security Hub"
     }
 
-    generator_id {
-      comparison = "CONTAINS"
+    compliance_security_control_id {
+      comparison = "EQUALS"
       value      = "Config.1"
     }
 

--- a/modules/securityhub/variables.tf
+++ b/modules/securityhub/variables.tf
@@ -17,3 +17,9 @@ variable "enrolled_accounts" {
   type    = map(any)
   default = {}
 }
+
+variable "opg_config_1_suppress_account_ids" {
+  description = "OPG account IDs for which Config.1 findings are suppressed outside the active regions."
+  type        = list(string)
+  default     = []
+}

--- a/organisation-security/terraform/data.tf
+++ b/organisation-security/terraform/data.tf
@@ -24,6 +24,10 @@ data "aws_organizations_organizational_units" "opg" {
   parent_id = local.ou_opg
 }
 
+data "aws_organizations_organizational_unit_descendant_accounts" "opg" {
+  parent_id = local.ou_opg
+}
+
 data "terraform_remote_state" "management_account" {
   backend = "s3"
   config = {

--- a/organisation-security/terraform/securityhub.tf
+++ b/organisation-security/terraform/securityhub.tf
@@ -10,6 +10,8 @@ module "securityhub_eu_west_2" {
   aggregation_region = true
 
   is_delegated_administrator = true
+
+  opg_config_1_suppress_account_ids = data.aws_organizations_organizational_unit_descendant_accounts.opg.accounts[*].id
 }
 
 module "securityhub_eu_west_1" {


### PR DESCRIPTION

<!-- markdownlint-disable MD041 -->

## 👀 Purpose

OPG accounts opted in to security hub have the root account as a delegated administrator and can't apply automation rules to themselves.

Each account has a critical fail on AWS Foundational Security Best Practices v1.0.0 > Config.1 for regions without AWS config enabled.
Regions that we don't use should be suppressed for this standard.

## ♻️ What's changed

Adding a new security hub automation rule resource. This is scoped to OPG accounts and regions.
The resource is not created outside of the home region (eu-west-2).

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [ x] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
