### PR TITLE
adding extra permission for mod p eng role

### DIFF
--- a/management-account/terraform/sso-admin-permission-sets.tf
+++ b/management-account/terraform/sso-admin-permission-sets.tf
@@ -400,7 +400,7 @@ data "aws_iam_policy_document" "modernisation_platform_engineer" {
       "rds:RebootDB*",
       "rhelkb:GetRhelURL",
       "q:*",
-      "s3:PutObject",
+      "s3:Put*",
       "s3:DeleteObject",
       "s3:DeleteObjectVersion",
       "s3:RestoreObject",
@@ -937,7 +937,7 @@ data "aws_iam_policy_document" "network_automation_support_operator" {
       "ecs:ExecuteCommand",
       "ecs:DescribeTasks"
     ]
-    resources = [        
+    resources = [
       "arn:aws:ecs:eu-west-2:${aws_organizations_account.moj_official_development.id}:cluster/*",
       "arn:aws:ecs:eu-west-2:${aws_organizations_account.moj_official_development.id}:task/*/*",
       "arn:aws:ecs:eu-west-2:${aws_organizations_account.moj_official_preproduction.id}:cluster/*",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

modernisation platform engineers role is currently unable to change s3 encryption permission on any account so when it comes to testing we are able to test what we need to test

## ♻️ What's changed

Changed the Put permission to be a put* which will cover the necesary changes we need for testing

## 🔊 Does this PR affect multiple parties?

- [ X ] Yes. ish I will contact the #aws-root-account team to arrange a suitable window.
- [ ] No.

## 📓 Notes

This is only a change to the modernisationplatformengineer role
{ Optionally add content here - is there any broader discussion or context that would assist the reviewer or someone viewing this later }
