### PR TITLE
SP-3982 - use generator id for opg automation rule #minor

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -194,9 +194,9 @@ resource "aws_securityhub_automation_rule" "suppress_opg_config_1_inactive_regio
       value      = "Security Hub"
     }
 
-    compliance_security_control_id {
+    generator_id {
       comparison = "EQUALS"
-      value      = "Config.1"
+      value      = "security-control/Config.1"
     }
 
     workflow_status {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

updating opg automation rule to use different criteria

## ♻️ What's changed

changing resource "aws_securityhub_automation_rule" "suppress_opg_config_1_inactive_regions"

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.
