### PR TITLE
Add periodic GitHub sync (v2) in shadow mode

### DIFF
--- a/management-account/terraform/sso-scim-periodic-sync.tf
+++ b/management-account/terraform/sso-scim-periodic-sync.tf
@@ -17,3 +17,22 @@ resource "aws_ssm_parameter" "github_periodic_sync_audit_cursor" {
     ignore_changes = [value]
   }
 }
+
+# The poller: self-building Lambda + EventBridge schedule + least-privilege IAM.
+# Shadow mode (not_dry_run = false) logs the diff it would apply without writing;
+# flip to true only after CloudWatch confirms a clean plan. v1_lambda_name
+# defaults to the v1 Lambda inside the module, seeding the first-run window.
+module "github_periodic_sync" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "github.com/ministryofjustice/moj-terraform-github-periodic-sync?ref=fc7d604faafeabe978192fbe9727e0d467aba52a" # v0.1.1
+
+  github_organisation   = local.sso.github_organisation
+  github_app_secret_arn = aws_secretsmanager_secret.github_periodic_sync_private_key.arn
+  cursor_parameter_name = aws_ssm_parameter.github_periodic_sync_audit_cursor.name
+
+  sso_aws_region        = local.sso.region
+  sso_identity_store_id = local.sso_admin_identity_store_id
+  sso_email_suffix      = local.sso.email_suffix
+
+  not_dry_run = false
+}

--- a/management-account/terraform/sso-scim-periodic-sync.tf
+++ b/management-account/terraform/sso-scim-periodic-sync.tf
@@ -24,7 +24,7 @@ resource "aws_ssm_parameter" "github_periodic_sync_audit_cursor" {
 # defaults to the v1 Lambda inside the module, seeding the first-run window.
 module "github_periodic_sync" {
   # tflint-ignore: terraform_module_pinned_source
-  source = "github.com/ministryofjustice/moj-terraform-github-periodic-sync?ref=fc7d604faafeabe978192fbe9727e0d467aba52a" # v0.1.1
+  source = "github.com/ministryofjustice/moj-terraform-github-periodic-sync?ref=51c329beb7b8f3639b8ce026be3f2577b17cab1b" # v0.1.2
 
   github_organisation   = local.sso.github_organisation
   github_app_secret_arn = aws_secretsmanager_secret.github_periodic_sync_private_key.arn


### PR DESCRIPTION
## What

Wires up the v2 periodic GitHub-team → IAM Identity Center poller by calling the `moj-terraform-github-periodic-sync` module (pinned to **v0.1.1**, `fc7d604`).

The secret (`github_periodic_sync_private_key`) and audit-log cursor SSM parameter already exist; this adds the module call that creates the Lambda, EventBridge schedule, and least-privilege IAM.

## Shadow mode

`not_dry_run = false` — the poller **logs the diff it would apply but writes nothing**. This lets us soak it alongside the existing v1 SCIM Lambda and confirm a clean plan in CloudWatch before enabling writes (a follow-up one-line PR flips `not_dry_run = true`).

## Validation

A local dry-run against the org produced a clean, correct plan (4 legitimate changes, zero spurious removes) after the v0.1.1 fixes. `terraform validate` passes. GitHub App is created, installed, and its JSON credentials are in the secret.