### PR TITLE
Fix Config and GuardDuty Sprinkler pilot SCP enforcement

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -354,7 +354,6 @@ resource "aws_organizations_policy_attachment" "mp_protect_secure_baselines" {
 ###############################################################
 
 data "aws_iam_policy_document" "mp_protect_security_services_pilot" {
-  # These resources are not consistently tagged, so scope protection by OU and trusted principals.
   statement {
     sid    = "DenyChangesToSecurityServices"
     effect = "Deny"

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -354,53 +354,15 @@ resource "aws_organizations_policy_attachment" "mp_protect_secure_baselines" {
 ###############################################################
 
 data "aws_iam_policy_document" "mp_protect_security_services_pilot" {
+  # These resources are not consistently tagged, so scope protection by OU and trusted principals.
   statement {
-    sid    = "DenyModificationOfSecureBaselinesResources"
+    sid    = "DenyModificationOfSecurityServices"
     effect = "Deny"
     actions = [
       "config:PutConfigurationRecorder",
       "guardduty:UpdateDetector"
     ]
     resources = ["*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:ResourceTag/component"
-      values   = ["secure-baselines"]
-    }
-
-    condition {
-      test     = "ArnNotLike"
-      variable = "aws:PrincipalArn"
-      values = [
-        "arn:aws:iam::*:role/ModernisationPlatformAccess",
-        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
-      ]
-    }
-  }
-
-  statement {
-    sid    = "DenyChangingSecureBaselinesComponentTag"
-    effect = "Deny"
-    actions = [
-      "config:TagResource",
-      "config:UntagResource",
-      "guardduty:TagResource",
-      "guardduty:UntagResource"
-    ]
-    resources = ["*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:ResourceTag/component"
-      values   = ["secure-baselines"]
-    }
-
-    condition {
-      test     = "ForAnyValue:StringEquals"
-      variable = "aws:TagKeys"
-      values   = ["component"]
-    }
 
     condition {
       test     = "ArnNotLike"
@@ -415,7 +377,7 @@ data "aws_iam_policy_document" "mp_protect_security_services_pilot" {
 
 resource "aws_organizations_policy" "mp_protect_security_services_pilot" {
   name        = "Modernisation Platform Protect Security Services Pilot"
-  description = "Pilot protection against modification of secure-baselines AWS Config and GuardDuty resources in the Sprinkler OU."
+  description = "Pilot protection against modification of AWS Config and GuardDuty resources in the Sprinkler OU."
   type        = "SERVICE_CONTROL_POLICY"
 
   tags = {

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -355,7 +355,7 @@ resource "aws_organizations_policy_attachment" "mp_protect_secure_baselines" {
 
 data "aws_iam_policy_document" "mp_protect_security_services_pilot" {
   statement {
-    sid    = "DenyChangesToSecurityServices"
+    sid    = "DenyChangesToConfigAndGuardDuty"
     effect = "Deny"
     actions = [
       "config:Delete*",

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -356,10 +356,13 @@ resource "aws_organizations_policy_attachment" "mp_protect_secure_baselines" {
 data "aws_iam_policy_document" "mp_protect_security_services_pilot" {
   # These resources are not consistently tagged, so scope protection by OU and trusted principals.
   statement {
-    sid    = "DenyModificationOfSecurityServices"
+    sid    = "DenyChangesToSecurityServices"
     effect = "Deny"
     actions = [
+      "config:Delete*",
       "config:PutConfigurationRecorder",
+      "config:StopConfigurationRecorder",
+      "guardduty:Delete*",
       "guardduty:UpdateDetector"
     ]
     resources = ["*"]
@@ -377,7 +380,7 @@ data "aws_iam_policy_document" "mp_protect_security_services_pilot" {
 
 resource "aws_organizations_policy" "mp_protect_security_services_pilot" {
   name        = "Modernisation Platform Protect Security Services Pilot"
-  description = "Pilot protection against modification of AWS Config and GuardDuty resources in the Sprinkler OU."
+  description = "Pilot protection against modification, disabling, or deletion of AWS Config and GuardDuty resources in the Sprinkler OU."
   type        = "SERVICE_CONTROL_POLICY"
 
   tags = {

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -371,6 +371,7 @@ data "aws_iam_policy_document" "mp_protect_security_services_pilot" {
       variable = "aws:PrincipalArn"
       values = [
         "arn:aws:iam::*:role/ModernisationPlatformAccess",
+        "arn:aws:iam::*:role/github-actions",
         "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
       ]
     }

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -371,7 +371,6 @@ data "aws_iam_policy_document" "mp_protect_security_services_pilot" {
       variable = "aws:PrincipalArn"
       values = [
         "arn:aws:iam::*:role/ModernisationPlatformAccess",
-        "arn:aws:iam::*:role/github-actions",
         "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
       ]
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

[ministeryofjustice/modernisation-platform-security#116](https://github.com/ministryofjustice/modernisation-platform-security/issues/116)

This PR updates the Sprinkler pilot SCP following validation of the policy introduced in [PR #1576](https://github.com/ministryofjustice/aws-root-account/pull/1576).

Testing confirmed that the pilot SCP is correctly inherited by `sprinkler-development`. However, the GuardDuty detector and AWS Config recorder do not have the expected `component=secure-baselines` resource tag. Consequently, the tag conditions prevented the deny statements from applying to either resource.

This change corrects the pilot before testing its behaviour and progressing to wider Modernisation Platform enforcement.

## ♻️ What's changed

- Removed the `aws:ResourceTag/component = secure-baselines` condition from the pilot SCP.
- Removed the ineffective statement protecting the `component` tag.
- Updated the pilot to deny the following actions:
  - `config:Delete*`
  - `config:PutConfigurationRecorder`
  - `config:StopConfigurationRecorder`
  - `guardduty:Delete*`
  - `guardduty:UpdateDetector`

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes