### PR TITLE
Narrowed Config and GuardDuty SCP protections in Sprinkler

### DIFF
--- a/management-account/terraform/alerting-modernisation-platform-scp.tf
+++ b/management-account/terraform/alerting-modernisation-platform-scp.tf
@@ -37,7 +37,8 @@ resource "aws_cloudwatch_event_rule" "modernisation_platform_scp_change_alerts" 
           aws_organizations_policy.mp_deny_cloudtrail_delete_stop_update.id,
           aws_organizations_policy.mp_protect_core_s3_buckets.id,
           aws_organizations_policy.modernisation_platform_member_ou_scp.id,
-          aws_organizations_policy.mp_protect_secure_baselines.id # Includes Config/GuardDuty protections due to the OU SCP limit.
+          aws_organizations_policy.mp_protect_secure_baselines.id, # Includes Config/GuardDuty protections due to the OU SCP limit.
+          aws_organizations_policy.mp_protect_config_guardduty_pilot.id
         ]
       }
     }

--- a/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
+++ b/management-account/terraform/organizations-policy-service-control-modernisation-platform.tf
@@ -299,6 +299,14 @@ data "aws_iam_policy_document" "mp_protect_secure_baselines" {
         "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
       ]
     }
+
+    # Sprinkler is protected by the narrower pilot statement below while the
+    # replacement actions are validated before wider OU enforcement.
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:PrincipalAccount"
+      values   = local.modernisation_platform_accounts.sprinkler_id
+    }
   }
 
   statement {
@@ -372,6 +380,59 @@ resource "aws_organizations_policy_attachment" "mp_protect_secure_baselines" {
 # AWS Config recorder and GuardDuty detector protections are included in the existing secure-baselines SCP because
 # the Modernisation Platform OU is already at its SCP attachment limit. These controls use a separate statement
 # without a resource-tag condition because Config recorders and GuardDuty detectors are not consistently tagged.
+
+###############################################################
+# Pilot narrowed Config and GuardDuty protections in Sprinkler
+###############################################################
+
+data "aws_iam_policy_document" "mp_protect_config_guardduty_pilot" {
+  statement {
+    sid    = "DenyConfigRecorderAndGuardDutyDetectorChanges"
+    effect = "Deny"
+    actions = [
+      "config:DeleteConfigurationRecorder",
+      "config:PutConfigurationRecorder",
+      "config:StopConfigurationRecorder",
+      "guardduty:DeleteDetector",
+      "guardduty:UpdateDetector"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::*:role/ModernisationPlatformAccess",
+        "arn:aws:iam::*:role/github-actions",
+        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AdministratorAccess*"
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "mp_protect_config_guardduty_pilot" {
+  name        = "Modernisation Platform Protect Config and GuardDuty Pilot"
+  description = "Pilot narrowed protection for AWS Config recorders and GuardDuty detectors in Sprinkler."
+  type        = "SERVICE_CONTROL_POLICY"
+
+  tags = {
+    business-unit = "Platforms"
+    component     = "SERVICE_CONTROL_POLICY"
+    source-code   = join("", [local.github_repository, "/terraform/organizations-policy-service-control-modernisation-platform.tf"])
+  }
+
+  content = data.aws_iam_policy_document.mp_protect_config_guardduty_pilot.json
+}
+
+resource "aws_organizations_policy_attachment" "mp_protect_config_guardduty_pilot" {
+  for_each = toset([
+    for child in data.aws_organizations_organizational_units.mp_member_children.children : child.id
+    if child.name == "modernisation-platform-sprinkler"
+  ])
+
+  policy_id = aws_organizations_policy.mp_protect_config_guardduty_pilot.id
+  target_id = each.value
+}
 
 ##############################
 # Enforce S3 KMS encryption  #


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## 👀 Purpose

I previously raised this [PR](https://github.com/ministryofjustice/aws-root-account/pull/1599), which introduced broad wildcard actions that unintentionally blocked operations outside the intended scope, including `guardduty:DeleteMalwareProtectionPlan`.

I raised [PR #1617](https://github.com/ministryofjustice/aws-root-account/pull/1617/changes) to narrow the actions to the intended scope. This PR validates those changes in Sprinkler before they are applied across the wider Modernisation Platform OU

## ♻️ What's changed

- Excluded Sprinkler from the existing broad AWS Config and GuardDuty statement.
- Added a Sprinkler-only pilot SCP protecting:
  - `config:DeleteConfigurationRecorder`
  - `config:PutConfigurationRecorder`
  - `config:StopConfigurationRecorder`
  - `guardduty:DeleteDetector`
  - `guardduty:UpdateDetector`
- Added the pilot SCP to the existing change-alerting configuration.

## 🔊 Does this PR affect multiple parties?

- [ ] Yes. I will contact the #aws-root-account team to arrange a suitable window.
- [x] No.

## 📓 Notes

Testing will confirm:

1. `guardduty:DeleteMalwareProtectionPlan` is no longer denied by the SCP.
2. `guardduty:DeleteDetector` and `guardduty:UpdateDetector` remain denied for a non-exempt role.
3. AWS Config recorder deletion, stopping and modification remain denied.
