### PR TITLE
MP SCP protection for AWS Config and GuardDuty

### DIFF
--- a/management-account/terraform/alerting-modernisation-platform-scp.tf
+++ b/management-account/terraform/alerting-modernisation-platform-scp.tf
@@ -37,8 +37,8 @@ resource "aws_cloudwatch_event_rule" "modernisation_platform_scp_change_alerts" 
           aws_organizations_policy.mp_deny_cloudtrail_delete_stop_update.id,
           aws_organizations_policy.mp_protect_core_s3_buckets.id,
           aws_organizations_policy.modernisation_platform_member_ou_scp.id,
-          aws_organizations_policy.mp_protect_secure_baselines.id,
-          aws_organizations_policy.mp_protect_security_services_pilot.id
+          # This SCP also contains the tag-independent AWS Config and GuardDuty protections.
+          aws_organizations_policy.mp_protect_secure_baselines.id
         ]
       }
     }

--- a/management-account/terraform/alerting-modernisation-platform-scp.tf
+++ b/management-account/terraform/alerting-modernisation-platform-scp.tf
@@ -37,8 +37,7 @@ resource "aws_cloudwatch_event_rule" "modernisation_platform_scp_change_alerts" 
           aws_organizations_policy.mp_deny_cloudtrail_delete_stop_update.id,
           aws_organizations_policy.mp_protect_core_s3_buckets.id,
           aws_organizations_policy.modernisation_platform_member_ou_scp.id,
-          # This SCP also contains the tag-independent AWS Config and GuardDuty protections.
-          aws_organizations_policy.mp_protect_secure_baselines.id
+          aws_organizations_policy.mp_protect_secure_baselines.id # Includes Config/GuardDuty protections due to the OU SCP limit.
         ]
       }
     }

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -278,6 +278,29 @@ resource "aws_organizations_policy_attachment" "mp_protect_core_s3_buckets" {
 
 data "aws_iam_policy_document" "mp_protect_secure_baselines" {
   statement {
+    sid    = "DenyConfigRecorderAndGuardDutyDetectorChanges"
+    effect = "Deny"
+    actions = [
+      "config:Delete*",
+      "config:PutConfigurationRecorder",
+      "config:StopConfigurationRecorder",
+      "guardduty:Delete*",
+      "guardduty:UpdateDetector"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/ModernisationPlatformAccess",
+        "arn:aws:iam::*:role/github-actions",
+        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
+      ]
+    }
+  }
+
+  statement {
     sid    = "DenyDeleteSecureBaselinesResources"
     effect = "Deny"
     actions = [
@@ -321,29 +344,6 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
       values = flatten([
         local.modernisation_platform_accounts.testing_test
       ])
-    }
-  }
-
-  statement {
-    sid    = "DenyConfigRecorderAndGuardDutyDetectorChanges"
-    effect = "Deny"
-    actions = [
-      "config:Delete*",
-      "config:PutConfigurationRecorder",
-      "config:StopConfigurationRecorder",
-      "guardduty:Delete*",
-      "guardduty:UpdateDetector"
-    ]
-    resources = ["*"]
-
-    condition {
-      test     = "ArnNotLike"
-      variable = "aws:PrincipalArn"
-      values = [
-        "arn:aws:iam::*:role/ModernisationPlatformAccess",
-        "arn:aws:iam::*:role/github-actions",
-        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
-      ]
     }
   }
 }

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -289,7 +289,6 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
       "cloudwatch:DisableAlarmActions",
       "events:Delete*",
       "events:Remove*",
-      "guardduty:Delete*",
       "kms:Delete*",
       "kms:DisableKey",
       "kms:ScheduleKeyDeletion",
@@ -298,9 +297,7 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
       "s3:Delete*",
       "s3:PutBucketPolicy",
       "sns:Delete*",
-      "securityhub:DisableSecurityHub",
-      "config:Delete*",
-      "config:StopConfigurationRecorder"
+      "securityhub:DisableSecurityHub"
     ]
     resources = ["*"]
 
@@ -326,11 +323,34 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
       ])
     }
   }
