### PR TITLE
⬇️ Import Existing DSIT Foucs Export Module

### DIFF
--- a/management-account/terraform/dsit-integration.tf
+++ b/management-account/terraform/dsit-integration.tf
@@ -29,7 +29,7 @@ import {
 
 import {
   to = module.dsit_cost_integration.aws_iam_role.this
-  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/service-role/GDSCloudConsumption"
+  id = "GDSCloudConsumption"
 }
 
 import {
@@ -44,7 +44,7 @@ import {
 
 import {
   to = module.dsit_cost_integration.aws_s3_bucket.this
-  id = "arn:aws:s3:::gds-export-${data.aws_caller_identity.current.account_id}"
+  id = "gds-export-${data.aws_caller_identity.current.account_id}"
 }
 
 import {

--- a/management-account/terraform/dsit-integration.tf
+++ b/management-account/terraform/dsit-integration.tf
@@ -13,7 +13,7 @@ import {
 }
 
 import {
-  to = module.dsit_cost_integration.aws_bcmdataexports_export.focus["enabled"]
+  to = module.dsit_cost_integration.aws_bcmdataexports_export.focus
   id = "arn:aws:bcm-data-exports:us-east-1:${data.aws_caller_identity.current.account_id}:export/gds-focus-v1-cf913b7e-c6bb-4576-aaeb-2a6f6335f3e4"
 }
 
@@ -23,7 +23,7 @@ import {
 }
 
 import {
-  to = module.dsit_cost_integration.aws_costoptimizationhub_enrollment_status.this
+  to = module.dsit_cost_integration.aws_costoptimizationhub_enrollment_status.this[0]
   id = data.aws_caller_identity.current.account_id
 }
 
@@ -38,7 +38,7 @@ import {
 }
 
 import {
-  to = module.dsit_cost_integration.aws_iam_service_linked_role.bcm_data_exports
+  to = module.dsit_cost_integration.aws_iam_service_linked_role.bcm_data_exports[0]
   id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/bcm-data-exports.amazonaws.com/AWSServiceRoleForBCMDataExports"
 }
 

--- a/management-account/terraform/dsit-integration.tf
+++ b/management-account/terraform/dsit-integration.tf
@@ -34,7 +34,7 @@ import {
 
 import {
   to = module.dsit_cost_integration.aws_iam_role_policy.replicator
-  id = "GDSCloudConsumption:Replicator"
+  id = "GDSCloudConsumption:Replication"
 }
 
 import {

--- a/management-account/terraform/dsit-integration.tf
+++ b/management-account/terraform/dsit-integration.tf
@@ -8,17 +8,17 @@ module "dsit_cost_integration" {
 }
 
 import {
-  to = module.dsit_cost_integration.aws_bcmdataexports_export.carbon
+  to = module.dsit_cost_integration.aws_bcmdataexports_export.carbon["enabled"]
   id = "arn:aws:bcm-data-exports:us-east-1:${data.aws_caller_identity.current.account_id}:export/gds-carbon-v1-1b9ff508-81c4-497b-aae5-b617a4aece39"
 }
 
 import {
-  to = module.dsit_cost_integration.aws_bcmdataexports_export.focus
+  to = module.dsit_cost_integration.aws_bcmdataexports_export.focus["enabled"]
   id = "arn:aws:bcm-data-exports:us-east-1:${data.aws_caller_identity.current.account_id}:export/gds-focus-v1-cf913b7e-c6bb-4576-aaeb-2a6f6335f3e4"
 }
 
 import {
-  to = module.dsit_cost_integration.aws_bcmdataexports_export.recommendations
+  to = module.dsit_cost_integration.aws_bcmdataexports_export.recommendations["enabled"]
   id = "arn:aws:bcm-data-exports:us-east-1:${data.aws_caller_identity.current.account_id}:export/gds-recommendations-v1-4d32ddca-c357-494d-944f-60b775b26e33"
 }
 

--- a/management-account/terraform/dsit-integration.tf
+++ b/management-account/terraform/dsit-integration.tf
@@ -1,107 +1,70 @@
 # Infrastructure to integrate cost reporting with DSIT central account: Data export, S3, and bucket replication
+module "dsit_cost_integration" {
+  source = "github.com/co-cddo/terraform-aws-focus?ref=949f1318da46d6e211b440a77b42c6a90205613b" # v2.0.2
 
-removed {
-  from = module.dsit_cost_integration.aws_bcmdataexports_export.carbon
-
-  lifecycle {
-    destroy = false
-  }
+  destination_account_id                          = "203341582084"
+  destination_bucket_name                         = "uk-gov-gds-cost-inbound"
+  create_cost_recommendations_service_linked_role = true
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_bcmdataexports_export.focus
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_bcmdataexports_export.carbon
+  id = "arn:aws:bcm-data-exports:us-east-1:${data.aws_caller_identity.current.account_id}:export/gds-carbon-v1-1b9ff508-81c4-497b-aae5-b617a4aece39"
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_bcmdataexports_export.recommendations
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_bcmdataexports_export.focus
+  id = "arn:aws:bcm-data-exports:us-east-1:${data.aws_caller_identity.current.account_id}:export/gds-focus-v1-cf913b7e-c6bb-4576-aaeb-2a6f6335f3e4"
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_costoptimizationhub_enrollment_status.this
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_bcmdataexports_export.recommendations
+  id = "arn:aws:bcm-data-exports:us-east-1:${data.aws_caller_identity.current.account_id}:export/gds-recommendations-v1-4d32ddca-c357-494d-944f-60b775b26e33"
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_iam_role.this
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_costoptimizationhub_enrollment_status.this
+  id = data.aws_caller_identity.current.account_id
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_iam_role_policy.replicator
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_iam_role.this
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/service-role/GDSCloudConsumption"
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_iam_service_linked_role.bcm_data_exports
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_iam_role_policy.replicator
+  id = "GDSCloudConsumption:Replicator"
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_s3_bucket.this
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_iam_service_linked_role.bcm_data_exports
+  id = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/bcm-data-exports.amazonaws.com/AWSServiceRoleForBCMDataExports"
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_s3_bucket_lifecycle_configuration.this
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_s3_bucket.this
+  id = "arn:aws:s3:::gds-export-${data.aws_caller_identity.current.account_id}"
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_s3_bucket_policy.this
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_s3_bucket_lifecycle_configuration.this
+  id = "gds-export-${data.aws_caller_identity.current.account_id}"
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_s3_bucket_replication_configuration.this
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_s3_bucket_policy.this
+  id = "gds-export-${data.aws_caller_identity.current.account_id}"
 }
 
-removed {
-  from = module.dsit_cost_integration.aws_s3_bucket_versioning.this
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_s3_bucket_replication_configuration.this
+  id = "gds-export-${data.aws_caller_identity.current.account_id}"
 }
 
-removed {
-  from = module.dsit_cost_integration.time_sleep.service_linked_role
-
-  lifecycle {
-    destroy = false
-  }
+import {
+  to = module.dsit_cost_integration.aws_s3_bucket_versioning.this
+  id = "gds-export-${data.aws_caller_identity.current.account_id}"
 }
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

- Relating to https://github.com/ministryofjustice/aws-root-account/pull/1452, https://github.com/ministryofjustice/aws-root-account/commit/d0331f004e37e049666668f847fb15b5a39b3702 and https://mojdt.slack.com/archives/C06P4KA0V0A/p1774883171768669?thread_ts=1774882254.918729&cid=C06P4KA0V0A
- This PR imports the DSIT Focus report export which had previouslt removed from terraform due to issues in the provider called by the module https://github.com/hashicorp/terraform-provider-aws/issues/46230.

## ♻️ What's changed

- All resources already exist, this PR just imports them so they are managed under terraform again.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

- NA
