### PR TITLE
Nd 2080 fix ecs permissions

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -855,6 +855,7 @@ data "aws_iam_policy_document" "network_automation_engineer" {
 # - AWS Cloudshell
 # - manage secrets
 # - S3 access
+# - ECS ExecuteCommand in dev and pre-prod accounts
 
 resource "aws_ssoadmin_permission_set" "network_automation_support_operator" {
   name             = "network-automation-support"
@@ -914,6 +915,7 @@ data "aws_iam_policy_document" "network_automation_support_operator" {
       "cloudshell:DeleteEnvironment",
       "cloudshell:CreateEnvironment",
       "cloudshell:PutCredentials",
+      "cloudshell:ApproveCommand",
 
       "secretsmanager:CreateSecret",
       "secretsmanager:GetSecretValue",
@@ -927,7 +929,24 @@ data "aws_iam_policy_document" "network_automation_support_operator" {
 
     resources = ["*"]
   }
+  statement {
+    sid    = "AllowECSRunTask"
+    effect = "Allow"
+
+    actions = [
+      "ecs:ExecuteCommand",
+      "ecs:DescribeTasks"
+    ]
+    resources = [        
+      "arn:aws:ecs:eu-west-2:${aws_organizations_account.moj_official_development.id}:cluster/*",
+      "arn:aws:ecs:eu-west-2:${aws_organizations_account.moj_official_development.id}:task/*/*",
+      "arn:aws:ecs:eu-west-2:${aws_organizations_account.moj_official_preproduction.id}:cluster/*",
+      "arn:aws:ecs:eu-west-2:${aws_organizations_account.moj_official_preproduction.id}:task/*/*"
+    ]
+  }
 }
+
+
 
 
 #########################################

--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -930,7 +930,7 @@ data "aws_iam_policy_document" "network_automation_support_operator" {
     resources = ["*"]
   }
   statement {
-    sid    = "AllowECSRunTask"
+    sid    = "AllowECSExecuteCommandInDevAndPreProd"
     effect = "Allow"
 
     actions = [


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

This adds some permssions to the network-automation-support role so that they are able to connect into running fargate containers.

## ♻️ What's changed

Added permissions 
      "ecs:ExecuteCommand",
      "ecs:DescribeTasks"

These permssions are scoped to none live environments so just development and pre-production accounts

Also added "cloudshell:ApproveCommand" so that the "Connect" button in the AWS console can launch cloudshell and run the ExecuteCommand.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
