### PR TITLE
SP-3982 - parse region from id rather than resource #minor

### DIFF
--- a/modules/securityhub/main.tf
+++ b/modules/securityhub/main.tf
@@ -204,11 +204,11 @@ resource "aws_securityhub_automation_rule" "suppress_opg_config_1_inactive_regio
       value      = "NEW"
     }
 
-    dynamic "resource_region" {
+    dynamic "id" {
       for_each = ["eu-west-1", "eu-west-2", "us-east-1"]
       content {
-        comparison = "NOT_EQUALS"
-        value      = resource_region.value
+        comparison = "NOT_CONTAINS"
+        value      = ":${id.value}:"
       }
     }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

automation rule still isn't suppressing in delegated accounts, attempt to fix this

## ♻️ What's changed

updating the automation rule to match the region criteria from the arn rather than the resource region which may not be aggregating to to sub accounts

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.
