### PR TITLE
Scp/fix s3 scp kms key id detection

### DIFF
--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -376,16 +376,15 @@ resource "aws_organizations_policy_attachment" "mp_protect_secure_baselines" {
 # Enforce S3 KMS encryption  #
 ##############################
 
-# Denies attempts to set bucket default encryption to SSE-S3 (AES256).
+# Denies attempts to set bucket default encryption to SSE-S3 (AES256), or to
+# anything other than an explicit customer-managed KMS key. This means any
+# bucket in scope must use an explicit kms_master_key_id (not the AWS-managed
+# default key) for its server_side_encryption_configuration.
 # This is a low blast-radius pilot scoped via the attachment below.
-#
-# The PutObject deny below blocks explicit SSE-S3 (AES256) writes while
-# allowing requests that omit the encryption header and rely on bucket
-# default encryption. Bucket-level downgrade/removal is still denied below.
 
 resource "aws_organizations_policy" "enforce_s3_kms_encryption" {
   name        = "Enforce S3 KMS encryption"
-  description = "Denies explicit SSE-S3 object writes and setting bucket default encryption to SSE-S3"
+  description = "Denies setting bucket default encryption to anything other than an explicit customer-managed KMS key"
   type        = "SERVICE_CONTROL_POLICY"
   tags = {
     business-unit = "Platforms"
@@ -397,7 +396,6 @@ resource "aws_organizations_policy" "enforce_s3_kms_encryption" {
 }
 
 data "aws_iam_policy_document" "enforce_s3_kms_encryption" {
-  # Deny setting bucket default encryption to SSE-S3.
   statement {
     sid       = "DenyS3SetBucketDefaultEncryptionToSSES3"
     effect    = "Deny"
@@ -408,6 +406,19 @@ data "aws_iam_policy_document" "enforce_s3_kms_encryption" {
       test     = "StringEquals"
       variable = "s3:x-amz-server-side-encryption"
       values   = ["AES256"]
+    }
+  }
+
+  statement {
+    sid       = "DenyS3SetBucketDefaultEncryptionWithoutExplicitKmsKey"
+    effect    = "Deny"
+    actions   = ["s3:PutEncryptionConfiguration"]
+    resources = ["*"]
+
+    condition {
+      test     = "Null"
+      variable = "s3:x-amz-server-side-encryption-aws-kms-key-id"
+      values   = ["true"]
     }
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

I want to stop S3 bucket default encryption being downgraded from SSE-KMS to SSE-S3 (AES256) in the Modernisation Platform sprinkler OU.

The condition currently used to detect AES256 is not reliably evaluated for `s3:PutEncryptionConfiguration`, so the policy does not block a KMS-to-AES256 change as intended.

## ♻️ What's changed

- I added a Deny condition for `s3:PutEncryptionConfiguration` when `s3:x-amz-server-side-encryption-aws-kms-key-id` is absent.
- This rejects a change to SSE-S3 (AES256), or another bucket default encryption setting that does not specify a KMS key ID.
- I kept the existing AES256 condition in place.
- I kept the SCP attached only to the `modernisation-platform-sprinkler` sub-OU while this is validated.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [X] No.

## 📓 Notes

This pilot requires each scoped bucket to configure an explicit customer-managed KMS key. It rejects SSE-KMS configurations that rely on S3's AWS-managed default key.

Validation passed:

- `terraform plan (management-account)`
- MegaLinter, including Terraform formatting and TFLint