### PR TITLE
Narrow Config and GuardDuty SCP delete protections

### DIFF
--- a/management-account/terraform/alerting-modernisation-platform-scp.tf
+++ b/management-account/terraform/alerting-modernisation-platform-scp.tf
@@ -37,8 +37,7 @@ resource "aws_cloudwatch_event_rule" "modernisation_platform_scp_change_alerts" 
           aws_organizations_policy.mp_deny_cloudtrail_delete_stop_update.id,
           aws_organizations_policy.mp_protect_core_s3_buckets.id,
           aws_organizations_policy.modernisation_platform_member_ou_scp.id,
-          aws_organizations_policy.mp_protect_secure_baselines.id, # Includes Config/GuardDuty protections due to the OU SCP limit.
-          aws_organizations_policy.mp_protect_config_guardduty_pilot.id
+          aws_organizations_policy.mp_protect_secure_baselines.id # Includes Config/GuardDuty protections due to the OU SCP limit.
         ]
       }
     }

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -298,14 +298,6 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
         "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
       ]
     }
-
-    # Sprinkler is protected by the narrower pilot statement below while the
-    # replacement actions are validated before wider OU enforcement.
-    condition {
-      test     = "StringNotEquals"
-      variable = "aws:PrincipalAccount"
-      values   = local.modernisation_platform_accounts.sprinkler_id
-    }
   }
 
   statement {
@@ -379,59 +371,6 @@ resource "aws_organizations_policy_attachment" "mp_protect_secure_baselines" {
 # AWS Config recorder and GuardDuty detector protections are included in the existing secure-baselines SCP because
 # the Modernisation Platform OU is already at its SCP attachment limit. These controls use a separate statement
 # without a resource-tag condition because Config recorders and GuardDuty detectors are not consistently tagged.
-
-###############################################################
-# Pilot narrowed Config and GuardDuty protections in Sprinkler
-###############################################################
-
-data "aws_iam_policy_document" "mp_protect_config_guardduty_pilot" {
-  statement {
-    sid    = "DenyConfigRecorderAndGuardDutyDetectorChanges"
-    effect = "Deny"
-    actions = [
-      "config:DeleteConfigurationRecorder",
-      "config:PutConfigurationRecorder",
-      "config:StopConfigurationRecorder",
-      "guardduty:DeleteDetector",
-      "guardduty:UpdateDetector"
-    ]
-    resources = ["*"]
-
-    condition {
-      test     = "ArnNotLike"
-      variable = "aws:PrincipalArn"
-      values = [
-        "arn:aws:iam::*:role/ModernisationPlatformAccess",
-        "arn:aws:iam::*:role/github-actions",
-        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
-      ]
-    }
-  }
-}
-
-resource "aws_organizations_policy" "mp_protect_config_guardduty_pilot" {
-  name        = "Modernisation Platform Protect Config and GuardDuty Pilot"
-  description = "Pilot narrowed protection for AWS Config recorders and GuardDuty detectors in Sprinkler."
-  type        = "SERVICE_CONTROL_POLICY"
-
-  tags = {
-    business-unit = "Platforms"
-    component     = "SERVICE_CONTROL_POLICY"
-    source-code   = join("", [local.github_repository, "/terraform/organizations-policy-service-control-modernisation-platform.tf"])
-  }
-
-  content = data.aws_iam_policy_document.mp_protect_config_guardduty_pilot.json
-}
-
-resource "aws_organizations_policy_attachment" "mp_protect_config_guardduty_pilot" {
-  for_each = toset([
-    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
-    if child.name == "modernisation-platform-sprinkler"
-  ])
-
-  policy_id = aws_organizations_policy.mp_protect_config_guardduty_pilot.id
-  target_id = each.value
-}
 
 ##############################
 # Enforce S3 KMS encryption  #

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -281,10 +281,10 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
     sid    = "DenyConfigRecorderAndGuardDutyDetectorChanges"
     effect = "Deny"
     actions = [
-      "config:Delete*",
+      "config:DeleteConfigurationRecorder",
       "config:PutConfigurationRecorder",
       "config:StopConfigurationRecorder",
-      "guardduty:Delete*",
+      "guardduty:DeleteDetector",
       "guardduty:UpdateDetector"
     ]
     resources = ["*"]
@@ -295,7 +295,6 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
       values = [
         "arn:aws:iam::*:role/ModernisationPlatformAccess",
         "arn:aws:iam::*:role/github-actions",
-        "arn:aws:iam::*:role/MemberInfrastructureAccess",
         "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
       ]
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

https://github.com/orgs/ministryofjustice/projects/17/views/4?pane=issue&itemId=162496721&issue=ministryofjustice%7Cmodernisation-platform-security%7C116

I previously raised PR [https://github.com/ministryofjustice/aws-root-account/pull/1599](https://github.com/ministryofjustice/aws-root-account/pull/1599), which introduced broad wildcard actions that unintentionally blocked operations outside the intended scope, including `guardduty:DeleteMalwareProtectionPlan`.

I raised PR [https://github.com/ministryofjustice/aws-root-account/pull/1618](https://github.com/ministryofjustice/aws-root-account/pull/1618) to test narrower actions in `sprinkler-development` before applying them across the wider Modernisation Platform OU.

The narrowed controls were tested successfully in `sprinkler-development`:

- GuardDuty detector deletion and updates were explicitly denied by the SCP.
- Config recorder deletion, stopping and modification were explicitly denied by the SCP.
- `DeleteMalwareProtectionPlan` was not denied by the SCP.

## ♻️ What's changed

- Replaced broad wildcard actions with:
  - `config:DeleteConfigurationRecorder`
  - `config:PutConfigurationRecorder`
  - `config:StopConfigurationRecorder`
  - `guardduty:DeleteDetector`
  - `guardduty:UpdateDetector`
- Removed the temporary `MemberInfrastructureAccess` exemption, which was added to bypass the issues introduced by the broad wildcard actions.
- Removed the Sprinkler pilot SCP, attachment and alerting entry.
- Removed the temporary Sprinkler exclusion.
- Applied the tested controls across the Modernisation Platform OU through the existing secure-baselines SCP.

## 🔊 Does this PR affect multiple parties?

- [x] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [ ] No.

## 📓 Notes
