### PR TITLE
Allow GuardDuty malware protection plan deletion during destroy

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -295,6 +295,7 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
       values = [
         "arn:aws:iam::*:role/ModernisationPlatformAccess",
         "arn:aws:iam::*:role/github-actions",
+        "arn:aws:iam::*:role/MemberInfrastructureAccess",
         "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
       ]
     }


### PR DESCRIPTION
Update the SCP so Terraform destroy operations are not blocked when deleting the GuardDuty Malware Protection Plan. (The `integration-hub` workflow is failing because AWS denies `guardduty:DeleteMalwareProtectionPlan` with an explicit SCP deny.)
https://github.com/ministryofjustice/modernisation-platform-environments/actions/runs/32738330182/job/97474216970#step:11:640
