### PR TITLE
Remove connor_glynn iam-users

### DIFF
--- a/management-account/terraform/iam-users.tf
+++ b/management-account/terraform/iam-users.tf
@@ -59,26 +59,6 @@ resource "aws_iam_user_group_membership" "ewa_stempel" {
   ]
 }
 
-################
-# Connor Glynn #
-################
-resource "aws_iam_user" "connor_glynn" {
-  name          = "ConnorGlynn"
-  path          = "/"
-  force_destroy = true
-  tags          = {}
-}
-
-# User membership
-resource "aws_iam_user_group_membership" "connor_glynn" {
-  user = aws_iam_user.connor_glynn.name
-
-  groups = [
-    aws_iam_group.iam_user_change_password.name,
-    aws_iam_group.modernisation_platform_organisation_management.name,
-  ]
-}
-
 ##############
 # Sablu Miah #
 ##############


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

Removes IAM user for `connor_glynn` as access is no longer required.

## ♻️ What's changed

Remove IAM user for `connor_glynn`

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.