+
+  statement {
+    sid    = "DenyConfigRecorderAndGuardDutyDetectorChanges"
+    effect = "Deny"
+    actions = [
+      "config:Delete*",
+      "config:PutConfigurationRecorder",
+      "config:StopConfigurationRecorder",
+      "guardduty:Delete*",
+      "guardduty:UpdateDetector"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/ModernisationPlatformAccess",
+        "arn:aws:iam::*:role/github-actions",
+        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
+      ]
+    }
+  }
 }
 
 resource "aws_organizations_policy" "mp_protect_secure_baselines" {
   name        = "Modernisation Platform Protect Secure Baselines"
-  description = "Deny deletion or disabling of secure-baselines tagged resources in Modernisation Platform accounts, except AWSReservedSSO_AdministratorAccess roles."
+  description = "Protect secure baseline resources and prevent untrusted principals from changing AWS Config recorders or GuardDuty detectors."
   type        = "SERVICE_CONTROL_POLICY"
 
   tags = {
@@ -348,56 +368,6 @@ resource "aws_organizations_policy_attachment" "mp_protect_secure_baselines" {
   target_id = aws_organizations_organizational_unit.platforms_and_architecture_modernisation_platform.id
 }
 
-###############################################################
-# Protect critical security services from modification
-# Sprinkler OU scope for testing
-###############################################################
-
-data "aws_iam_policy_document" "mp_protect_security_services_pilot" {
-  statement {
-    sid    = "DenyChangesToConfigAndGuardDuty"
-    effect = "Deny"
-    actions = [
-      "config:Delete*",
-      "config:PutConfigurationRecorder",
-      "config:StopConfigurationRecorder",
-      "guardduty:Delete*",
-      "guardduty:UpdateDetector"
-    ]
-    resources = ["*"]
-
-    condition {
-      test     = "ArnNotLike"
-      variable = "aws:PrincipalArn"
-      values = [
-        "arn:aws:iam::*:role/ModernisationPlatformAccess",
-        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
-      ]
-    }
-  }
-}
-
-resource "aws_organizations_policy" "mp_protect_security_services_pilot" {
-  name        = "Modernisation Platform Protect Security Services Pilot"
-  description = "Pilot protection against modification, disabling, or deletion of AWS Config and GuardDuty resources in the Sprinkler OU."
-  type        = "SERVICE_CONTROL_POLICY"
-
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = join("", [local.github_repository, "/terraform/organizations-policy-service-control-modernisation-platform.tf"])
-  }
-
-  content = data.aws_iam_policy_document.mp_protect_security_services_pilot.json
-}
-
-# Attach the pilot SCP to the Sprinkler OU only for testing before wider MP OU enforcement
-resource "aws_organizations_policy_attachment" "mp_protect_security_services_pilot" {
-  for_each = toset([
-    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
-    if child.name == "modernisation-platform-sprinkler"
-  ])
-
-  policy_id = aws_organizations_policy.mp_protect_security_services_pilot.id
-  target_id = each.value
-}
+# AWS Config recorder and GuardDuty detector protections are included in the existing secure-baselines SCP because
+# the Modernisation Platform OU is already at its SCP attachment limit. These controls use a separate statement
+# without a resource-tag condition because Config recorders and GuardDuty detectors are not consistently tagged.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

[ministryofjustice/modernisation-platform-security#116](https://github.com/ministryofjustice/modernisation-platform-security/issues/116)

Extend SCP protection across the Modernisation Platform OU to prevent untrusted principals from modifying, disabling, or deleting AWS Config recorders and GuardDuty detectors.

Follow on from https://github.com/ministryofjustice/aws-root-account/pull/1576 and https://github.com/ministryofjustice/aws-root-account/pull/1597

## ♻️ What's changed

Promoted the tested Sprinkler controls into the existing OU-wide `Modernisation Platform Protect Secure Baselines` SCP:

- `config:Delete*`
- `config:PutConfigurationRecorder`
- `config:StopConfigurationRecorder`
- `guardduty:Delete*`
- `guardduty:UpdateDetector`

These actions may not appear as green additions in git diff because they already exist in the pilot on `main`. This PR changes their scope from Sprinkler-only to the full Modernisation Platform OU.

Also:

- Removed the temporary Sprinkler pilot SCP and attachment.
- Removed duplicate Config and GuardDuty actions from the tag-dependent statement.
- Made the promoted statement independent of resource tags.
- Exempted `ModernisationPlatformAccess`, `github-actions`, and AWS SSO AdministratorAccess roles.
- Removed the pilot policy from alerting. The updated secure-baselines SCP remains monitored.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

The Modernisation Platform OU already has five directly attached SCPs, including `FullAWSAccess`. To avoid exceeding the attachment limit, these controls are included in the existing secure-baselines SCP.

Testing in `sprinkler-development` showed that Config recorders and GuardDuty detectors are not consistently tagged `component=secure-baselines`, so the new statement does not use a tag condition.

Validation completed:

- `config:PutConfigurationRecorder` was explicitly denied by the SCP.
- `guardduty:UpdateDetector` was explicitly denied by the SCP.