### PR TITLE
Bump Outstanding :dependabot:'s

### DIFF
--- a/.github/workflows/management-account-plan.yml
+++ b/.github/workflows/management-account-plan.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Alert Slack if drift detected on scheduled run
         if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && steps.plan.outputs.exitcode == '2' }}
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: MegaLinter
-        uses: oxsecurity/megalinter@ef3e84b8b836d76db562d0f3ed7da61e8fd538bc # v9.6.0
+        uses: oxsecurity/megalinter@15e5b45552097e318c93de385779ce3b1084052c # v10.0.0
         env:
           VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # Validates all source when push on main, else just the git diff with main. Override with true if you always want to lint all sources
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/management-account/terraform/kms.tf
+++ b/management-account/terraform/kms.tf
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "terraform_state_s3_bucket_kms" {
 
 module "focus_s3_kms" {
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.2.0"
+  version = "4.2.1"
 
   aliases                 = ["s3/focus"]
   description             = "FOCUS S3 bucket KMS key"
@@ -54,7 +54,7 @@ module "focus_s3_kms" {
 
 module "cur_v2_s3_kms" {
   source  = "terraform-aws-modules/kms/aws"
-  version = "4.2.0"
+  version = "4.2.1"
 
   aliases                 = ["s3/curv2"]
   description             = "CUR v2 S3 bucket KMS key"

--- a/management-account/terraform/s3.tf
+++ b/management-account/terraform/s3.tf
@@ -297,7 +297,7 @@ module "cur_reports_v2_hourly_s3_bucket" {
   #checkov:skip=CKV2_AWS_67:Regular CMK key rotation is not required currently
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.15.3"
+  version = "5.15.4"
 
   bucket        = "moj-cur-reports-v2-hourly"
   force_destroy = true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

Bumping outstanding Dependabots to ensure the latest versions are used.

## ♻️ What's changed

- Updated `slackapi/slack-github-action from `v3.0.3` to `v4.0.0`.
- Updated `oxsecurity/megalinter from `v9.6.0` to `v10.0.0`.
- Updated the Terraform KMS module from `v4.2.0` to `v4.2.1`.
- Updated the Terraform S3 module from `v5.15.3` to `v5.15.4`.
- No new AWS resources have been introduced.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [X] No.

## 📓 Notes

This is a dependency-only update to keep CI tooling and Terraform modules current